### PR TITLE
Init registry with rfe-creator and assess-rfe plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
-      "skills": ".claude/skills",
+      "skills": [".claude/skills"],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,58 @@
+{
+  "metadata": {
+    "description": "Skills and plugins for AI-assisted software engineering workflows, developed by the opendatahub-io team.\n"
+  },
+  "name": "opendatahub-skills",
+  "owner": {
+    "name": "opendatahub-io"
+  },
+  "plugins": [
+    {
+      "author": {
+        "name": "jwforres"
+      },
+      "category": "planning",
+      "description": "Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.\n",
+      "homepage": "https://github.com/jwforres/rfe-creator",
+      "keywords": [
+        "rfe",
+        "jira",
+        "review",
+        "strategy",
+        "pipeline"
+      ],
+      "name": "rfe-creator",
+      "repository": "https://github.com/jwforres/rfe-creator",
+      "skills": ".claude/skills",
+      "source": {
+        "ref": "main",
+        "repo": "jwforres/rfe-creator",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "Jason Greene"
+      },
+      "category": "evaluation",
+      "description": "Assess RFEs against quality criteria using a structured rubric.\n",
+      "homepage": "https://github.com/n1hility/assess-rfe",
+      "keywords": [
+        "rfe",
+        "rubric",
+        "quality",
+        "assessment"
+      ],
+      "name": "assess-rfe",
+      "repository": "https://github.com/n1hility/assess-rfe",
+      "source": {
+        "ref": "main",
+        "repo": "n1hility/assess-rfe",
+        "source": "github"
+      },
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",
-        "source": "github"
+        "type": "github"
       },
       "strict": false,
       "version": "0.1.0"
@@ -50,7 +50,7 @@
       "source": {
         "ref": "main",
         "repo": "n1hility/assess-rfe",
-        "source": "github"
+        "type": "github"
       },
       "version": "1.0.0"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,11 +23,11 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
-      "skills": [".claude/skills"],
+      "skills": ["./.claude/skills"],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",
-        "type": "github"
+        "source": "github"
       },
       "strict": false,
       "version": "0.1.0"
@@ -50,7 +50,7 @@
       "source": {
         "ref": "main",
         "repo": "n1hility/assess-rfe",
-        "type": "github"
+        "source": "github"
       },
       "version": "1.0.0"
     }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# opendatahub-io Skills Registry
+
+Central registry for AI skills and plugins developed across the opendatahub-io organization.
+Works as both a **Claude Code marketplace** (native integration) and a **universal skill catalog** for other agent harnesses.
+
+## Quick Start
+
+### Claude Code
+
+```bash
+# Add this marketplace
+claude plugin marketplace add opendatahub-io/skills-registry
+
+# Browse and install plugins
+/plugin
+```
+
+Or install a specific plugin:
+
+```bash
+/plugin install agent-eval-harness@opendatahub-skills
+```
+
+### Team Setup
+
+Add to your project's `.claude/settings.json` to auto-enable for all developers:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "opendatahub-skills": {
+      "source": { "source": "github", "repo": "opendatahub-io/skills-registry" }
+    }
+  },
+  "enabledPlugins": {
+    "agent-eval-harness@opendatahub-skills": true
+  }
+}
+```
+
+### Other Agent Harnesses
+
+Fetch `registry.yaml` directly and parse it — it contains all metadata including per-harness install instructions, skill lists, and source references.
+
+## Structure
+
+| File | Purpose |
+|------|---------|
+| `registry.yaml` | Source of truth for all plugins and skills |
+| `.claude-plugin/marketplace.json` | Generated Claude Code marketplace manifest |
+| `catalog.md` | Auto-generated human-readable catalog |
+| `schema/registry.schema.json` | JSON Schema for validation |
+| `scripts/` | Sync, validation, and automation scripts |
+
+## Available Plugins
+
+See [catalog.md](catalog.md) for the full list of plugins and skills.
+
+## Adding a Plugin
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on adding your plugin to this registry.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ claude plugin marketplace add opendatahub-io/skills-registry
 Or install a specific plugin:
 
 ```bash
-/plugin install agent-eval-harness@opendatahub-skills
+/plugin install rfe-creator@opendatahub-skills
 ```
 
 ### Team Setup
@@ -33,7 +33,7 @@ Add to your project's `.claude/settings.json` to auto-enable for all developers:
     }
   },
   "enabledPlugins": {
-    "agent-eval-harness@opendatahub-skills": true
+    "rfe-creator@opendatahub-skills": true
   }
 }
 ```
@@ -49,8 +49,6 @@ Fetch `registry.yaml` directly and parse it — it contains all metadata includi
 | `registry.yaml` | Source of truth for all plugins and skills |
 | `.claude-plugin/marketplace.json` | Generated Claude Code marketplace manifest |
 | `catalog.md` | Auto-generated human-readable catalog |
-| `schema/registry.schema.json` | JSON Schema for validation |
-| `scripts/` | Sync, validation, and automation scripts |
 
 ## Available Plugins
 

--- a/catalog.md
+++ b/catalog.md
@@ -1,0 +1,70 @@
+# Skills and plugins for AI-assisted software engineering workflows, developed by the opendatahub-io team.
+
+
+Auto-generated from `registry.yaml`. Do not edit directly.
+
+## Quick Start
+
+```bash
+# Add this marketplace to Claude Code
+claude plugin marketplace add opendatahub-io/skills-registry
+
+# Browse available plugins
+/plugin
+```
+
+## Evaluation & Testing
+
+Skills for evaluating and testing AI agent skills
+
+### assess-rfe
+
+Assess RFEs against quality criteria using a structured rubric.
+
+v1.0.0 | [n1hility/assess-rfe](https://github.com/n1hility/assess-rfe)
+
+Tags: rfe, rubric, quality, assessment
+
+| Skill | Description |
+|-------|-------------|
+| `/assess-rfe` | Assess RFEs against quality criteria using a structured rubric |
+| `/export-rubric` | Export the assessment rubric |
+
+```bash
+/plugin install assess-rfe@opendatahub-skills
+```
+
+## Product Planning
+
+Skills for requirements, RFEs, and product strategy
+
+### rfe-creator
+
+Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.
+
+v0.1.0 | [jwforres/rfe-creator](https://github.com/jwforres/rfe-creator)
+
+Tags: rfe, jira, review, strategy, pipeline
+
+| Skill | Description |
+|-------|-------------|
+| `/rfe.create` | Generate new RFEs from problem statements |
+| `/rfe.review` | Score and improve RFEs with auto-revision |
+| `/rfe.split` | Decompose oversized RFEs into appropriately-scoped pieces |
+| `/rfe.submit` | Push RFEs to Jira |
+| `/rfe.speedrun` | Execute the full RFE pipeline end-to-end |
+| `/rfe.auto-fix` | Batch review, revise, and split operations |
+| `/strat.create` | Create strategy documents |
+| `/strat.refine` | Refine strategy documents |
+| `/strat.review` | Review strategy documents |
+| `/strat.prioritize` | Prioritize strategy items |
+| `/rfe-creator.update-deps` | Update vendored dependencies |
+| `/architecture-review` | Architecture review skill |
+| `/feasibility-review` | Feasibility review skill |
+| `/rfe-feasibility-review` | RFE feasibility review |
+| `/scope-review` | Scope review skill |
+| `/testability-review` | Testability review skill |
+
+```bash
+/plugin install rfe-creator@opendatahub-skills
+```

--- a/catalog.md
+++ b/catalog.md
@@ -42,6 +42,8 @@ Skills for requirements, RFEs, and product strategy
 
 Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.
 
+**Requires:** `assess-rfe`
+
 v0.1.0 | [jwforres/rfe-creator](https://github.com/jwforres/rfe-creator)
 
 Tags: rfe, jira, review, strategy, pipeline

--- a/registry.yaml
+++ b/registry.yaml
@@ -1,0 +1,131 @@
+# opendatahub-io Skills Registry
+# Source of truth for all skills and plugins across the org.
+# marketplace.json is generated from this file — do not edit it directly.
+
+name: opendatahub-skills
+description: >
+  Skills and plugins for AI-assisted software engineering workflows,
+  developed by the opendatahub-io team.
+owner:
+  name: opendatahub-io
+
+categories:
+  evaluation:
+    name: Evaluation & Testing
+    description: Skills for evaluating and testing AI agent skills
+  code-quality:
+    name: Code Quality
+    description: Code review, linting, and quality enforcement
+  documentation:
+    name: Documentation
+    description: Skills for generating and maintaining documentation
+  devops:
+    name: DevOps & CI/CD
+    description: Skills for deployment, CI/CD, and infrastructure
+  planning:
+    name: Product Planning
+    description: Skills for requirements, RFEs, and product strategy
+
+plugins:
+
+  - name: rfe-creator
+    description: >
+      Claude Code skills for creating, reviewing, and submitting RFEs
+      to the RHAIRFE Jira project. Provides an automated pipeline from
+      initial creation through review, splitting, and submission, plus
+      strategy refinement skills.
+    version: "0.1.0"
+    category: planning
+    tags: [rfe, jira, review, strategy, pipeline]
+    author:
+      name: jwforres
+    source:
+      type: github
+      repo: jwforres/rfe-creator
+      ref: main
+    strict: false
+    skills_dir: .claude/skills
+    homepage: https://github.com/jwforres/rfe-creator
+    repository: https://github.com/jwforres/rfe-creator
+    skills:
+      - name: rfe.create
+        description: Generate new RFEs from problem statements
+        user-invocable: true
+      - name: rfe.review
+        description: Score and improve RFEs with auto-revision
+        user-invocable: true
+      - name: rfe.split
+        description: Decompose oversized RFEs into appropriately-scoped pieces
+        user-invocable: true
+      - name: rfe.submit
+        description: Push RFEs to Jira
+        user-invocable: true
+      - name: rfe.speedrun
+        description: Execute the full RFE pipeline end-to-end
+        user-invocable: true
+      - name: rfe.auto-fix
+        description: Batch review, revise, and split operations
+        user-invocable: true
+      - name: strat.create
+        description: Create strategy documents
+        user-invocable: true
+      - name: strat.refine
+        description: Refine strategy documents
+        user-invocable: true
+      - name: strat.review
+        description: Review strategy documents
+        user-invocable: true
+      - name: strat.prioritize
+        description: Prioritize strategy items
+        user-invocable: true
+      - name: rfe-creator.update-deps
+        description: Update vendored dependencies
+        user-invocable: true
+      - name: architecture-review
+        description: Architecture review skill
+        user-invocable: true
+      - name: feasibility-review
+        description: Feasibility review skill
+        user-invocable: true
+      - name: rfe-feasibility-review
+        description: RFE feasibility review
+        user-invocable: true
+      - name: scope-review
+        description: Scope review skill
+        user-invocable: true
+      - name: testability-review
+        description: Testability review skill
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install rfe-creator@opendatahub-skills"
+    python:
+      package: rfe-creator
+      requires_python: ">=3.11"
+    depends_on: [assess-rfe]
+
+  - name: assess-rfe
+    description: >
+      Assess RFEs against quality criteria using a structured rubric.
+    version: "1.0.0"
+    category: evaluation
+    tags: [rfe, rubric, quality, assessment]
+    author:
+      name: Jason Greene
+    source:
+      type: github
+      repo: n1hility/assess-rfe
+      ref: main
+    homepage: https://github.com/n1hility/assess-rfe
+    repository: https://github.com/n1hility/assess-rfe
+    skills:
+      - name: assess-rfe
+        description: Assess RFEs against quality criteria using a structured rubric
+        user-invocable: true
+      - name: export-rubric
+        description: Export the assessment rubric
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install assess-rfe@opendatahub-skills"
+    depends_on: []


### PR DESCRIPTION
## Summary
- Add **rfe-creator** plugin (`jwforres/rfe-creator`) with 16 skills for RFE creation, review, splitting, submission, and strategy refinement
- Add **assess-rfe** plugin (`n1hility/assess-rfe`) for RFE quality assessment against a structured rubric
- Add **planning** category for product requirements workflows
- Set `rfe-creator.depends_on: [assess-rfe]`

## Test plan
- [ ] Verify `registry.yaml` passes schema validation
- [ ] Verify `marketplace.json` and `catalog.md` are in sync
- [ ] Verify plugin install works: `/plugin install rfe-creator@opendatahub-skills`
- [ ] Verify plugin install works: `/plugin install assess-rfe@opendatahub-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "opendatahub-skills" marketplace for centralized discovery.
  * Published two plugins: rfe-creator (v0.1.0, planning) and assess-rfe (v1.0.0, evaluation), each exposing multiple user-invocable skills and installable via marketplace commands.

* **Documentation**
  * Added registry documentation and an auto-generated catalog with quick-starts, install commands, and team setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->