### PR TITLE
Register test plan repo with test plan and test cases skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,6 +53,30 @@
         "source": "github"
       },
       "version": "1.0.0"
+    },
+    {
+      "author": {
+        "name": "Federico Mosca"
+      },
+      "category": "evaluation",
+      "description": "Generate test plans and test cases from RHOAI strategies using parallel sub-agent analysis and automated review.\n",
+      "homepage": "https://github.com/fege/test-plan",
+      "keywords": [
+        "test-plan",
+        "test-cases",
+        "quality",
+        "strategy"
+      ],
+      "name": "test-plan",
+      "repository": "https://github.com/fege/test-plan",
+      "skills": ["./.claude/skills"],
+      "source": {
+        "ref": "main",
+        "repo": "fege/test-plan",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,9 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
-      "skills": ["./.claude/skills"],
+      "skills": [
+        "./.claude/skills"
+      ],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",
@@ -69,13 +71,11 @@
       ],
       "name": "test-plan",
       "repository": "https://github.com/fege/test-plan",
-      "skills": ["./.claude/skills"],
       "source": {
         "ref": "main",
         "repo": "fege/test-plan",
         "source": "github"
       },
-      "strict": false,
       "version": "0.1.0"
     }
   ]

--- a/catalog.md
+++ b/catalog.md
@@ -34,6 +34,23 @@ Tags: rfe, rubric, quality, assessment
 /plugin install assess-rfe@opendatahub-skills
 ```
 
+### test-plan
+
+Generate test plans and test cases from RHOAI strategies using parallel sub-agent analysis and automated review.
+
+v0.1.0 | [fege/test-plan](https://github.com/fege/test-plan)
+
+Tags: test-plan, test-cases, quality, strategy
+
+| Skill | Description |
+|-------|-------------|
+| `/test-plan.create` | Generate a test plan from a strategy |
+| `/test-cases.create` | Generate test case files from a test plan |
+
+```bash
+/plugin install test-plan@opendatahub-skills
+```
+
 ## Product Planning
 
 Skills for requirements, RFEs, and product strategy

--- a/catalog.md
+++ b/catalog.md
@@ -45,7 +45,11 @@ Tags: test-plan, test-cases, quality, strategy
 | Skill | Description |
 |-------|-------------|
 | `/test-plan.create` | Generate a test plan from a strategy |
-| `/test-cases.create` | Generate test case files from a test plan |
+| `/test-plan.create-cases` | Generate test case files from a test plan |
+| test-plan.analyze.endpoints | Extract scope and API endpoints |
+| test-plan.analyze.risks | Determine test levels, priorities, and risks |
+| test-plan.analyze.infra | Identify environment and infrastructure needs |
+| test-plan.review | Review test plan for completeness |
 
 ```bash
 /plugin install test-plan@opendatahub-skills

--- a/registry.yaml
+++ b/registry.yaml
@@ -129,3 +129,44 @@ plugins:
       claude-code:
         install: "/plugin install assess-rfe@opendatahub-skills"
     depends_on: []
+
+  - name: test-plan
+    description: >
+      Generate test plans and test cases from RHOAI strategies
+      using parallel sub-agent analysis and automated review.
+    version: "0.1.0"
+    category: evaluation
+    tags: [test-plan, test-cases, quality, strategy]
+    author:
+      name: Federico Mosca
+    source:
+      type: github
+      repo: fege/test-plan
+      ref: main
+    strict: false
+    skills_dir: .claude/skills
+    homepage: https://github.com/fege/test-plan
+    repository: https://github.com/fege/test-plan
+    skills:
+      - name: test-plan.create
+        description: Generate a test plan from a strategy
+        user-invocable: true
+      - name: test-cases.create
+        description: Generate test case files from a test plan
+        user-invocable: true
+      - name: test-plan.analyze.endpoints
+        description: Extract scope and API endpoints
+        user-invocable: false
+      - name: test-plan.analyze.risks
+        description: Determine test levels, priorities, and risks
+        user-invocable: false
+      - name: test-plan.analyze.infra
+        description: Identify environment and infrastructure needs
+        user-invocable: false
+      - name: test-plan.review
+        description: Review test plan for completeness
+        user-invocable: false
+    harnesses:
+      claude-code:
+        install: "/plugin install test-plan@opendatahub-skills"
+    depends_on: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -143,7 +143,6 @@ plugins:
       type: github
       repo: fege/test-plan
       ref: main
-    strict: false
     skills_dir: .claude/skills
     homepage: https://github.com/fege/test-plan
     repository: https://github.com/fege/test-plan
@@ -151,7 +150,7 @@ plugins:
       - name: test-plan.create
         description: Generate a test plan from a strategy
         user-invocable: true
-      - name: test-cases.create
+      - name: test-plan.create-cases
         description: Generate test case files from a test plan
         user-invocable: true
       - name: test-plan.analyze.endpoints


### PR DESCRIPTION
## Summary

- Registers the `test-plan` plugin (`fege/test-plan`) in the skills registry
- Adds 6 skills: 2 user-invocable (`test-plan.create`, `test-cases.create`) and 4 sub-agents (`test-plan.analyze.endpoints`, `.risks`, `.infra`, `test-plan.review`)
- Updates `registry.yaml`, `marketplace.json`, and `catalog.md`

## Skills

| Skill | Invocable | Description |
|-------|-----------|-------------|
| `test-plan.create` | yes | Generate a test plan from a strategy (RHAISTRAT) |
| `test-cases.create` | yes | Generate test case files from a test plan |
| `test-plan.analyze.endpoints` | no | Extract scope and API endpoints |
| `test-plan.analyze.risks` | no | Determine test levels, priorities, and risks |
| `test-plan.analyze.infra` | no | Identify environment and infrastructure needs |
| `test-plan.review` | no | Review test plan for completeness |

## Install

/plugin install test-plan@opendatahub-skills


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the test-plan plugin (v0.1.0) to generate and manage test plans and test cases from RHOAI strategies, plus automated analysis and review of endpoints, risks, and infrastructure.
  * Exposes user-invocable commands for creating plans and cases, plus analysis/review actions for deeper inspection.
* **Documentation**
  * Plugin listed in the public catalog with usage and install instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->