### PR TITLE
Register Quality Tiger Team plugin with quality analysis skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,7 +121,7 @@
         "build-validation",
         "analysis"
       ],
-      "name": "quality-tiger-team",
+      "name": "quality-tooling",
       "repository": "https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team",
       "source": {
         "ref": "main",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,6 +106,30 @@
         "source": "github"
       },
       "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "Anthony Coughlin"
+      },
+      "category": "evaluation",
+      "description": "Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.\n",
+      "homepage": "https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team",
+      "keywords": [
+        "quality",
+        "testing",
+        "ci-cd",
+        "build-validation",
+        "analysis"
+      ],
+      "name": "quality-tiger-team",
+      "repository": "https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team",
+      "skills": ["./.claude/skills"],
+      "source": {
+        "ref": "main",
+        "repo": "antowaddle/Red-Hat-Quality-Tiger-Team",
+        "source": "github"
+      },
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -123,7 +123,6 @@
       ],
       "name": "quality-tiger-team",
       "repository": "https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team",
-      "skills": ["./.claude/skills"],
       "source": {
         "ref": "main",
         "repo": "antowaddle/Red-Hat-Quality-Tiger-Team",

--- a/catalog.md
+++ b/catalog.md
@@ -55,7 +55,7 @@ Tags: test-plan, test-cases, quality, strategy
 /plugin install test-plan@opendatahub-skills
 ```
 
-### quality-tiger-team
+### quality-tooling
 
 Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.
 
@@ -70,7 +70,7 @@ Tags: quality, testing, ci-cd, build-validation, analysis
 | `/test-rules-generator` | Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency |
 
 ```bash
-/plugin install quality-tiger-team@opendatahub-skills
+/plugin install quality-tooling@opendatahub-skills
 ```
 
 ## Security Review

--- a/catalog.md
+++ b/catalog.md
@@ -55,6 +55,24 @@ Tags: test-plan, test-cases, quality, strategy
 /plugin install test-plan@opendatahub-skills
 ```
 
+### quality-tiger-team
+
+Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.
+
+v1.0.0 | [antowaddle/Red-Hat-Quality-Tiger-Team](https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team)
+
+Tags: quality, testing, ci-cd, build-validation, analysis
+
+| Skill | Description |
+|-------|-------------|
+| `/quality-repo-analysis` | Automated analysis tool that evaluates CI/CD, testing, security, and best practices against gold standards |
+| `/konflux-build-simulator` | Generate GitHub Actions workflows that simulate Konflux builds at PR time to catch failures before merge |
+| `/test-rules-generator` | Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency |
+
+```bash
+/plugin install quality-tiger-team@opendatahub-skills
+```
+
 ## Security Review
 
 Security analysis, threat modeling, and compliance review

--- a/registry.yaml
+++ b/registry.yaml
@@ -215,7 +215,7 @@ plugins:
         install: "/plugin install test-plan@opendatahub-skills"
     depends_on: []
 
-  - name: quality-tiger-team
+  - name: quality-tooling
     description: >
       Quality tooling and automation for RHOAI component development.
       Includes automated repository analysis, build validation, and test pattern extraction.
@@ -228,7 +228,6 @@ plugins:
       type: github
       repo: antowaddle/Red-Hat-Quality-Tiger-Team
       ref: main
-    skills_dir: .claude/skills
     homepage: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
     repository: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
     skills:
@@ -241,7 +240,3 @@ plugins:
       - name: test-rules-generator
         description: Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency
         user-invocable: true
-    harnesses:
-      claude-code:
-        install: "/plugin install quality-tiger-team@opendatahub-skills"
-    depends_on: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -214,3 +214,34 @@ plugins:
       claude-code:
         install: "/plugin install test-plan@opendatahub-skills"
     depends_on: []
+
+  - name: quality-tiger-team
+    description: >
+      Quality tooling and automation for RHOAI component development.
+      Includes automated repository analysis, build validation, and test pattern extraction.
+    version: "1.0.0"
+    category: evaluation
+    tags: [quality, testing, ci-cd, build-validation, analysis]
+    author:
+      name: Anthony Coughlin
+    source:
+      type: github
+      repo: antowaddle/Red-Hat-Quality-Tiger-Team
+      ref: main
+    skills_dir: .claude/skills
+    homepage: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
+    repository: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
+    skills:
+      - name: quality-repo-analysis
+        description: Automated analysis tool that evaluates CI/CD, testing, security, and best practices against gold standards
+        user-invocable: true
+      - name: konflux-build-simulator
+        description: Generate GitHub Actions workflows that simulate Konflux builds at PR time to catch failures before merge
+        user-invocable: true
+      - name: test-rules-generator
+        description: Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install quality-tiger-team@opendatahub-skills"
+    depends_on: []


### PR DESCRIPTION
## Summary

- Registers the `quality-tiger-team` plugin (`antowaddle/Red-Hat-Quality-Tiger-Team`) in the skills registry
- Adds 3 user-invocable skills for RHOAI component quality improvement
- Updates `registry.yaml`, `marketplace.json`, and `catalog.md`

## Skills

| Skill | Description |
|-------|-------------|
| `quality-repo-analysis` | Automated analysis tool that evaluates CI/CD, testing, security, and best practices against gold standards |
| `konflux-build-simulator` | Generate GitHub Actions workflows that simulate Konflux builds at PR time to catch failures before merge |
| `test-rules-generator` | Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency |

## Install

```bash
/plugin install quality-tiger-team@opendatahub-skills
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the quality-tooling plugin (v1.0.0) with three evaluation commands:
    * /quality-repo-analysis — analyze repository quality
    * /konflux-build-simulator — simulate build processes
    * /test-rules-generator — generate testing rules

* **Documentation**
  * Added catalog and registry entries describing the new plugin, commands, tags, version, source, and install instructions for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->