### PR TITLE
Add CI validation, scripts, and schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,9 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
-      "skills": ["./.claude/skills"],
+      "skills": [
+        "./.claude/skills"
+      ],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,15 +12,17 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install pyyaml jsonschema
+        run: pip install pyyaml==6.0.3 jsonschema==4.26.0
 
       - name: Validate registry schema
         run: python3 scripts/validate_registry.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,44 @@
+name: Validate Registry
+on:
+  pull_request:
+    paths:
+      - 'registry.yaml'
+      - '.claude-plugin/**'
+      - 'schema/**'
+      - 'scripts/**'
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml jsonschema
+
+      - name: Validate registry schema
+        run: python3 scripts/validate_registry.py
+
+      - name: Sync marketplace.json
+        run: python3 scripts/sync_marketplace.py
+
+      - name: Check marketplace.json is in sync
+        run: |
+          git diff --exit-code .claude-plugin/marketplace.json || \
+            (echo "ERROR: marketplace.json is out of sync with registry.yaml." && \
+             echo "Run: python3 scripts/sync_marketplace.py" && exit 1)
+
+      - name: Generate catalog
+        run: python3 scripts/generate_catalog.py
+
+      - name: Check catalog.md is in sync
+        run: |
+          git diff --exit-code catalog.md || \
+            (echo "ERROR: catalog.md is out of sync with registry.yaml." && \
+             echo "Run: python3 scripts/generate_catalog.py" && exit 1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 Your plugin repo needs at minimum:
 
 **Option A — Full plugin (recommended):**
-```
+```text
 your-repo/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin manifest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to the Skills Registry
+
+## Adding a New Plugin
+
+### 1. Prepare Your Repository
+
+Your plugin repo needs at minimum:
+
+**Option A — Full plugin (recommended):**
+```
+your-repo/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest
+└── skills/                  # Or .claude/skills/
+    └── your-skill/
+        └── SKILL.md         # Skill definition
+```
+
+The `plugin.json` needs at least:
+```json
+{
+  "name": "your-plugin",
+  "description": "What your plugin does",
+  "version": "1.0.0"
+}
+```
+
+**Option B — Skills-only repo (no plugin.json):**
+
+If your repo only has `.claude/skills/` and you can't add a `plugin.json`, you can use `strict: false` in the registry entry (see step 2).
+
+### 2. Add Your Entry to registry.yaml
+
+Open a PR adding your plugin to the `plugins` list in `registry.yaml`:
+
+```yaml
+plugins:
+  # ... existing plugins ...
+
+  - name: your-plugin
+    description: What your plugin does (one paragraph)
+    version: "1.0.0"
+    category: evaluation          # Must match a key in 'categories'
+    tags: [tag1, tag2]
+    author:
+      name: your-name
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/your-repo
+      ref: main
+    skills:
+      - name: your-skill
+        description: What this skill does
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install your-plugin@opendatahub-skills"
+      generic:
+        skill_format: markdown
+        skill_dir: skills/
+        entry_point: "skills/{skill_name}/SKILL.md"
+    depends_on: []
+```
+
+For repos without `plugin.json`, add `strict: false` and `skills_dir`:
+```yaml
+    strict: false
+    skills_dir: .claude/skills
+```
+
+### 3. Regenerate Artifacts
+
+After editing `registry.yaml`, regenerate the marketplace and catalog:
+
+```bash
+pip install pyyaml jsonschema
+python3 scripts/sync_marketplace.py
+python3 scripts/generate_catalog.py
+```
+
+Commit the updated `marketplace.json` and `catalog.md` with your PR.
+
+### 4. CI Validation
+
+The PR will automatically:
+- Validate `registry.yaml` against the JSON Schema
+- Check that your GitHub repo is accessible
+- Clone your repo and verify `plugin.json` and `SKILL.md` files exist
+
+### 5. Review and Merge
+
+Once CI passes and the PR is reviewed, it will be merged and the plugin will be available to all users who have added this marketplace.
+
+## Updating a Plugin Version
+
+Plugin versions are checked automatically every week. If you bump the `version` field in your repo's `plugin.json`, a PR will be auto-created to update `registry.yaml`.
+
+You can also manually update the `version` field in `registry.yaml` and submit a PR.
+
+## Adding a New Category
+
+Add the category to the `categories` map in `registry.yaml`:
+
+```yaml
+categories:
+  your-category:
+    name: Your Category Name
+    description: What plugins in this category do
+```

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -59,7 +59,7 @@
         },
         "version": {
           "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$",
           "description": "Semantic version"
         },
         "category": {

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Skills Registry",
+  "description": "Schema for the opendatahub-io skills registry (registry.yaml)",
+  "type": "object",
+  "required": ["name", "owner", "plugins"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Registry identifier"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the registry"
+    },
+    "owner": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" }
+      },
+      "additionalProperties": false
+    },
+    "categories": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/plugin"
+      }
+    }
+  },
+  "$defs": {
+    "plugin": {
+      "type": "object",
+      "required": ["name", "description", "version", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Plugin identifier (lowercase, hyphens allowed)"
+        },
+        "description": {
+          "type": "string",
+          "description": "What this plugin does"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+",
+          "description": "Semantic version"
+        },
+        "category": {
+          "type": "string",
+          "description": "Category key from the categories map"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string", "format": "email" }
+          },
+          "additionalProperties": false
+        },
+        "license": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "strict": {
+          "type": "boolean",
+          "default": true,
+          "description": "If false, marketplace defines the plugin (no plugin.json required in repo)"
+        },
+        "skills_dir": {
+          "type": "string",
+          "description": "Path to skills directory in the repo (used when strict: false)"
+        },
+        "homepage": {
+          "type": "string",
+          "format": "uri"
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri"
+        },
+        "skills": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/skill"
+          }
+        },
+        "harnesses": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "python": {
+          "type": "object",
+          "properties": {
+            "package": { "type": "string" },
+            "requires_python": { "type": "string" },
+            "dependencies": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Names of other plugins in this registry that this plugin depends on"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["type", "repo"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["github", "git-subdir", "npm", "local"],
+          "description": "Source type"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository identifier (e.g., owner/repo)"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Git branch, tag, or ref"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Exact commit SHA"
+        },
+        "path": {
+          "type": "string",
+          "description": "Subdirectory path (for git-subdir type)"
+        }
+      }
+    },
+    "skill": {
+      "type": "object",
+      "required": ["name", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Skill name (matches directory name)"
+        },
+        "description": {
+          "type": "string",
+          "description": "What this skill does"
+        },
+        "user-invocable": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -106,6 +106,7 @@ def main():
     else:
         print(f"WARNING: failed to regenerate marketplace.json: {result.stderr}",
               file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Check for version updates in registered plugin repositories.
+
+For each plugin with a GitHub source, fetches the remote plugin.json
+and compares the version against registry.yaml. If updates are found,
+updates registry.yaml and regenerates marketplace.json.
+
+Usage:
+    python3 scripts/check_versions.py [--registry registry.yaml] [--dry-run]
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+import yaml
+
+
+def load_registry(path: str = "registry.yaml") -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def save_registry(registry: dict, path: str = "registry.yaml"):
+    with open(path, "w") as f:
+        yaml.dump(registry, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def fetch_remote_version(repo: str, ref: str = "main") -> str | None:
+    """Fetch version from remote plugin.json via GitHub API."""
+    result = subprocess.run(
+        ["gh", "api",
+         f"repos/{repo}/contents/.claude-plugin/plugin.json",
+         "--jq", ".content"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    import base64
+    try:
+        content = base64.b64decode(result.stdout.strip()).decode()
+        data = json.loads(content)
+        return data.get("version")
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--registry", default="registry.yaml")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show updates without modifying files")
+    args = parser.parse_args()
+
+    registry = load_registry(args.registry)
+    updates = []
+
+    for plugin in registry.get("plugins", []):
+        source = plugin["source"]
+        if source["type"] != "github":
+            continue
+
+        # Only check strict-mode plugins (they have their own plugin.json)
+        if plugin.get("strict", True) is False:
+            continue
+
+        repo = source["repo"]
+        current = plugin.get("version", "0.0.0")
+        remote = fetch_remote_version(repo, source.get("ref", "main"))
+
+        if remote is None:
+            print(f"  SKIP: {plugin['name']} (could not fetch remote version)")
+            continue
+
+        if remote != current:
+            print(f"  UPDATE: {plugin['name']} {current} -> {remote}")
+            updates.append((plugin, remote))
+        else:
+            print(f"  OK: {plugin['name']} {current}")
+
+    if not updates:
+        print("\nAll plugins up to date.")
+        return
+
+    if args.dry_run:
+        print(f"\n{len(updates)} update(s) found (dry run, no changes made)")
+        return
+
+    # Apply updates
+    for plugin, new_version in updates:
+        plugin["version"] = new_version
+
+    save_registry(registry, args.registry)
+    print(f"\nUpdated {len(updates)} plugin(s) in {args.registry}")
+
+    # Regenerate marketplace.json
+    result = subprocess.run(
+        [sys.executable, "scripts/sync_marketplace.py", "--registry", args.registry],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        print(result.stdout.strip())
+    else:
+        print(f"WARNING: failed to regenerate marketplace.json: {result.stderr}",
+              file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -12,8 +12,10 @@ Usage:
 import argparse
 import base64
 import json
+import shutil
 import subprocess
 import sys
+from urllib.parse import quote
 
 import yaml
 
@@ -30,11 +32,15 @@ def save_registry(registry: dict, path: str = "registry.yaml"):
 
 def fetch_remote_version(repo: str, ref: str = "main") -> str | None:
     """Fetch version from remote plugin.json via GitHub API."""
+    gh_bin = shutil.which("gh")
+    if not gh_bin:
+        return None
     result = subprocess.run(
-        ["gh", "api",
-         f"repos/{repo}/contents/.claude-plugin/plugin.json?ref={ref}",
+        [gh_bin, "api",
+         f"repos/{repo}/contents/.claude-plugin/plugin.json?ref={quote(ref, safe='')}",
          "--jq", ".content"],
         capture_output=True, text=True,
+        timeout=30,
     )
     if result.returncode != 0:
         return None
@@ -59,15 +65,18 @@ def main():
     updates = []
 
     for plugin in registry.get("plugins", []):
-        source = plugin["source"]
-        if source["type"] != "github":
+        source = plugin.get("source") or {}
+        if source.get("type") != "github":
             continue
 
         # Only check strict-mode plugins (they have their own plugin.json)
         if plugin.get("strict", True) is False:
             continue
 
-        repo = source["repo"]
+        repo = source.get("repo")
+        if not repo:
+            print(f"  SKIP: {plugin.get('name', '<unknown>')} (missing source.repo)")
+            continue
         current = plugin.get("version", "0.0.0")
         remote = fetch_remote_version(repo, source.get("ref", "main"))
 
@@ -100,6 +109,7 @@ def main():
     result = subprocess.run(
         [sys.executable, "scripts/sync_marketplace.py", "--registry", args.registry],
         capture_output=True, text=True,
+        timeout=60,
     )
     if result.returncode == 0:
         print(result.stdout.strip())

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -80,15 +80,16 @@ def main():
         current = plugin.get("version", "0.0.0")
         remote = fetch_remote_version(repo, source.get("ref", "main"))
 
+        name = plugin.get("name", "<unknown>")
         if remote is None:
-            print(f"  SKIP: {plugin['name']} (could not fetch remote version)")
+            print(f"  SKIP: {name} (could not fetch remote version)")
             continue
 
         if remote != current:
-            print(f"  UPDATE: {plugin['name']} {current} -> {remote}")
+            print(f"  UPDATE: {name} {current} -> {remote}")
             updates.append((plugin, remote))
         else:
-            print(f"  OK: {plugin['name']} {current}")
+            print(f"  OK: {name} {current}")
 
     if not updates:
         print("\nAll plugins up to date.")

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import base64
 import json
 import subprocess
 import sys
@@ -31,19 +32,18 @@ def fetch_remote_version(repo: str, ref: str = "main") -> str | None:
     """Fetch version from remote plugin.json via GitHub API."""
     result = subprocess.run(
         ["gh", "api",
-         f"repos/{repo}/contents/.claude-plugin/plugin.json",
+         f"repos/{repo}/contents/.claude-plugin/plugin.json?ref={ref}",
          "--jq", ".content"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
         return None
 
-    import base64
     try:
         content = base64.b64decode(result.stdout.strip()).decode()
         data = json.loads(content)
         return data.get("version")
-    except Exception:
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
         return None
 
 

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -31,7 +31,8 @@ def generate_catalog(registry: dict) -> str:
     lines.append("")
     lines.append("```bash")
     lines.append("# Add this marketplace to Claude Code")
-    lines.append(f"claude plugin marketplace add opendatahub-io/skills-registry")
+    owner = registry["owner"]["name"]
+    lines.append(f"claude plugin marketplace add {owner}/skills-registry")
     lines.append("")
     lines.append("# Browse available plugins")
     lines.append("/plugin")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Generate catalog.md from registry.yaml.
+
+Creates a human-readable, browsable catalog of all plugins and skills,
+grouped by category.
+
+Usage:
+    python3 scripts/generate_catalog.py [--registry registry.yaml] [--output catalog.md]
+"""
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+
+def load_registry(path: str = "registry.yaml") -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def generate_catalog(registry: dict) -> str:
+    lines = []
+    lines.append(f"# {registry.get('description', registry['name'])}")
+    lines.append("")
+    lines.append("Auto-generated from `registry.yaml`. Do not edit directly.")
+    lines.append("")
+
+    # Quick install
+    lines.append("## Quick Start")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("# Add this marketplace to Claude Code")
+    lines.append(f"claude plugin marketplace add opendatahub-io/skills-registry")
+    lines.append("")
+    lines.append("# Browse available plugins")
+    lines.append("/plugin")
+    lines.append("```")
+    lines.append("")
+
+    # Group plugins by category
+    categories = registry.get("categories", {})
+    plugins = registry.get("plugins", [])
+    by_category: dict[str, list] = {}
+    uncategorized = []
+
+    for plugin in plugins:
+        cat = plugin.get("category")
+        if cat and cat in categories:
+            by_category.setdefault(cat, []).append(plugin)
+        else:
+            uncategorized.append(plugin)
+
+    # Render each category
+    for cat_key, cat_meta in categories.items():
+        cat_plugins = by_category.get(cat_key, [])
+        if not cat_plugins:
+            continue
+
+        lines.append(f"## {cat_meta['name']}")
+        lines.append("")
+        lines.append(cat_meta.get("description", ""))
+        lines.append("")
+
+        for plugin in cat_plugins:
+            lines.extend(render_plugin(plugin, registry["name"]))
+
+    # Uncategorized
+    if uncategorized:
+        lines.append("## Other")
+        lines.append("")
+        for plugin in uncategorized:
+            lines.extend(render_plugin(plugin, registry["name"]))
+
+    return "\n".join(lines)
+
+
+def render_plugin(plugin: dict, registry_name: str) -> list[str]:
+    lines = []
+    name = plugin["name"]
+    desc = plugin["description"].strip()
+    version = plugin.get("version", "")
+    repo = plugin["source"].get("repo", "")
+    license_str = plugin.get("license", "")
+    tags = plugin.get("tags", [])
+
+    lines.append(f"### {name}")
+    lines.append("")
+    lines.append(desc)
+    lines.append("")
+
+    # Dependencies
+    deps = plugin.get("depends_on", [])
+    if deps:
+        lines.append(f"**Requires:** {', '.join(f'`{d}`' for d in deps)}")
+        lines.append("")
+
+    # Metadata line
+    meta_parts = []
+    if version:
+        meta_parts.append(f"v{version}")
+    if license_str:
+        meta_parts.append(license_str)
+    if repo:
+        meta_parts.append(f"[{repo}](https://github.com/{repo})")
+    if meta_parts:
+        lines.append(" | ".join(meta_parts))
+        lines.append("")
+
+    if tags:
+        lines.append(f"Tags: {', '.join(tags)}")
+        lines.append("")
+
+    # Skills table
+    skills = plugin.get("skills", [])
+    if skills:
+        lines.append("| Skill | Description |")
+        lines.append("|-------|-------------|")
+        for skill in skills:
+            sname = skill["name"]
+            sdesc = skill.get("description", "")
+            invocable = skill.get("user-invocable", True)
+            prefix = f"`/{sname}`" if invocable else sname
+            lines.append(f"| {prefix} | {sdesc} |")
+        lines.append("")
+
+    # Install command
+    lines.append("```bash")
+    lines.append(f"/plugin install {name}@{registry_name}")
+    lines.append("```")
+    lines.append("")
+
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--registry", default="registry.yaml")
+    parser.add_argument("--output", default="catalog.md")
+    args = parser.parse_args()
+
+    registry = load_registry(args.registry)
+    catalog = generate_catalog(registry)
+
+    Path(args.output).write_text(catalog)
+    plugin_count = len(registry.get("plugins", []))
+    print(f"Generated {args.output} with {plugin_count} plugin(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_marketplace.py
+++ b/scripts/sync_marketplace.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate .claude-plugin/marketplace.json from registry.yaml.
+
+This script projects the universal registry format into Claude Code's
+native marketplace.json format, mapping source types and dropping fields
+that marketplace.json does not support.
+
+Usage:
+    python3 scripts/sync_marketplace.py [--registry registry.yaml] [--output .claude-plugin/marketplace.json]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+
+# Fields from registry.yaml plugin entries that map directly to marketplace.json
+DIRECT_FIELDS = {
+    "name", "description", "version", "author", "homepage",
+    "repository", "license", "category",
+}
+
+
+def load_registry(path: str = "registry.yaml") -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def plugin_to_marketplace_entry(plugin: dict) -> dict:
+    """Convert a registry plugin entry to a marketplace plugin entry."""
+    entry = {}
+
+    # Copy direct fields
+    for field in DIRECT_FIELDS:
+        if field in plugin:
+            entry[field] = plugin[field]
+
+    # Map tags to keywords (marketplace uses "keywords")
+    if "tags" in plugin:
+        entry["keywords"] = plugin["tags"]
+
+    # Map source
+    source = plugin["source"]
+    entry["source"] = {
+        "source": source["type"],
+        "repo": source["repo"],
+    }
+    if "ref" in source:
+        entry["source"]["ref"] = source["ref"]
+    if "sha" in source:
+        entry["source"]["sha"] = source["sha"]
+    if "path" in source:
+        entry["source"]["path"] = source["path"]
+
+    # Handle strict: false plugins
+    if plugin.get("strict") is False:
+        entry["strict"] = False
+        if "skills_dir" in plugin:
+            skills_dir = plugin["skills_dir"]
+            if not skills_dir.startswith("./"):
+                skills_dir = "./" + skills_dir
+            entry["skills"] = [skills_dir]
+
+    return entry
+
+
+def generate_marketplace(registry: dict) -> dict:
+    """Generate marketplace.json content from registry data."""
+    marketplace = {
+        "name": registry["name"],
+        "owner": registry["owner"],
+        "plugins": [],
+    }
+
+    if "description" in registry:
+        marketplace["metadata"] = {
+            "description": registry["description"],
+        }
+
+    for plugin in registry.get("plugins", []):
+        entry = plugin_to_marketplace_entry(plugin)
+        marketplace["plugins"].append(entry)
+
+    return marketplace
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--registry", default="registry.yaml",
+                        help="Path to registry.yaml (default: registry.yaml)")
+    parser.add_argument("--output", default=".claude-plugin/marketplace.json",
+                        help="Output path (default: .claude-plugin/marketplace.json)")
+    args = parser.parse_args()
+
+    registry = load_registry(args.registry)
+    marketplace = generate_marketplace(registry)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w") as f:
+        json.dump(marketplace, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    print(f"Generated {output_path} with {len(marketplace['plugins'])} plugin(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -36,8 +36,8 @@ def load_schema(path: str = "schema/registry.schema.json") -> dict:
 def validate_schema(registry: dict, schema: dict) -> list[str]:
     """Validate registry against JSON Schema. Returns list of errors."""
     if jsonschema is None:
-        print("WARNING: jsonschema not installed, skipping schema validation", file=sys.stderr)
-        return []
+        print("ERROR: jsonschema not installed, cannot validate schema", file=sys.stderr)
+        sys.exit(1)
 
     errors = []
     validator = jsonschema.Draft202012Validator(schema)
@@ -74,10 +74,12 @@ def check_sources(registry: dict) -> list[str]:
     """Check that GitHub repos are accessible via the GitHub API."""
     errors = []
     for plugin in registry.get("plugins", []):
-        source = plugin["source"]
-        if source["type"] != "github":
+        source = plugin.get("source")
+        if not source or source.get("type") != "github":
             continue
-        repo = source["repo"]
+        repo = source.get("repo")
+        if not repo:
+            continue
         result = subprocess.run(
             ["gh", "api", f"repos/{repo}", "--silent"],
             capture_output=True, text=True,
@@ -110,8 +112,8 @@ def diff_plugins(registry: dict, base_ref: str) -> list[str]:
 def validate_remote_plugin(plugin: dict) -> list[str]:
     """Clone a plugin repo and validate its structure."""
     errors = []
-    source = plugin["source"]
-    if source["type"] != "github":
+    source = plugin.get("source")
+    if not source or source.get("type") != "github":
         return errors
 
     repo = source["repo"]
@@ -121,7 +123,7 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
     with tempfile.TemporaryDirectory() as tmpdir:
         clone_url = f"https://github.com/{repo}.git"
         result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", ref, clone_url, tmpdir],
+            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
@@ -220,6 +222,7 @@ def main():
             print("  OK")
 
     # Diff
+    new_plugins = []
     if args.diff:
         new_plugins = diff_plugins(registry, args.diff)
         if new_plugins:
@@ -231,7 +234,7 @@ def main():
     if args.validate_remote_plugins:
         plugins_to_check = registry.get("plugins", [])
         if args.diff:
-            new_names = set(diff_plugins(registry, args.diff))
+            new_names = set(new_plugins)
             plugins_to_check = [p for p in plugins_to_check if p["name"] in new_names]
 
         print(f"Validating {len(plugins_to_check)} remote plugin(s)...")

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -92,7 +92,7 @@ def check_sources(registry: dict) -> list[str]:
 def diff_plugins(registry: dict, base_ref: str) -> list[str]:
     """Find plugin names added since base_ref."""
     result = subprocess.run(
-        ["git", "show", f"{base_ref}:registry.yaml"],
+        ["git", "show", "--", f"{base_ref}:registry.yaml"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
@@ -243,7 +243,7 @@ def main():
                 for e in errors:
                     print(e)
             else:
-                print(f"    OK")
+                print("    OK")
 
     # Summary
     print()

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -141,9 +141,16 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
                     f"(strict mode). Add plugin.json or set strict: false in registry.yaml"
                 )
         # Check for at least one SKILL.md
-        skills_dir = plugin.get("skills_dir", "skills")
+        skills_dir_val = plugin.get("skills_dir", "skills")
+        skills_dir = Path(skills_dir_val)
+        resolved_skills_dir = (repo_path / skills_dir).resolve()
+        if skills_dir.is_absolute() or not resolved_skills_dir.is_relative_to(repo_path.resolve()):
+            errors.append(
+                f"  Plugin '{plugin['name']}': invalid skills_dir '{skills_dir_val}' escapes the repository root"
+            )
+            return errors
         skill_locations = [
-            repo_path / skills_dir,
+            resolved_skills_dir,
             repo_path / ".claude" / "skills",
             repo_path / "skills",
         ]
@@ -186,6 +193,7 @@ def main():
         print(f"  FAIL: {len(errors)} schema error(s)")
         for e in errors:
             print(e)
+        sys.exit(1)
     else:
         print("  OK")
 

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Validate registry.yaml against the JSON Schema and check plugin sources.
+
+Usage:
+    python3 scripts/validate_registry.py                        # Schema validation only
+    python3 scripts/validate_registry.py --check-sources        # Also check GitHub repos exist
+    python3 scripts/validate_registry.py --diff origin/main     # Detect newly added plugins
+    python3 scripts/validate_registry.py --validate-remote-plugins  # Clone and validate new plugins
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+
+def load_registry(path: str = "registry.yaml") -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def load_schema(path: str = "schema/registry.schema.json") -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def validate_schema(registry: dict, schema: dict) -> list[str]:
+    """Validate registry against JSON Schema. Returns list of errors."""
+    if jsonschema is None:
+        print("WARNING: jsonschema not installed, skipping schema validation", file=sys.stderr)
+        return []
+
+    errors = []
+    validator = jsonschema.Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(registry), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.path) or "(root)"
+        errors.append(f"  {path}: {error.message}")
+    return errors
+
+
+def check_duplicates(registry: dict) -> list[str]:
+    """Check for duplicate plugin names."""
+    names = [p["name"] for p in registry.get("plugins", [])]
+    seen = set()
+    dupes = []
+    for name in names:
+        if name in seen:
+            dupes.append(f"  Duplicate plugin name: {name}")
+        seen.add(name)
+    return dupes
+
+
+def check_categories(registry: dict) -> list[str]:
+    """Check that all plugin categories reference defined categories."""
+    defined = set(registry.get("categories", {}).keys())
+    errors = []
+    for plugin in registry.get("plugins", []):
+        cat = plugin.get("category")
+        if cat and cat not in defined:
+            errors.append(f"  Plugin '{plugin['name']}' references undefined category '{cat}'")
+    return errors
+
+
+def check_sources(registry: dict) -> list[str]:
+    """Check that GitHub repos are accessible via the GitHub API."""
+    errors = []
+    for plugin in registry.get("plugins", []):
+        source = plugin["source"]
+        if source["type"] != "github":
+            continue
+        repo = source["repo"]
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}", "--silent"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            errors.append(f"  Plugin '{plugin['name']}': repo '{repo}' not accessible")
+        else:
+            print(f"  OK: {repo}")
+    return errors
+
+
+def diff_plugins(registry: dict, base_ref: str) -> list[str]:
+    """Find plugin names added since base_ref."""
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:registry.yaml"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: could not read registry.yaml from {base_ref}, treating all as new",
+              file=sys.stderr)
+        return [p["name"] for p in registry.get("plugins", [])]
+
+    base_registry = yaml.safe_load(result.stdout)
+    base_names = {p["name"] for p in base_registry.get("plugins", [])}
+    current_names = {p["name"] for p in registry.get("plugins", [])}
+    new_names = sorted(current_names - base_names)
+    return new_names
+
+
+def validate_remote_plugin(plugin: dict) -> list[str]:
+    """Clone a plugin repo and validate its structure."""
+    errors = []
+    source = plugin["source"]
+    if source["type"] != "github":
+        return errors
+
+    repo = source["repo"]
+    ref = source.get("ref", "main")
+    strict = plugin.get("strict", True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        clone_url = f"https://github.com/{repo}.git"
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", ref, clone_url, tmpdir],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            errors.append(f"  Plugin '{plugin['name']}': failed to clone {clone_url} (ref={ref})")
+            return errors
+
+        repo_path = Path(tmpdir)
+
+        if strict:
+            # Strict mode: plugin.json must exist in the repo
+            plugin_json = repo_path / ".claude-plugin" / "plugin.json"
+            if not plugin_json.exists():
+                errors.append(
+                    f"  Plugin '{plugin['name']}': missing .claude-plugin/plugin.json "
+                    f"(strict mode). Add plugin.json or set strict: false in registry.yaml"
+                )
+        # Check for at least one SKILL.md
+        skills_dir = plugin.get("skills_dir", "skills")
+        skill_locations = [
+            repo_path / skills_dir,
+            repo_path / ".claude" / "skills",
+            repo_path / "skills",
+        ]
+        found_skills = False
+        for loc in skill_locations:
+            if loc.exists() and list(loc.glob("*/SKILL.md")):
+                found_skills = True
+                break
+
+        if not found_skills:
+            errors.append(
+                f"  Plugin '{plugin['name']}': no SKILL.md found in any skills directory"
+            )
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--registry", default="registry.yaml")
+    parser.add_argument("--schema", default="schema/registry.schema.json")
+    parser.add_argument("--check-sources", action="store_true",
+                        help="Check that GitHub repos are accessible")
+    parser.add_argument("--diff", metavar="BASE_REF",
+                        help="Show plugins added since BASE_REF")
+    parser.add_argument("--validate-remote-plugins", action="store_true",
+                        help="Clone and validate plugin repos")
+    args = parser.parse_args()
+
+    registry = load_registry(args.registry)
+    schema = load_schema(args.schema)
+    all_errors = []
+
+    # Schema validation
+    print("Validating schema...")
+    errors = validate_schema(registry, schema)
+    all_errors.extend(errors)
+    if errors:
+        print(f"  FAIL: {len(errors)} schema error(s)")
+        for e in errors:
+            print(e)
+    else:
+        print("  OK")
+
+    # Duplicate check
+    print("Checking for duplicates...")
+    errors = check_duplicates(registry)
+    all_errors.extend(errors)
+    if errors:
+        print(f"  FAIL: {len(errors)} duplicate(s)")
+        for e in errors:
+            print(e)
+    else:
+        print("  OK")
+
+    # Category check
+    print("Checking categories...")
+    errors = check_categories(registry)
+    all_errors.extend(errors)
+    if errors:
+        print(f"  FAIL: {len(errors)} category error(s)")
+        for e in errors:
+            print(e)
+    else:
+        print("  OK")
+
+    # Source accessibility
+    if args.check_sources:
+        print("Checking sources...")
+        errors = check_sources(registry)
+        all_errors.extend(errors)
+        if errors:
+            print(f"  FAIL: {len(errors)} source error(s)")
+        else:
+            print("  OK")
+
+    # Diff
+    if args.diff:
+        new_plugins = diff_plugins(registry, args.diff)
+        if new_plugins:
+            print(f"New plugins since {args.diff}: {', '.join(new_plugins)}")
+        else:
+            print(f"No new plugins since {args.diff}")
+
+    # Remote validation
+    if args.validate_remote_plugins:
+        plugins_to_check = registry.get("plugins", [])
+        if args.diff:
+            new_names = set(diff_plugins(registry, args.diff))
+            plugins_to_check = [p for p in plugins_to_check if p["name"] in new_names]
+
+        print(f"Validating {len(plugins_to_check)} remote plugin(s)...")
+        for plugin in plugins_to_check:
+            print(f"  Checking {plugin['name']}...")
+            errors = validate_remote_plugin(plugin)
+            all_errors.extend(errors)
+            if errors:
+                for e in errors:
+                    print(e)
+            else:
+                print(f"    OK")
+
+    # Summary
+    print()
+    plugin_count = len(registry.get("plugins", []))
+    skill_count = sum(len(p.get("skills", [])) for p in registry.get("plugins", []))
+    print(f"Registry: {plugin_count} plugin(s), {skill_count} skill(s)")
+
+    if all_errors:
+        print(f"\nFAILED: {len(all_errors)} error(s)")
+        sys.exit(1)
+    else:
+        print("\nPASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -102,7 +102,7 @@ def diff_plugins(registry: dict, base_ref: str) -> list[str]:
               file=sys.stderr)
         return [p["name"] for p in registry.get("plugins", [])]
 
-    base_registry = yaml.safe_load(result.stdout)
+    base_registry = yaml.safe_load(result.stdout) or {}
     base_names = {p["name"] for p in base_registry.get("plugins", [])}
     current_names = {p["name"] for p in registry.get("plugins", [])}
     new_names = sorted(current_names - base_names)


### PR DESCRIPTION
## Summary
- Add JSON Schema for `registry.yaml` validation
- Add scripts: `validate_registry.py`, `sync_marketplace.py`, `generate_catalog.py`, `check_versions.py`
- Add CI workflow that validates schema and checks `marketplace.json` / `catalog.md` stay in sync
- Add `CONTRIBUTING.md` with instructions for adding plugins
- Regenerate `marketplace.json` and `catalog.md` to match script output

## Test plan
- [ ] CI workflow passes on this branch
- [ ] `python3 scripts/validate_registry.py` passes
- [ ] `python3 scripts/sync_marketplace.py` produces no diff
- [ ] `python3 scripts/generate_catalog.py` produces no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive CONTRIBUTING guide for adding and maintaining plugins.

* **New Features**
  * Introduced a formal registry JSON Schema and CLI tools to validate registries, validate remote plugins, sync marketplace metadata, generate a Markdown catalog, and check plugin versions.

* **Chores**
  * Added a CI workflow that validates registry changes and ensures generated artifacts (marketplace/catalog) stay up-to-date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->