### PR TITLE
Add rhoai-security-reviewer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,35 @@
         "source": "github"
       },
       "version": "1.0.0"
+    },
+    {
+      "author": {
+        "name": "jctanner"
+      },
+      "category": "security",
+      "description": "Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent reviewers to identify security risks, then synthesizes findings with confidence tagging based on cross-reviewer agreement. Covers 39 catalog patterns across auth, data protection, cryptographic compliance, network security, supply chain, and infrastructure.\n",
+      "homepage": "https://github.com/jctanner/ai-first-pipeline",
+      "keywords": [
+        "security",
+        "review",
+        "strat",
+        "threat-modeling",
+        "fips",
+        "compliance",
+        "consensus"
+      ],
+      "name": "rhoai-security-reviewer",
+      "repository": "https://github.com/jctanner/ai-first-pipeline",
+      "skills": [
+        "./.claude/skills"
+      ],
+      "source": {
+        "ref": "main",
+        "repo": "jctanner/ai-first-pipeline",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -34,6 +34,29 @@ Tags: rfe, rubric, quality, assessment
 /plugin install assess-rfe@opendatahub-skills
 ```
 
+## Security Review
+
+Security analysis, threat modeling, and compliance review
+
+### rhoai-security-reviewer
+
+Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent reviewers to identify security risks, then synthesizes findings with confidence tagging based on cross-reviewer agreement. Covers 39 catalog patterns across auth, data protection, cryptographic compliance, network security, supply chain, and infrastructure.
+
+v0.1.0 | [jctanner/ai-first-pipeline](https://github.com/jctanner/ai-first-pipeline)
+
+Tags: security, review, strat, threat-modeling, fips, compliance, consensus
+
+| Skill | Description |
+|-------|-------------|
+| `/strat-security-review` | Multi-reviewer consensus orchestrator for security review of STRAT documents. Extracts threat surfaces, spawns three independent security-reviewer instances, synthesizes findings with confidence levels, and produces a final verdict (PASS/CONCERNS/FAIL).
+ |
+| `/security-reviewer` | Individual security reviewer that assesses RHOAI strategy documents against 39 catalog patterns covering authentication, data protection, cryptographic compliance, network security, supply chain, and infrastructure. Uses a two-phase discovery-then-filter approach with severity classification.
+ |
+
+```bash
+/plugin install rhoai-security-reviewer@opendatahub-skills
+```
+
 ## Product Planning
 
 Skills for requirements, RFEs, and product strategy

--- a/registry.yaml
+++ b/registry.yaml
@@ -22,6 +22,9 @@ categories:
   devops:
     name: DevOps & CI/CD
     description: Skills for deployment, CI/CD, and infrastructure
+  security:
+    name: Security Review
+    description: Security analysis, threat modeling, and compliance review
   planning:
     name: Product Planning
     description: Skills for requirements, RFEs, and product strategy
@@ -128,4 +131,46 @@ plugins:
     harnesses:
       claude-code:
         install: "/plugin install assess-rfe@opendatahub-skills"
+    depends_on: []
+
+  - name: rhoai-security-reviewer
+    description: >
+      Consensus-based security review for RHOAI strategy documents (STRATs).
+      An orchestrator spawns three independent reviewers to identify security
+      risks, then synthesizes findings with confidence tagging based on
+      cross-reviewer agreement. Covers 39 catalog patterns across auth,
+      data protection, cryptographic compliance, network security, supply
+      chain, and infrastructure.
+    version: "0.1.0"
+    category: security
+    tags: [security, review, strat, threat-modeling, fips, compliance, consensus]
+    author:
+      name: jctanner
+    source:
+      type: github
+      repo: jctanner/ai-first-pipeline
+      ref: main
+    strict: false
+    skills_dir: .claude/skills
+    homepage: https://github.com/jctanner/ai-first-pipeline
+    repository: https://github.com/jctanner/ai-first-pipeline
+    skills:
+      - name: strat-security-review
+        description: >
+          Multi-reviewer consensus orchestrator for security review of STRAT
+          documents. Extracts threat surfaces, spawns three independent
+          security-reviewer instances, synthesizes findings with confidence
+          levels, and produces a final verdict (PASS/CONCERNS/FAIL).
+        user-invocable: true
+      - name: security-reviewer
+        description: >
+          Individual security reviewer that assesses RHOAI strategy documents
+          against 39 catalog patterns covering authentication, data protection,
+          cryptographic compliance, network security, supply chain, and
+          infrastructure. Uses a two-phase discovery-then-filter approach with
+          severity classification.
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install rhoai-security-reviewer@opendatahub-skills"
     depends_on: []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the rhoai-security-reviewer plugin (v0.1.0).
  * Introduced a "Security Review" category in the registry.
  * Exposed two user-invocable skills: a multi-reviewer consensus review and a single-reviewer assessment with severity-tagged outputs.
* **Documentation**
  * Catalog updated to list the new plugin and its skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->