### PR TITLE
Enforce skills_dir requires strict: false

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,15 +23,11 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
-      "skills": [
-        "./.claude/skills"
-      ],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",
         "source": "github"
       },
-      "strict": false,
       "version": "0.1.0"
     },
     {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,176 @@
+# Architecture
+
+## Overview
+
+The skills-registry is a centralized catalog that aggregates Claude Code plugins
+from multiple GitHub repositories into a single discoverable marketplace. It acts
+as an indirection layer: plugin source code lives in separate repos, while this
+registry provides the metadata and discovery mechanism.
+
+```
+                        skills-registry
+┌──────────────────────────────────────────────────────┐
+│                                                      │
+│  registry.yaml          (source of truth)            │
+│       │                                              │
+│       ├──► marketplace.json   (Claude Code native)   │
+│       ├──► catalog.md         (human-readable)       │
+│       │                                              │
+│  schema/                (validation)                 │
+│  scripts/               (automation)                 │
+│  .github/workflows/     (CI)                         │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+## Data Flow
+
+```
+                 ┌─────────────────┐
+                 │  registry.yaml  │  Single source of truth
+                 │                 │  (edited by humans)
+                 └────────┬────────┘
+                          │
+              ┌───────────┼───────────┐
+              ▼           ▼           ▼
+     sync_marketplace  generate    validate
+          .py          _catalog     _registry
+                        .py          .py
+              │           │           │
+              ▼           ▼           ▼
+     marketplace.json  catalog.md   pass/fail
+     (Claude Code)     (docs)       (CI gate)
+```
+
+## File Structure
+
+```
+skills-registry/
+├── registry.yaml                    # Source of truth
+├── .claude-plugin/
+│   └── marketplace.json             # Generated — Claude Code reads this
+├── catalog.md                       # Generated — human-readable listing
+├── schema/
+│   └── registry.schema.json         # JSON Schema for registry.yaml
+├── scripts/
+│   ├── validate_registry.py         # Schema + structure validation
+│   ├── sync_marketplace.py          # registry.yaml -> marketplace.json
+│   ├── generate_catalog.py          # registry.yaml -> catalog.md
+│   └── check_versions.py            # Poll plugin repos for version bumps
+├── .github/workflows/
+│   └── validate.yml                 # CI: validate + sync check
+├── README.md
+├── CONTRIBUTING.md
+└── LICENSE
+```
+
+## Plugin Model
+
+Each plugin entry in `registry.yaml` points to an external GitHub repo
+that contains the actual skills:
+
+```
+  registry.yaml                     External Repos
+ ┌──────────────┐
+ │ plugins:     │
+ │              │        ┌────────────────────────────────┐
+ │  rfe-creator ├───────►│ jwforres/rfe-creator           │
+ │              │        │  └─ .claude/skills/            │
+ │              │        │      ├─ rfe.create/SKILL.md    │
+ │              │        │      ├─ rfe.review/SKILL.md    │
+ │              │        │      └─ ...                    │
+ │              │        └────────────────────────────────┘
+ │              │
+ │              │        ┌────────────────────────────────┐
+ │  assess-rfe  ├───────►│ n1hility/assess-rfe            │
+ │  (strict:    │        │  ├─ .claude-plugin/            │
+ │   true)      │        │  │   └─ plugin.json            │
+ │              │        │  └─ skills/                    │
+ │              │        │      ├─ assess-rfe/SKILL.md    │
+ │              │        │      └─ export-rubric/SKILL.md │
+ │              │        └────────────────────────────────┘
+ └──────────────┘
+```
+
+### Strict vs Non-Strict Plugins
+
+- **strict: true** (default) — `plugin.json` in the repo is the authority
+  for component definitions. The marketplace entry can supplement it with
+  additional components, and both sources are merged. Claude Code
+  auto-discovers skills in default locations (`.claude/skills/`, `skills/`).
+  Most plugins use this mode, even those without a `plugin.json`.
+
+- **strict: false** — The marketplace entry is the entire plugin definition.
+  If the repo also has a `plugin.json` that declares components, that is a
+  conflict and the plugin fails to load. Use `skills_dir` to point to a
+  non-default skills location. `skills_dir` is only valid with `strict: false`.
+
+Note: `skills_dir` must not be specified without `strict: false`. The schema
+and validation scripts enforce this constraint.
+
+### Dependencies
+
+Plugins can declare `depends_on: [other-plugin]` to express inter-plugin
+dependencies within the registry. This is registry-level metadata only —
+it is not propagated to `marketplace.json` (Claude Code does not support
+dependency resolution).
+
+## CI Pipeline
+
+```
+  push/PR to main
+        │
+        ▼
+  ┌─────────────────────────────┐
+  │  validate.yml               │
+  │                             │
+  │  1. validate_registry.py    │  Schema validation
+  │       │                     │
+  │  2. sync_marketplace.py     │  Regenerate marketplace.json
+  │       │                     │
+  │  3. git diff --exit-code    │  Fail if marketplace.json
+  │     marketplace.json        │  is out of sync
+  │       │                     │
+  │  4. generate_catalog.py     │  Regenerate catalog.md
+  │       │                     │
+  │  5. git diff --exit-code    │  Fail if catalog.md
+  │     catalog.md              │  is out of sync
+  └─────────────────────────────┘
+```
+
+CI does **not** auto-commit — it only verifies that the generated files
+match the registry. Contributors must run the scripts locally before pushing.
+
+## How Claude Code Discovers Plugins
+
+```
+  Developer                     Claude Code                 GitHub
+     │                              │                          │
+     │  claude plugin marketplace   │                          │
+     │  add opendatahub-io/         │                          │
+     │      skills-registry         │                          │
+     │─────────────────────────────►│                          │
+     │                              │  fetch marketplace.json  │
+     │                              │─────────────────────────►│
+     │                              │◄─────────────────────────│
+     │                              │                          │
+     │  /plugin install             │                          │
+     │  rfe-creator@opendatahub-    │                          │
+     │  skills                      │                          │
+     │─────────────────────────────►│  clone source repo       │
+     │                              │─────────────────────────►│
+     │                              │◄─────────────────────────│
+     │                              │                          │
+     │  /rfe.create                 │                          │
+     │─────────────────────────────►│  (runs skill locally)    │
+     │◄─────────────────────────────│                          │
+```
+
+## Adding a New Plugin
+
+1. Add an entry to `registry.yaml`
+2. Run `python3 scripts/validate_registry.py`
+3. Run `python3 scripts/sync_marketplace.py`
+4. Run `python3 scripts/generate_catalog.py`
+5. Commit all changes and open a PR
+6. CI verifies everything is in sync

--- a/registry.yaml
+++ b/registry.yaml
@@ -46,8 +46,6 @@ plugins:
       type: github
       repo: jwforres/rfe-creator
       ref: main
-    strict: false
-    skills_dir: .claude/skills
     homepage: https://github.com/jwforres/rfe-creator
     repository: https://github.com/jwforres/rfe-creator
     skills:
@@ -188,7 +186,6 @@ plugins:
       type: github
       repo: fege/test-plan
       ref: main
-    skills_dir: .claude/skills
     homepage: https://github.com/fege/test-plan
     repository: https://github.com/fege/test-plan
     skills:

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -47,6 +47,9 @@
       "type": "object",
       "required": ["name", "description", "version", "source"],
       "additionalProperties": false,
+      "dependentRequired": {
+        "skills_dir": ["strict"]
+      },
       "properties": {
         "name": {
           "type": "string",
@@ -87,11 +90,11 @@
         "strict": {
           "type": "boolean",
           "default": true,
-          "description": "If false, marketplace defines the plugin (no plugin.json required in repo)"
+          "description": "If false, marketplace is the entire plugin definition. If true (default), plugin.json in the repo is authoritative and marketplace supplements it. Setting strict: false when the repo also has a plugin.json with components causes a conflict"
         },
         "skills_dir": {
           "type": "string",
-          "description": "Path to skills directory in the repo (used when strict: false)"
+          "description": "Path to skills directory in the repo. Only valid when strict: false (marketplace defines the plugin). When strict: true, Claude Code auto-discovers skills in default locations"
         },
         "homepage": {
           "type": "string",

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -70,6 +70,22 @@ def check_categories(registry: dict) -> list[str]:
     return errors
 
 
+def check_strict_consistency(registry: dict) -> list[str]:
+    """Check that skills_dir is only used with strict: false."""
+    errors = []
+    for plugin in registry.get("plugins", []):
+        name = plugin.get("name", "<unknown>")
+        has_skills_dir = "skills_dir" in plugin
+        strict = plugin.get("strict", True)
+
+        if has_skills_dir and strict is not False:
+            errors.append(
+                f"  Plugin '{name}': skills_dir requires strict: false. "
+                f"Remove skills_dir or set strict: false"
+            )
+    return errors
+
+
 def check_sources(registry: dict) -> list[str]:
     """Check that GitHub repos are accessible via the GitHub API."""
     errors = []
@@ -214,6 +230,17 @@ def main():
     all_errors.extend(errors)
     if errors:
         print(f"  FAIL: {len(errors)} category error(s)")
+        for e in errors:
+            print(e)
+    else:
+        print("  OK")
+
+    # Strict/skills_dir consistency
+    print("Checking strict/skills_dir consistency...")
+    errors = check_strict_consistency(registry)
+    all_errors.extend(errors)
+    if errors:
+        print(f"  FAIL: {len(errors)} consistency error(s)")
         for e in errors:
             print(e)
     else:


### PR DESCRIPTION
## Summary
- Add schema constraint: `skills_dir` requires `strict` to be present (`dependentRequired`)
- Add `check_strict_consistency` validation that `skills_dir` is only used with `strict: false`
- Remove unnecessary `strict: false` and `skills_dir` from `rfe-creator` and `test-plan` (Claude Code auto-discovers `.claude/skills/`)
- Update schema descriptions to clarify strict mode semantics
- Add `ARCHITECTURE.md` documenting the registry architecture

## Context
`strict: false` means the marketplace entry is the **entire** plugin definition. When `strict: true` (default), Claude Code auto-discovers skills in default locations like `.claude/skills/` — no `skills_dir` needed. Setting `skills_dir` without `strict: false` has no effect and is misleading.

## Test plan
- [ ] `python3 scripts/validate_registry.py` passes
- [ ] Adding `skills_dir` without `strict: false` fails validation
- [ ] `marketplace.json` and `catalog.md` are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture docs for the skills-registry, expanded README with install/update/verify instructions, status badge, and a curated plugin summary.

* **Chores**
  * Strengthened registry/schema validation and CI checks to ensure plugin configuration consistency and more reliable marketplace generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->