### PR TITLE
Register odh-ai-helpers plugin with 11 skills and 1 agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -129,6 +129,40 @@
         "source": "github"
       },
       "version": "1.0.0"
+    },
+    {
+      "agents": [
+        "./helpers/agents/python-packaging-investigator.md"
+      ],
+      "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "development-tools",
+      "description": "Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.\n",
+      "homepage": "https://github.com/opendatahub-io/ai-helpers",
+      "keywords": [
+        "python-packaging",
+        "licensing",
+        "dependencies",
+        "gitlab",
+        "jira",
+        "adr",
+        "git",
+        "automation"
+      ],
+      "license": "Apache-2.0",
+      "name": "odh-ai-helpers",
+      "repository": "https://github.com/opendatahub-io/ai-helpers",
+      "skills": [
+        "./helpers/skills"
+      ],
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/ai-helpers",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -96,6 +96,40 @@ Tags: security, review, strat, threat-modeling, fips, compliance, consensus
 /plugin install rhoai-security-reviewer@opendatahub-skills
 ```
 
+## Development Tools
+
+Developer productivity tools for packaging, CI/CD debugging, and workflow automation
+
+### odh-ai-helpers
+
+Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
+
+v0.1.0 | Apache-2.0 | [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
+
+Tags: python-packaging, licensing, dependencies, gitlab, jira, adr, git, automation
+
+| Skill | Description |
+|-------|-------------|
+| `/adr-review` | Review an Architectural Decision Record (ADR) using a team of specialist reviewer subagents and produce a consolidated report |
+| `/gitlab-pipeline-debugger` | Debug and monitor GitLab CI/CD pipelines for merge requests, check pipeline status, view job logs, and troubleshoot CI failures |
+| `/git-shallow-clone` | Perform a shallow clone of a Git repository to a temporary location |
+| `/jira-upload-chat-log` | Export and upload the current chat conversation as a markdown file attachment to a Jira ticket |
+| `/python-full-deps` | Resolve the full install-time dependency tree for a Python package with environment markers |
+| `/python-packaging-bug-finder` | Find known packaging bugs, fixes, and workarounds for Python projects by searching GitHub issues |
+| `/python-packaging-complexity` | Analyze Python package build complexity by inspecting PyPI metadata, compilation requirements, and distribution types |
+| `/python-packaging-env-finder` | Investigate environment variables that can be set when building Python wheels for a given project |
+| `/python-packaging-license-checker` | Check whether a Python package license is compatible with redistribution in Red Hat products |
+| `/python-packaging-license-finder` | Deterministically find license information for Python packages by checking PyPI metadata and Git repository LICENSE files |
+| `/python-packaging-source-finder` | Locate source code repositories for Python packages by analyzing PyPI metadata and project URLs |
+
+| Agent | Description |
+|-------|-------------|
+| python-packaging-investigator | Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity |
+
+```bash
+/plugin install odh-ai-helpers@opendatahub-skills
+```
+
 ## Product Planning
 
 Skills for requirements, RFEs, and product strategy

--- a/registry.yaml
+++ b/registry.yaml
@@ -25,6 +25,9 @@ categories:
   security:
     name: Security Review
     description: Security analysis, threat modeling, and compliance review
+  development-tools:
+    name: Development Tools
+    description: Developer productivity tools for packaging, CI/CD debugging, and workflow automation
   planning:
     name: Product Planning
     description: Skills for requirements, RFEs, and product strategy
@@ -240,3 +243,66 @@ plugins:
       - name: test-rules-generator
         description: Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency
         user-invocable: true
+
+  - name: odh-ai-helpers
+    description: >
+      Developer productivity tools for Python packaging, CI/CD debugging,
+      and workflow automation. Includes skills for analyzing package build
+      complexity, resolving dependencies, finding licenses, debugging
+      GitLab pipelines, reviewing ADRs, and more.
+    version: "0.1.0"
+    category: development-tools
+    tags: [python-packaging, licensing, dependencies, gitlab, jira, adr, git, automation]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/ai-helpers
+      ref: main
+    strict: false
+    skills_dir: helpers/skills
+    agents_dir: helpers/agents
+    homepage: https://github.com/opendatahub-io/ai-helpers
+    repository: https://github.com/opendatahub-io/ai-helpers
+    skills:
+      - name: adr-review
+        description: Review an Architectural Decision Record (ADR) using a team of specialist reviewer subagents and produce a consolidated report
+        user-invocable: true
+      - name: gitlab-pipeline-debugger
+        description: Debug and monitor GitLab CI/CD pipelines for merge requests, check pipeline status, view job logs, and troubleshoot CI failures
+        user-invocable: true
+      - name: git-shallow-clone
+        description: Perform a shallow clone of a Git repository to a temporary location
+        user-invocable: true
+      - name: jira-upload-chat-log
+        description: Export and upload the current chat conversation as a markdown file attachment to a Jira ticket
+        user-invocable: true
+      - name: python-full-deps
+        description: Resolve the full install-time dependency tree for a Python package with environment markers
+        user-invocable: true
+      - name: python-packaging-bug-finder
+        description: Find known packaging bugs, fixes, and workarounds for Python projects by searching GitHub issues
+        user-invocable: true
+      - name: python-packaging-complexity
+        description: Analyze Python package build complexity by inspecting PyPI metadata, compilation requirements, and distribution types
+        user-invocable: true
+      - name: python-packaging-env-finder
+        description: Investigate environment variables that can be set when building Python wheels for a given project
+        user-invocable: true
+      - name: python-packaging-license-checker
+        description: Check whether a Python package license is compatible with redistribution in Red Hat products
+        user-invocable: true
+      - name: python-packaging-license-finder
+        description: Deterministically find license information for Python packages by checking PyPI metadata and Git repository LICENSE files
+        user-invocable: true
+      - name: python-packaging-source-finder
+        description: Locate source code repositories for Python packages by analyzing PyPI metadata and project URLs
+        user-invocable: true
+    agents:
+      - name: python-packaging-investigator
+        description: Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity
+    harnesses:
+      claude-code:
+        install: "/plugin install odh-ai-helpers@opendatahub-skills"
+    depends_on: []

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -107,6 +107,16 @@
             "$ref": "#/$defs/skill"
           }
         },
+        "agents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/agent"
+          }
+        },
+        "agents_dir": {
+          "type": "string",
+          "description": "Path to agents directory in the repo (used when strict: false)"
+        },
         "harnesses": {
           "type": "object",
           "additionalProperties": {
@@ -178,6 +188,21 @@
         "user-invocable": {
           "type": "boolean",
           "default": true
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "required": ["name", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Agent name (matches file name without extension)"
+        },
+        "description": {
+          "type": "string",
+          "description": "What this agent does"
         }
       }
     }

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -125,6 +125,17 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
             lines.append(f"| {prefix} | {sdesc} |")
         lines.append("")
 
+    # Agents table
+    agents = plugin.get("agents", [])
+    if agents:
+        lines.append("| Agent | Description |")
+        lines.append("|-------|-------------|")
+        for agent in agents:
+            aname = agent["name"]
+            adesc = agent.get("description", "")
+            lines.append(f"| {aname} | {adesc} |")
+        lines.append("")
+
     # Install command
     lines.append("```bash")
     lines.append(f"/plugin install {name}@{registry_name}")

--- a/scripts/sync_marketplace.py
+++ b/scripts/sync_marketplace.py
@@ -62,6 +62,14 @@ def plugin_to_marketplace_entry(plugin: dict) -> dict:
             if not skills_dir.startswith("./"):
                 skills_dir = "./" + skills_dir
             entry["skills"] = [skills_dir]
+        if "agents_dir" in plugin and "agents" in plugin:
+            agents_dir = plugin["agents_dir"]
+            if not agents_dir.startswith("./"):
+                agents_dir = "./" + agents_dir
+            entry["agents"] = [
+                f"{agents_dir}/{a['name']}.md"
+                for a in plugin["agents"]
+            ]
 
     return entry
 


### PR DESCRIPTION
Add the opendatahub-io/ai-helpers plugin to the skills registry with
a curated set of developer productivity skills covering Python packaging
analysis, GitLab CI/CD debugging, ADR review, and Jira integration,
plus the python-packaging-investigator agent.

Add a new "Development Tools" category and extend the registry schema,
sync script, and catalog generator to support agent definitions alongside
skills.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `odh-ai-helpers` development tools plugin with 11 new skills for Python packaging analysis, Jira integration, Git operations, ADR review, and GitLab pipeline debugging.
  * Added the `python-packaging-investigator` agent for enhanced dependency investigation.

* **Documentation**
  * Updated plugin registry and catalog to support agent definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->