### PR TITLE
Restore strict: false and skills_dir for plugins without plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,11 +23,15 @@
       ],
       "name": "rfe-creator",
       "repository": "https://github.com/jwforres/rfe-creator",
+      "skills": [
+        "./.claude/skills"
+      ],
       "source": {
         "ref": "main",
         "repo": "jwforres/rfe-creator",
         "source": "github"
       },
+      "strict": false,
       "version": "0.1.0"
     },
     {
@@ -96,11 +100,15 @@
       ],
       "name": "test-plan",
       "repository": "https://github.com/fege/test-plan",
+      "skills": [
+        "./.claude/skills"
+      ],
       "source": {
         "ref": "main",
         "repo": "fege/test-plan",
         "source": "github"
       },
+      "strict": false,
       "version": "0.1.0"
     },
     {
@@ -119,11 +127,15 @@
       ],
       "name": "quality-tooling",
       "repository": "https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team",
+      "skills": [
+        "./.claude/skills"
+      ],
       "source": {
         "ref": "main",
         "repo": "antowaddle/Red-Hat-Quality-Tiger-Team",
         "source": "github"
       },
+      "strict": false,
       "version": "1.0.0"
     }
   ]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,14 +96,15 @@ that contains the actual skills:
 
 - **strict: true** (default) — `plugin.json` in the repo is the authority
   for component definitions. The marketplace entry can supplement it with
-  additional components, and both sources are merged. Claude Code
-  auto-discovers skills in default locations (`.claude/skills/`, `skills/`).
-  Most plugins use this mode, even those without a `plugin.json`.
+  additional components, and both sources are merged. Use this for repos
+  that have their own `.claude-plugin/plugin.json`.
 
 - **strict: false** — The marketplace entry is the entire plugin definition.
   If the repo also has a `plugin.json` that declares components, that is a
-  conflict and the plugin fails to load. Use `skills_dir` to point to a
-  non-default skills location. `skills_dir` is only valid with `strict: false`.
+  conflict and the plugin fails to load. Use `skills_dir` to tell Claude
+  Code where to find skills in the repo. **Required for repos without a
+  `plugin.json`** — without it, Claude Code has no way to discover skills
+  when installing via a marketplace.
 
 Note: `skills_dir` must not be specified without `strict: false`. The schema
 and validation scripts enforce this constraint.

--- a/registry.yaml
+++ b/registry.yaml
@@ -46,6 +46,8 @@ plugins:
       type: github
       repo: jwforres/rfe-creator
       ref: main
+    strict: false
+    skills_dir: .claude/skills
     homepage: https://github.com/jwforres/rfe-creator
     repository: https://github.com/jwforres/rfe-creator
     skills:
@@ -186,6 +188,8 @@ plugins:
       type: github
       repo: fege/test-plan
       ref: main
+    strict: false
+    skills_dir: .claude/skills
     homepage: https://github.com/fege/test-plan
     repository: https://github.com/fege/test-plan
     skills:
@@ -225,6 +229,8 @@ plugins:
       type: github
       repo: antowaddle/Red-Hat-Quality-Tiger-Team
       ref: main
+    strict: false
+    skills_dir: .claude/skills
     homepage: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
     repository: https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team
     skills:


### PR DESCRIPTION
## Summary
Fixes regression from PR #7 which incorrectly removed `strict: false` and `skills_dir` from `rfe-creator` and `test-plan`.

Plugins without `plugin.json` in their repo **require** `strict: false` and `skills_dir` for Claude Code to discover skills when installed via marketplace. Auto-discovery of `.claude/skills/` only works locally, not for marketplace installs.

## Changes
- Restore `strict: false` and `skills_dir: .claude/skills` on `rfe-creator` and `test-plan`
- Update ARCHITECTURE.md to correct strict mode documentation
- Regenerate marketplace.json

## Test plan
- [ ] Install `rfe-creator` via marketplace and verify skills are discoverable
- [ ] Install `assess-rfe` (has plugin.json, strict: true) and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation clarifying strict vs. non-strict plugin modes and skills discovery requirements.

* **Chores**
  * Updated plugin configuration and registry metadata to specify skills directory locations for plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->