### PR TITLE
Hide internal skills (user-invocable: false) from catalog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,10 @@ from multiple GitHub repositories into a single discoverable marketplace. It act
 as an indirection layer: plugin source code lives in separate repos, while this
 registry provides the metadata and discovery mechanism.
 
+Plugins in this registry conform to the [Agent Skills](https://agentskills.io/specification)
+open standard, extended by Claude Code with features like invocation control
+and subagent execution (see [Claude Code skills](https://code.claude.com/docs/en/skills)).
+
 ```
                         skills-registry
 ┌──────────────────────────────────────────────────────┐
@@ -175,3 +179,10 @@ match the registry. Contributors must run the scripts locally before pushing.
 4. Run `python3 scripts/generate_catalog.py`
 5. Commit all changes and open a PR
 6. CI verifies everything is in sync
+
+## References
+
+- [Agent Skills specification](https://agentskills.io/specification) — open standard for skill definitions
+- [Claude Code skills](https://code.claude.com/docs/en/skills) — SKILL.md frontmatter and invocation semantics
+- [Claude Code sub-agents](https://code.claude.com/docs/en/sub-agents) — agent frontmatter and delegation
+- [Claude Code plugins](https://code.claude.com/docs/en/plugins) — plugin manifest and marketplace format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,10 @@ To update after already adding:
 claude plugin marketplace remove opendatahub-skills
 claude plugin marketplace add opendatahub-io/skills-registry#branch-name
 ```
+
+## References
+
+- [Claude Code skills](https://code.claude.com/docs/en/skills) — SKILL.md frontmatter spec (`user-invocable`, `disable-model-invocation`, `allowed-tools`, etc.)
+- [Claude Code sub-agents](https://code.claude.com/docs/en/sub-agents) — agent frontmatter spec
+- [Claude Code plugins](https://code.claude.com/docs/en/plugins) — plugin manifest and marketplace format
+- [Agent Skills specification](https://agentskills.io/specification) — open standard that Claude Code skills conform to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ For repos without `plugin.json`, add `strict: false` and `skills_dir`:
     skills_dir: .claude/skills
 ```
 
+The `user-invocable` field mirrors the [native Claude Code SKILL.md frontmatter field](https://code.claude.com/docs/en/skills#frontmatter-reference). Set it to `false` for internal skills that are called only by other skills/agents in the background — they will be hidden from the generated catalog. The registry value is catalog-only, so to actually hide the skill from the `/` menu in Claude Code you must also set `user-invocable: false` in the SKILL.md frontmatter in your source repo.
+
 ### 3. Regenerate Artifacts
 
 After editing `registry.yaml`, regenerate the marketplace and catalog:

--- a/catalog.md
+++ b/catalog.md
@@ -46,10 +46,6 @@ Tags: test-plan, test-cases, quality, strategy
 |-------|-------------|
 | `/test-plan.create` | Generate a test plan from a strategy |
 | `/test-plan.create-cases` | Generate test case files from a test plan |
-| test-plan.analyze.endpoints | Extract scope and API endpoints |
-| test-plan.analyze.risks | Determine test levels, priorities, and risks |
-| test-plan.analyze.infra | Identify environment and infrastructure needs |
-| test-plan.review | Review test plan for completeness |
 
 ```bash
 /plugin install test-plan@opendatahub-skills

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -190,7 +190,8 @@
         },
         "user-invocable": {
           "type": "boolean",
-          "default": true
+          "default": true,
+          "description": "Whether the skill can be invoked directly by the user via /skill-name. Mirrors the native Claude Code SKILL.md frontmatter field — see https://code.claude.com/docs/en/skills#frontmatter-reference. Set to false for internal skills called only by other skills/agents in the background. Note: the registry value is catalog-only; the actual invocation behavior is governed by the SKILL.md in the source repo."
         }
       }
     },

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -112,17 +112,15 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
         lines.append(f"Tags: {', '.join(tags)}")
         lines.append("")
 
-    # Skills table
-    skills = plugin.get("skills", [])
+    # Skills table (only user-invocable skills; internal ones are hidden)
+    skills = [s for s in plugin.get("skills", []) if s.get("user-invocable", True)]
     if skills:
         lines.append("| Skill | Description |")
         lines.append("|-------|-------------|")
         for skill in skills:
             sname = skill["name"]
             sdesc = skill.get("description", "")
-            invocable = skill.get("user-invocable", True)
-            prefix = f"`/{sname}`" if invocable else sname
-            lines.append(f"| {prefix} | {sdesc} |")
+            lines.append(f"| `/{sname}` | {sdesc} |")
         lines.append("")
 
     # Agents table


### PR DESCRIPTION
## Summary

- The `user-invocable` field in `registry.yaml` mirrors the [native Claude Code SKILL.md frontmatter field](https://code.claude.com/docs/en/skills#frontmatter-reference): when set to `false`, the skill is hidden from the `/` menu and only Claude can invoke it.
- The generated `catalog.md` is meant to help users discover skills they can invoke. Internal skills (background-only) don't belong there since users can't run them via `/skill-name`.
- `scripts/generate_catalog.py` now filters out skills with `user-invocable: false` before rendering the skills table. This drops the 4 internal `test-plan.analyze.*` / `test-plan.review` rows from the test-plan section.

## Notes

- `marketplace.json` is unchanged — `sync_marketplace.py` doesn't propagate per-skill flags (Claude Code reads each `SKILL.md` directly from the cloned plugin repo, so the actual invocation behavior is governed there, not here).
- The schema already defines `user-invocable` (boolean, default `true`); no schema change needed.

## Test plan

- [x] `python3 scripts/validate_registry.py` passes
- [x] `python3 scripts/sync_marketplace.py` produces no diff
- [x] `python3 scripts/generate_catalog.py` produces the expected 4-line removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed internal analysis and review subcommands from the public command catalog. The catalog now exclusively displays user-invocable commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->