### PR TITLE
Add vLLM backport triage skills to odh-ai-helpers

### DIFF
--- a/catalog.md
+++ b/catalog.md
@@ -142,6 +142,14 @@ Tags: python-packaging, licensing, dependencies, gitlab, jira, adr, git, automat
 | `/python-packaging-license-checker` | Check whether a Python package license is compatible with redistribution in Red Hat products |
 | `/python-packaging-license-finder` | Deterministically find license information for Python packages by checking PyPI metadata and Git repository LICENSE files |
 | `/python-packaging-source-finder` | Locate source code repositories for Python packages by analyzing PyPI metadata and project URLs |
+| `/vllm-backport-fetch-prs` | Fetch merged bugfix PRs from upstream vLLM within a configurable date window using GitHub CLI |
+| `/vllm-backport-classify` | Classify PRs by backport relevance using labels, title patterns, and file-existence heuristics |
+| `/vllm-backport-check-backported` | Check if PRs are already cherry-picked in a downstream release branch via SHA and title matching |
+| `/vllm-backport-score-rank` | Score and rank backport candidates by severity, scope, and risk using a deterministic composite score |
+| `/vllm-backport-push-report` | Push triage report to a GitHub repository with timestamped directory structure |
+| `/vllm-backport-cherry-pick` | Attempt automatic cherry-pick of clean backport candidates to a downstream release branch |
+| `/vllm-compare-reqs` | Compare Python requirements between upstream vLLM and a downstream fork to identify version mismatches and missing packages |
+| `/vllm-slack-summary` | Generate a concise Slack-formatted summary of vLLM backport triage results |
 
 | Agent | Description |
 |-------|-------------|

--- a/registry.yaml
+++ b/registry.yaml
@@ -312,6 +312,30 @@ plugins:
       - name: python-packaging-source-finder
         description: Locate source code repositories for Python packages by analyzing PyPI metadata and project URLs
         user-invocable: true
+      - name: vllm-backport-fetch-prs
+        description: Fetch merged bugfix PRs from upstream vLLM within a configurable date window using GitHub CLI
+        user-invocable: true
+      - name: vllm-backport-classify
+        description: Classify PRs by backport relevance using labels, title patterns, and file-existence heuristics
+        user-invocable: true
+      - name: vllm-backport-check-backported
+        description: Check if PRs are already cherry-picked in a downstream release branch via SHA and title matching
+        user-invocable: true
+      - name: vllm-backport-score-rank
+        description: Score and rank backport candidates by severity, scope, and risk using a deterministic composite score
+        user-invocable: true
+      - name: vllm-backport-push-report
+        description: Push triage report to a GitHub repository with timestamped directory structure
+        user-invocable: true
+      - name: vllm-backport-cherry-pick
+        description: Attempt automatic cherry-pick of clean backport candidates to a downstream release branch
+        user-invocable: true
+      - name: vllm-compare-reqs
+        description: Compare Python requirements between upstream vLLM and a downstream fork to identify version mismatches and missing packages
+        user-invocable: true
+      - name: vllm-slack-summary
+        description: Generate a concise Slack-formatted summary of vLLM backport triage results
+        user-invocable: true
     agents:
       - name: python-packaging-investigator
         description: Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity


### PR DESCRIPTION
## Summary

- Registers 8 vLLM-related skills under the existing `odh-ai-helpers` plugin entry
- These skills are already merged in `opendatahub-io/ai-helpers` (under `helpers/skills/vllm-backport-*`, `vllm-compare-reqs`, `vllm-slack-summary`)
- Marketplace and catalog artifacts regenerated via `sync_marketplace.py` and `generate_catalog.py`

### Skills added

| Skill | Description |
|-------|-------------|
| `vllm-backport-fetch-prs` | Fetch merged bugfix PRs from upstream vLLM using GitHub CLI |
| `vllm-backport-classify` | Classify PRs by backport relevance using labels and heuristics |
| `vllm-backport-check-backported` | Check if PRs are already cherry-picked downstream |
| `vllm-backport-score-rank` | Score and rank candidates by severity, scope, and risk |
| `vllm-backport-push-report` | Push triage report to GitHub with timestamped structure |
| `vllm-backport-cherry-pick` | Auto cherry-pick clean backport candidates |
| `vllm-compare-reqs` | Compare Python requirements between upstream and downstream |
| `vllm-slack-summary` | Generate Slack-formatted triage summary |

### Context

These skills power an automated backport triage workflow for vLLM release branches (v0.13.x, v0.18.x). The workflow runs as a scheduled GitLab CI pipeline in the `autofix` repo (MR !170) and uses Claude Code to orchestrate the skills.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced eight new skills for vLLM backport triage workflow: upstream PR fetching, relevance classification, existing backport detection, candidate scoring/ranking, report generation and publishing, automated cherry-pick attempts, cross-fork requirements comparison, and Slack-formatted summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->