### PR TITLE
Meeting-quality-skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -217,7 +217,7 @@
       "name": "meeting-quality-skills",
       "repository": "https://github.com/ahinek/meeting-quality-skills",
       "source": {
-        "ref": "058ef75e5e9f83872c8351ad7dcfe2798951128d",
+        "ref": "f39c944a31cad1ec6d57360f56ef28f04dd0ad78",
         "repo": "ahinek/meeting-quality-skills",
         "source": "github"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -198,6 +198,28 @@
         "source": "github"
       },
       "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "Arjay Hinek"
+      },
+      "category": "planning",
+      "description": "Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.\n",
+      "keywords": [
+        "meeting",
+        "google-workspace",
+        "agenda",
+        "async-updates",
+        "productivity"
+      ],
+      "license": "Apache-2.0",
+      "name": "meeting-quality-skills",
+      "source": {
+        "ref": "main",
+        "repo": "ahinek/meeting-quality-skills",
+        "source": "github"
+      },
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -205,6 +205,7 @@
       },
       "category": "planning",
       "description": "Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.\n",
+      "homepage": "https://github.com/ahinek/meeting-quality-skills",
       "keywords": [
         "meeting",
         "google-workspace",
@@ -214,8 +215,9 @@
       ],
       "license": "Apache-2.0",
       "name": "meeting-quality-skills",
+      "repository": "https://github.com/ahinek/meeting-quality-skills",
       "source": {
-        "ref": "main",
+        "ref": "058ef75e5e9f83872c8351ad7dcfe2798951128d",
         "repo": "ahinek/meeting-quality-skills",
         "source": "github"
       },

--- a/catalog.md
+++ b/catalog.md
@@ -195,3 +195,19 @@ Tags: rfe, jira, review, strategy, pipeline
 ```bash
 /plugin install rfe-creator@opendatahub-skills
 ```
+
+### meeting-quality-skills
+
+Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.
+
+v0.1.0 | Apache-2.0 | [ahinek/meeting-quality-skills](https://github.com/ahinek/meeting-quality-skills)
+
+Tags: meeting, google-workspace, agenda, async-updates, productivity
+
+| Skill | Description |
+|-------|-------------|
+| `/meeting-async-update-check` | Check a shared update doc and identify attendees missing async updates before a status meeting |
+
+```bash
+/plugin install meeting-quality-skills@opendatahub-skills
+```

--- a/catalog.md
+++ b/catalog.md
@@ -207,6 +207,7 @@ Tags: meeting, google-workspace, agenda, async-updates, productivity
 | Skill | Description |
 |-------|-------------|
 | `/meeting-async-update-check` | Check a shared update doc and identify attendees missing async updates before a status meeting |
+| `/meeting-risk-agenda` | Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items |
 
 ```bash
 /plugin install meeting-quality-skills@opendatahub-skills

--- a/registry.yaml
+++ b/registry.yaml
@@ -406,7 +406,7 @@ plugins:
     source:
       type: github
       repo: ahinek/meeting-quality-skills
-      ref: main
+      ref: 058ef75e5e9f83872c8351ad7dcfe2798951128d
     skills:
       - name: meeting-async-update-check
         description: Check a shared update doc and identify attendees missing async updates before a status meeting

--- a/registry.yaml
+++ b/registry.yaml
@@ -406,12 +406,15 @@ plugins:
     source:
       type: github
       repo: ahinek/meeting-quality-skills
-      ref: 058ef75e5e9f83872c8351ad7dcfe2798951128d
+      ref: f39c944a31cad1ec6d57360f56ef28f04dd0ad78
     homepage: https://github.com/ahinek/meeting-quality-skills
     repository: https://github.com/ahinek/meeting-quality-skills
     skills:
       - name: meeting-async-update-check
         description: Check a shared update doc and identify attendees missing async updates before a status meeting
+        user-invocable: true
+      - name: meeting-risk-agenda
+        description: Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items
         user-invocable: true
     harnesses:
       claude-code:

--- a/registry.yaml
+++ b/registry.yaml
@@ -391,3 +391,31 @@ plugins:
       package: agent-eval-harness
       requires_python: ">=3.11"
     depends_on: []
+
+  - name: meeting-quality-skills
+    description: >
+      Pre-meeting skills for improving meeting quality by checking shared update docs,
+      identifying missing async updates, and helping organizers focus meetings on items
+      that actually need discussion.
+    version: "0.1.0"
+    category: planning
+    tags: [meeting, google-workspace, agenda, async-updates, productivity]
+    author:
+      name: Arjay Hinek
+    license: Apache-2.0
+    source:
+      type: github
+      repo: ahinek/meeting-quality-skills
+      ref: main
+    skills:
+      - name: meeting-async-update-check
+        description: Check a shared update doc and identify attendees missing async updates before a status meeting
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install meeting-quality-skills@opendatahub-skills"
+      generic:
+        skill_format: markdown
+        skill_dir: skills/
+        entry_point: "skills/{skill_name}/SKILL.md"
+    depends_on: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -407,6 +407,8 @@ plugins:
       type: github
       repo: ahinek/meeting-quality-skills
       ref: 058ef75e5e9f83872c8351ad7dcfe2798951128d
+    homepage: https://github.com/ahinek/meeting-quality-skills
+    repository: https://github.com/ahinek/meeting-quality-skills
     skills:
       - name: meeting-async-update-check
         description: Check a shared update doc and identify attendees missing async updates before a status meeting


### PR DESCRIPTION
Adds the `meeting-quality-skills` plugin with two pre-meeting skills designed to improve the effectiveness of recurring status meetings using Google Workspace artifacts (e.g., shared docs):

1. `meeting-async-update-check`  
   Identifies attendees who have not provided async updates prior to a meeting, helping shift status reporting out of the meeting and into a shared document.

2. `meeting-risk-agenda`  
   Analyzes pre-meeting updates and generates a risk-focused agenda by identifying blocked and at-risk items, allowing meetings to focus on issues and decisions rather than general status.

The plugin is intended to support a transition from status-driven meetings to exception-based, outcome-focused discussions.