### PR TITLE
Fix deploy workflow site-dir path

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,11 +28,11 @@ jobs:
         run: pip install -r site/requirements.txt
 
       - name: Build site
-        run: mkdocs build --config-file site/mkdocs.yml --site-dir _site
+        run: mkdocs build --config-file site/mkdocs.yml --site-dir site/_site
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: _site
+          path: site/_site
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

Fix the GitHub Pages deploy workflow — `mkdocs build` outputs to `site/_site/` (relative to the config file at `site/mkdocs.yml`), but the upload step was looking for `_site/` at the repo root.

## Changes

- `--site-dir _site` → `--site-dir site/_site`
- `path: _site` → `path: site/_site`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site deployment configuration to optimize build artifact handling and output directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->