### PR TITLE
Fix deploy workflow: use working-directory for mkdocs build

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,11 +28,12 @@ jobs:
         run: pip install -r site/requirements.txt
 
       - name: Build site
-        run: mkdocs build --config-file site/mkdocs.yml --site-dir site/_site
+        working-directory: site
+        run: mkdocs build --site-dir ../_site
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: site/_site
+          path: _site
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

Second fix for the deploy workflow. MkDocs resolves `--site-dir` relative to the config file location, not the working directory. The previous fix (`site/_site`) still resolved to `site/site/_site`.

## Fix

Use `working-directory: site` so mkdocs runs from the config directory, then `--site-dir ../_site` outputs to the repo root.

Verified locally:
```
$ cd site && mkdocs build --site-dir ../_site
INFO - Building documentation to directory: .../skills-registry/_site
$ ls _site/index.html
_site/index.html
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)