### PR TITLE
Add CI workflow to sync drawio from user-edited SVGs

### DIFF
--- a/.github/workflows/diagram-pr.yml
+++ b/.github/workflows/diagram-pr.yml
@@ -1,4 +1,4 @@
-name: Diagram PR Feedback
+name: Diagram PR Sync
 
 on:
   pull_request:
@@ -6,50 +6,75 @@ on:
       - 'site/docs/plugins/**/*.svg'
 
 jobs:
-  extract-feedback:
+  sync-drawio:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
-        run: pip install pyyaml
-
-      - name: Validate diagram SVGs have embedded data
+      - name: Find changed SVGs
+        id: changed
         run: |
-          changed_svgs=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- 'site/docs/plugins/**/*.svg')
-          if [ -z "$changed_svgs" ]; then
-            echo "No SVG changes detected"
+          # If drawio files were also changed, this is a batch update — skip sync
+          changed_drawio=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- 'site/docs/plugins/**/*.drawio')
+          if [ -n "$changed_drawio" ]; then
+            echo "svgs=" >> $GITHUB_OUTPUT
+            echo "Batch update detected (drawio files changed) — skipping sync"
             exit 0
           fi
 
-          for svg in $changed_svgs; do
-            if [ -f "$svg" ] && ! grep -q "mxfile" "$svg"; then
-              echo "ERROR: $svg does not contain embedded draw.io data (mxfile)."
-              echo "Re-export with: draw.io --export --format svg --embed-diagram"
-              exit 1
+          changed_svgs=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- 'site/docs/plugins/**/*.svg')
+          if [ -z "$changed_svgs" ]; then
+            echo "svgs=" >> $GITHUB_OUTPUT
+            echo "No SVG changes detected"
+          else
+            echo "svgs<<EOF" >> $GITHUB_OUTPUT
+            echo "$changed_svgs" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate SVGs have embedded draw.io data
+        if: steps.changed.outputs.svgs != ''
+        run: |
+          while IFS= read -r svg; do
+            if [ -f "$svg" ] && ! grep -q "mxfile\|mxGraphModel" "$svg"; then
+              echo "WARNING: $svg does not contain embedded draw.io data"
             fi
-          done
-          echo "All modified SVGs have embedded diagram data"
+          done <<< "${{ steps.changed.outputs.svgs }}"
+
+      - name: Sync drawio files from SVGs
+        if: steps.changed.outputs.svgs != ''
+        run: |
+          python3 scripts/sync_drawio_from_svg.py ${{ steps.changed.outputs.svgs }}
+
+      - name: Commit updated drawio files
+        if: steps.changed.outputs.svgs != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add 'site/docs/plugins/**/*.drawio'
+          if git diff --cached --quiet; then
+            echo "No drawio changes to commit"
+          else
+            git commit -m "Sync drawio files from edited SVGs"
+            git push
+          fi
 
       - name: Extract before/after pairs for eval dataset
+        if: steps.changed.outputs.svgs != ''
         run: |
-          changed_svgs=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- 'site/docs/plugins/**/*.svg')
-          if [ -z "$changed_svgs" ]; then
-            echo "No SVG changes to extract"
-            exit 0
-          fi
-
+          pip install pyyaml
           python3 scripts/extract_diagram_feedback.py \
             --base-ref ${{ github.event.pull_request.base.sha }} \
-            --svgs $changed_svgs
+            --svgs ${{ steps.changed.outputs.svgs }}
 
       - name: Upload feedback cases
         if: always()

--- a/scripts/sync_drawio_from_svg.py
+++ b/scripts/sync_drawio_from_svg.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Extract embedded draw.io XML from SVGs and write matching .drawio files.
+
+When a user edits an SVG in draw.io and submits it via PR, this script
+extracts the embedded mxfile data and writes a .drawio file alongside it.
+This keeps the .drawio files in sync without requiring users to commit both.
+
+Usage:
+    # Sync specific SVGs (e.g., from CI with changed files list)
+    python3 scripts/sync_drawio_from_svg.py site/docs/plugins/assess-rfe/assess-rfe.svg
+
+    # Sync all SVGs under a plugin
+    python3 scripts/sync_drawio_from_svg.py site/docs/plugins/assess-rfe/*.svg
+
+    # Dry run — show what would change
+    python3 scripts/sync_drawio_from_svg.py --dry-run site/docs/plugins/**/*.svg
+"""
+
+import html
+import re
+import sys
+from pathlib import Path
+
+
+def extract_mxfile_from_svg(svg_content: str) -> str | None:
+    match = re.search(r'content="([^"]*)"', svg_content)
+    if match:
+        return html.unescape(match.group(1))
+    if "mxGraphModel" in svg_content:
+        match = re.search(r"(<mxGraphModel.*?</mxGraphModel>)", svg_content, re.DOTALL)
+        if match:
+            return match.group(1)
+    return None
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    svg_paths = [p for p in sys.argv[1:] if not p.startswith("--")]
+
+    if not svg_paths:
+        print("Usage: sync_drawio_from_svg.py [--dry-run] <svg-files...>")
+        sys.exit(1)
+
+    updated = 0
+    skipped = 0
+    failed = 0
+
+    for svg_path_str in svg_paths:
+        svg_path = Path(svg_path_str)
+        if not svg_path.exists() or svg_path.suffix != ".svg":
+            continue
+
+        drawio_path = svg_path.with_suffix(".drawio")
+        svg_content = svg_path.read_text(encoding="utf-8")
+        mxfile = extract_mxfile_from_svg(svg_content)
+
+        if not mxfile:
+            print(f"  - {svg_path.name}: no embedded mxfile (d2-rendered SVG)")
+            skipped += 1
+            continue
+
+        if drawio_path.exists():
+            existing = drawio_path.read_text(encoding="utf-8")
+            if existing.strip() == mxfile.strip():
+                skipped += 1
+                continue
+
+        if dry_run:
+            print(f"  ~ {svg_path.name} → {drawio_path.name} (would update)")
+        else:
+            drawio_path.write_text(mxfile, encoding="utf-8")
+            print(f"  ✓ {svg_path.name} → {drawio_path.name}")
+        updated += 1
+
+    print(f"\n{updated} updated, {skipped} skipped, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

When users edit diagram SVGs in draw.io and submit PRs, CI now auto-extracts the embedded draw.io XML and commits a matching `.drawio` file back to the PR branch. This keeps drawio files in sync without requiring users to commit both files.

## How it works

1. User downloads SVG from the site/repo
2. Opens in draw.io (reads embedded diagram data)
3. Edits, saves as SVG
4. Commits just the SVG, opens PR
5. **CI auto-generates the matching `.drawio` and commits it**

## Changes

- `scripts/sync_drawio_from_svg.py` — extracts mxfile XML from SVGs, writes `.drawio` files
- `.github/workflows/diagram-pr.yml` — updated workflow:
  - Skips batch update PRs (where `.drawio` files already changed)
  - Validates SVGs have embedded draw.io data
  - Syncs and commits `.drawio` files
  - Extracts before/after feedback pairs (existing feature, preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)