### PR TITLE
Fix navigation titles and add categories index page

### DIFF
--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -170,7 +170,8 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
 def generate_plugins_index(registry: dict) -> str:
     plugins = registry.get("plugins", [])
     categories = registry.get("categories", {})
-    lines = [GENERATED_MARKER]
+    lines = ["---\ntitle: Plugins\n---\n"]
+    lines.append(GENERATED_MARKER)
     lines.append("# Plugins")
     lines.append("")
     lines.append(f"{len(plugins)} plugins registered in the marketplace.")
@@ -208,7 +209,8 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     if enrichment:
         desc = enrichment.get("description", desc)
 
-    lines = [GENERATED_MARKER]
+    lines = [f"---\ntitle: {name}\n---\n"]
+    lines.append(GENERATED_MARKER)
     lines.append(f"# {name}")
     lines.append("")
     lines.append(desc)
@@ -309,7 +311,8 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
     if enriched_skill and enriched_skill.get("description"):
         sdesc = enriched_skill["description"].strip()
 
-    lines = [GENERATED_MARKER]
+    lines = [f"---\ntitle: {sname}\n---\n"]
+    lines.append(GENERATED_MARKER)
     lines.append(f"# {sname}")
     lines.append("")
     lines.append(sdesc)
@@ -361,9 +364,32 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
     return "\n".join(lines)
 
 
+def generate_categories_index(registry: dict) -> str:
+    categories = registry.get("categories", {})
+    by_cat = build_category_plugins(registry)
+    lines = ["---\ntitle: Categories\n---\n"]
+    lines.append(GENERATED_MARKER)
+    lines.append("# Categories")
+    lines.append("")
+    lines.append(f"{len(categories)} categories in the marketplace.")
+    lines.append("")
+    lines.append("| Category | Plugins | Description |")
+    lines.append("|----------|---------|-------------|")
+    for key, meta in categories.items():
+        if not by_cat.get(key):
+            continue
+        name = meta["name"]
+        desc = meta.get("description", "").strip().split("\n")[0]
+        count = len(by_cat[key])
+        lines.append(f"| [{name}]({key}.md) | {count} | {desc} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def generate_category_page(cat_key: str, cat_meta: dict,
                            plugins: list) -> str:
-    lines = [GENERATED_MARKER]
+    lines = [f"---\ntitle: {cat_meta['name']}\n---\n"]
+    lines.append(GENERATED_MARKER)
     lines.append(f"# {cat_meta['name']}")
     lines.append("")
     lines.append(cat_meta.get("description", ""))
@@ -418,8 +444,9 @@ def generate_mkdocs_yml(registry: dict, categories: dict,
             sname = skill["name"]
             nav_lines.append(f"      - {sname}: plugins/{name}/{sname}.md")
 
-    # Categories section — flat list
+    # Categories section — with index page
     nav_lines.append("  - Categories:")
+    nav_lines.append("    - categories/index.md")
     for cat_key, cat_meta in categories.items():
         if cat_plugins.get(cat_key):
             nav_lines.append(f"    - {cat_meta['name']}: categories/{cat_key}.md")
@@ -464,6 +491,9 @@ def generate_site(registry: dict, output_dir: Path):
                 generate_skill_page(skill, plugin, enrichment, plugin_dir))
 
     # Category pages
+    (docs / "categories").mkdir(parents=True, exist_ok=True)
+    (docs / "categories" / "index.md").write_text(
+        generate_categories_index(registry))
     for cat_key, cat_meta in categories.items():
         cat_list = cat_plugins.get(cat_key, [])
         if cat_list:

--- a/site/docs/categories/development-tools.md
+++ b/site/docs/categories/development-tools.md
@@ -1,3 +1,7 @@
+---
+title: Development Tools
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/categories/evaluation.md
+++ b/site/docs/categories/evaluation.md
@@ -1,3 +1,7 @@
+---
+title: Evaluation & Testing
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -1,0 +1,17 @@
+---
+title: Categories
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# Categories
+
+7 categories in the marketplace.
+
+| Category | Plugins | Description |
+|----------|---------|-------------|
+| [Evaluation & Testing](evaluation.md) | 4 | Skills for evaluating and testing AI agent skills |
+| [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
+| [Development Tools](development-tools.md) | 1 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
+| [Product Planning](planning.md) | 2 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/categories/planning.md
+++ b/site/docs/categories/planning.md
@@ -1,3 +1,7 @@
+---
+title: Product Planning
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/categories/security.md
+++ b/site/docs/categories/security.md
@@ -1,3 +1,7 @@
+---
+title: Security Review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-analyze.md
+++ b/site/docs/plugins/agent-eval-harness/eval-analyze.md
@@ -1,3 +1,7 @@
+---
+title: eval-analyze
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-dataset.md
+++ b/site/docs/plugins/agent-eval-harness/eval-dataset.md
@@ -1,3 +1,7 @@
+---
+title: eval-dataset
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-mlflow.md
+++ b/site/docs/plugins/agent-eval-harness/eval-mlflow.md
@@ -1,3 +1,7 @@
+---
+title: eval-mlflow
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-optimize.md
+++ b/site/docs/plugins/agent-eval-harness/eval-optimize.md
@@ -1,3 +1,7 @@
+---
+title: eval-optimize
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-review.md
+++ b/site/docs/plugins/agent-eval-harness/eval-review.md
@@ -1,3 +1,7 @@
+---
+title: eval-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-run.md
+++ b/site/docs/plugins/agent-eval-harness/eval-run.md
@@ -1,3 +1,7 @@
+---
+title: eval-run
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/eval-setup.md
+++ b/site/docs/plugins/agent-eval-harness/eval-setup.md
@@ -1,3 +1,7 @@
+---
+title: eval-setup
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -1,3 +1,7 @@
+---
+title: agent-eval-harness
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/assess-rfe/assess-rfe.md
+++ b/site/docs/plugins/assess-rfe/assess-rfe.md
@@ -1,3 +1,7 @@
+---
+title: assess-rfe
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/assess-rfe/export-rubric.md
+++ b/site/docs/plugins/assess-rfe/export-rubric.md
@@ -1,3 +1,7 @@
+---
+title: export-rubric
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/assess-rfe/index.md
+++ b/site/docs/plugins/assess-rfe/index.md
@@ -1,3 +1,7 @@
+---
+title: assess-rfe
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -1,3 +1,7 @@
+---
+title: Plugins
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/meeting-quality-skills/index.md
+++ b/site/docs/plugins/meeting-quality-skills/index.md
@@ -1,3 +1,7 @@
+---
+title: meeting-quality-skills
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
@@ -1,3 +1,7 @@
+---
+title: meeting-async-update-check
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
@@ -1,3 +1,7 @@
+---
+title: meeting-risk-agenda
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/adr-review.md
+++ b/site/docs/plugins/odh-ai-helpers/adr-review.md
@@ -1,3 +1,7 @@
+---
+title: adr-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
+++ b/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
@@ -1,3 +1,7 @@
+---
+title: git-shallow-clone
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
+++ b/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
@@ -1,3 +1,7 @@
+---
+title: gitlab-pipeline-debugger
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/index.md
+++ b/site/docs/plugins/odh-ai-helpers/index.md
@@ -1,3 +1,7 @@
+---
+title: odh-ai-helpers
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
+++ b/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
@@ -1,3 +1,7 @@
+---
+title: jira-upload-chat-log
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-full-deps.md
+++ b/site/docs/plugins/odh-ai-helpers/python-full-deps.md
@@ -1,3 +1,7 @@
+---
+title: python-full-deps
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-bug-finder
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-complexity
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-env-finder
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-license-checker
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-license-finder
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
@@ -1,3 +1,7 @@
+---
+title: python-packaging-source-finder
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-check-backported
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-cherry-pick
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-classify
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-fetch-prs
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-push-report
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
@@ -1,3 +1,7 @@
+---
+title: vllm-backport-score-rank
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
@@ -1,3 +1,7 @@
+---
+title: vllm-compare-reqs
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
@@ -1,3 +1,7 @@
+---
+title: vllm-slack-summary
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/historical-bug-coverage.md
+++ b/site/docs/plugins/quality-tooling/historical-bug-coverage.md
@@ -1,3 +1,7 @@
+---
+title: historical-bug-coverage
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/index.md
+++ b/site/docs/plugins/quality-tooling/index.md
@@ -1,3 +1,7 @@
+---
+title: quality-tooling
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/konflux-build-simulator.md
+++ b/site/docs/plugins/quality-tooling/konflux-build-simulator.md
@@ -1,3 +1,7 @@
+---
+title: konflux-build-simulator
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/quality-repo-analysis.md
+++ b/site/docs/plugins/quality-tooling/quality-repo-analysis.md
@@ -1,3 +1,7 @@
+---
+title: quality-repo-analysis
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/risk-assessment.md
+++ b/site/docs/plugins/quality-tooling/risk-assessment.md
@@ -1,3 +1,7 @@
+---
+title: risk-assessment
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/quality-tooling/test-rules-generator.md
+++ b/site/docs/plugins/quality-tooling/test-rules-generator.md
@@ -1,3 +1,7 @@
+---
+title: test-rules-generator
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/architecture-review.md
+++ b/site/docs/plugins/rfe-creator/architecture-review.md
@@ -1,3 +1,7 @@
+---
+title: architecture-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/feasibility-review.md
@@ -1,3 +1,7 @@
+---
+title: feasibility-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/index.md
+++ b/site/docs/plugins/rfe-creator/index.md
@@ -1,3 +1,7 @@
+---
+title: rfe-creator
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
+++ b/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
@@ -1,3 +1,7 @@
+---
+title: rfe-creator.update-deps
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
@@ -1,3 +1,7 @@
+---
+title: rfe-feasibility-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.auto-fix.md
+++ b/site/docs/plugins/rfe-creator/rfe.auto-fix.md
@@ -1,3 +1,7 @@
+---
+title: rfe.auto-fix
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.create.md
+++ b/site/docs/plugins/rfe-creator/rfe.create.md
@@ -1,3 +1,7 @@
+---
+title: rfe.create
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.review.md
+++ b/site/docs/plugins/rfe-creator/rfe.review.md
@@ -1,3 +1,7 @@
+---
+title: rfe.review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.speedrun.md
+++ b/site/docs/plugins/rfe-creator/rfe.speedrun.md
@@ -1,3 +1,7 @@
+---
+title: rfe.speedrun
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.split.md
+++ b/site/docs/plugins/rfe-creator/rfe.split.md
@@ -1,3 +1,7 @@
+---
+title: rfe.split
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/rfe.submit.md
+++ b/site/docs/plugins/rfe-creator/rfe.submit.md
@@ -1,3 +1,7 @@
+---
+title: rfe.submit
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/scope-review.md
+++ b/site/docs/plugins/rfe-creator/scope-review.md
@@ -1,3 +1,7 @@
+---
+title: scope-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/strat.create.md
+++ b/site/docs/plugins/rfe-creator/strat.create.md
@@ -1,3 +1,7 @@
+---
+title: strat.create
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/strat.prioritize.md
+++ b/site/docs/plugins/rfe-creator/strat.prioritize.md
@@ -1,3 +1,7 @@
+---
+title: strat.prioritize
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/strat.refine.md
+++ b/site/docs/plugins/rfe-creator/strat.refine.md
@@ -1,3 +1,7 @@
+---
+title: strat.refine
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/strat.review.md
+++ b/site/docs/plugins/rfe-creator/strat.review.md
@@ -1,3 +1,7 @@
+---
+title: strat.review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rfe-creator/testability-review.md
+++ b/site/docs/plugins/rfe-creator/testability-review.md
@@ -1,3 +1,7 @@
+---
+title: testability-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rhoai-security-reviewer/index.md
+++ b/site/docs/plugins/rhoai-security-reviewer/index.md
@@ -1,3 +1,7 @@
+---
+title: rhoai-security-reviewer
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
+++ b/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
@@ -1,3 +1,7 @@
+---
+title: security-reviewer
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
+++ b/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
@@ -1,3 +1,7 @@
+---
+title: strat-security-review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/index.md
+++ b/site/docs/plugins/test-plan/index.md
@@ -1,3 +1,7 @@
+---
+title: test-plan
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.analyze.endpoints.md
+++ b/site/docs/plugins/test-plan/test-plan.analyze.endpoints.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.analyze.endpoints
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.analyze.infra.md
+++ b/site/docs/plugins/test-plan/test-plan.analyze.infra.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.analyze.infra
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.analyze.placement.md
+++ b/site/docs/plugins/test-plan/test-plan.analyze.placement.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.analyze.placement
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.analyze.risks.md
+++ b/site/docs/plugins/test-plan/test-plan.analyze.risks.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.analyze.risks
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.case-implement.md
+++ b/site/docs/plugins/test-plan/test-plan.case-implement.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.case-implement
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.create-cases.md
+++ b/site/docs/plugins/test-plan/test-plan.create-cases.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.create-cases
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.create.md
+++ b/site/docs/plugins/test-plan/test-plan.create.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.create
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.create.test-function.md
+++ b/site/docs/plugins/test-plan/test-plan.create.test-function.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.create.test-function
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.merge.md
+++ b/site/docs/plugins/test-plan/test-plan.merge.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.merge
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.publish.md
+++ b/site/docs/plugins/test-plan/test-plan.publish.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.publish
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.resolve-feedback.md
+++ b/site/docs/plugins/test-plan/test-plan.resolve-feedback.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.resolve-feedback
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.resolve-gaps.md
+++ b/site/docs/plugins/test-plan/test-plan.resolve-gaps.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.resolve-gaps
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.review.md
+++ b/site/docs/plugins/test-plan/test-plan.review.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.review
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.score.md
+++ b/site/docs/plugins/test-plan/test-plan.score.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.score
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.score.test-function.md
+++ b/site/docs/plugins/test-plan/test-plan.score.test-function.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.score.test-function
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.ui-verify.md
+++ b/site/docs/plugins/test-plan/test-plan.ui-verify.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.ui-verify
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/docs/plugins/test-plan/test-plan.update.md
+++ b/site/docs/plugins/test-plan/test-plan.update.md
@@ -1,3 +1,7 @@
+---
+title: test-plan.update
+---
+
 <!-- Auto-generated from registry.yaml. Do not edit directly. -->
 
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
       - meeting-async-update-check: plugins/meeting-quality-skills/meeting-async-update-check.md
       - meeting-risk-agenda: plugins/meeting-quality-skills/meeting-risk-agenda.md
   - Categories:
+    - categories/index.md
     - Evaluation & Testing: categories/evaluation.md
     - Security Review: categories/security.md
     - Development Tools: categories/development-tools.md


### PR DESCRIPTION
## Summary

- Add `title` frontmatter to all generated pages so MkDocs Material shows the page name in the navigation header when scrolling (instead of "Index")
- Add `categories/index.md` with a table of categories (clicking "Categories" now lands on its own page instead of auto-selecting the first category)
- Skip empty categories from the index to avoid broken link warnings

## Test plan
- [ ] Scroll down on a plugin page — header should show plugin name, not "Index"
- [ ] Click "Categories" in nav — should show categories table
- [ ] No broken link warnings in mkdocs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)