### PR TITLE
Add argument hints and invocation examples to skill pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 .idea/
 .tmp/
+site/docs/plugins/*/artifacts/

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -332,9 +332,29 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
         lines.append(f"</div>")
         lines.append("")
 
+    # Argument hint from enrichment (frontmatter argument-hint)
+    argument_hint = enriched_skill.get("argument_hint") if enriched_skill else None
+
     # Arguments from enrichment
     if enriched_skill and enriched_skill.get("arguments"):
         lines.append("## Arguments")
+        lines.append("")
+        # Show invocation example: from argument_hint or auto-generated from args
+        hint = argument_hint
+        if not hint:
+            parts = []
+            for arg in enriched_skill["arguments"]:
+                name = arg["name"]
+                if name.startswith("--"):
+                    parts.append(f"[{name}]")
+                elif arg.get("required"):
+                    parts.append(f"<{name}>")
+                else:
+                    parts.append(f"[{name}]")
+            hint = " ".join(parts)
+        lines.append(f"```")
+        lines.append(f"/{sname} {hint}")
+        lines.append(f"```")
         lines.append("")
         lines.append("| Argument | Required | Default | Description |")
         lines.append("|----------|----------|---------|-------------|")
@@ -344,6 +364,28 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
             default = f'`{arg["default"]}`' if arg.get("default") else "—"
             adesc = arg.get("description", "")
             lines.append(f"| {aname} | {req} | {default} | {adesc} |")
+        lines.append("")
+    elif argument_hint:
+        # No enriched arguments but argument-hint exists — parse it as fallback
+        lines.append("## Arguments")
+        lines.append("")
+        lines.append(f"```")
+        lines.append(f"/{sname} {argument_hint}")
+        lines.append(f"```")
+        lines.append("")
+        lines.append("| Argument | Required | Description |")
+        lines.append("|----------|----------|-------------|")
+        for token in argument_hint.split():
+            if token.startswith("[") and token.endswith("]"):
+                name = token.strip("[]")
+                lines.append(f"| `{name}` | | Optional |")
+            elif token.startswith("<") and token.endswith(">"):
+                name = token.strip("<>")
+                lines.append(f"| `{name}` | :material-check: | |")
+            elif token.startswith("--"):
+                lines.append(f"| `{token}` | | Flag |")
+            else:
+                lines.append(f"| `{token}` | :material-check: | |")
         lines.append("")
 
     # Usage examples from enrichment

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -20,6 +20,8 @@ import yaml
 MKDOCS_CONFIG_TEMPLATE = """\
 site_name: OpenDataHub Skills Registry
 site_url: https://opendatahub-io.github.io/skills-registry
+repo_url: https://github.com/opendatahub-io/skills-registry
+repo_name: opendatahub-io/skills-registry
 
 theme:
   name: material

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -236,13 +236,6 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     lines.extend(meta)
     lines.append("")
 
-    # Architecture notes from enrichment
-    if enrichment and enrichment.get("architecture_notes"):
-        lines.append("## Architecture")
-        lines.append("")
-        lines.append(enrichment["architecture_notes"].strip())
-        lines.append("")
-
     # Pipeline diagram (only if SVG exists)
     if plugin_dir and (plugin_dir / "pipeline.svg").exists():
         lines.append("## Pipeline")
@@ -284,6 +277,13 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
             aname = agent["name"]
             adesc = agent.get("description", "")
             lines.append(f"| {aname} | {adesc} |")
+        lines.append("")
+
+    # Architecture notes from enrichment (at the bottom, before install)
+    if enrichment and enrichment.get("architecture_notes"):
+        lines.append("## Architecture")
+        lines.append("")
+        lines.append(enrichment["architecture_notes"].strip())
         lines.append("")
 
     # Install

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -281,13 +281,6 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
             lines.append(f"| {aname} | {adesc} |")
         lines.append("")
 
-    # Architecture notes from enrichment (at the bottom, before install)
-    if enrichment and enrichment.get("architecture_notes"):
-        lines.append("## Architecture")
-        lines.append("")
-        lines.append(enrichment["architecture_notes"].strip())
-        lines.append("")
-
     # Install
     lines.append("## Installation")
     lines.append("")
@@ -295,6 +288,13 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     lines.append(f"/plugin install {name}@{registry_name}")
     lines.append("```")
     lines.append("")
+
+    # Architecture notes from enrichment (very bottom — deep-dive content)
+    if enrichment and enrichment.get("architecture_notes"):
+        lines.append("## Architecture")
+        lines.append("")
+        lines.append(enrichment["architecture_notes"].strip())
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -402,6 +402,14 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
         lines.append("")
         lines.append(enriched_skill["usage"].strip())
         lines.append("")
+    elif not (enriched_skill and enriched_skill.get("arguments")) and not argument_hint:
+        # No arguments, no usage examples — show basic invocation
+        lines.append("## Usage")
+        lines.append("")
+        lines.append("```")
+        lines.append(f"/{sname}")
+        lines.append("```")
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -101,6 +101,20 @@
   letter-spacing: -0.01em;
 }
 
+/* ── GitHub repo link ── */
+.md-source {
+  color: var(--sr-text) !important;
+}
+
+.md-source__icon,
+.md-source__repository {
+  color: var(--sr-text) !important;
+}
+
+.md-source:hover .md-source__repository {
+  color: var(--md-primary-fg-color) !important;
+}
+
 /* ── Tabs ── */
 .md-tabs {
   background: var(--sr-bg) !important;

--- a/site/docs/plugins/agent-eval-harness/_enriched.yaml
+++ b/site/docs/plugins/agent-eval-harness/_enriched.yaml
@@ -4,167 +4,282 @@ description: |
   review results with human feedback, sync with MLflow, and iteratively optimize
   skill quality with regression checks.
 
-  The framework is schema-driven via eval.yaml, which defines execution mode,
-  dataset schemas, output descriptions, judges, models, and thresholds. Supports
-  inline, LLM-based, and external judges for scoring, with MLflow integration
-  for experiment tracking and tracing.
+  The framework is schema-driven via eval.yaml, which defines execution mode
+  (case-by-case or batch), dataset schemas, output descriptions, judges (inline
+  checks, LLM prompts, external modules), model selection per role (skill, subagent,
+  judge, hook), thresholds for regression detection, and tool interception handlers.
+  Supports AskUserQuestion answering via 3-tier resolution (exact overrides, LLM
+  with case context, fallback) and annotation-aware judges that adapt scoring based
+  on expected outcomes per test case.
+
+  The harness also integrates with EvalHub for running evaluations on Red Hat
+  OpenShift AI via a custom provider adapter, supporting S3-hosted datasets and
+  containerized execution.
 architecture_notes: |
-  Seven skills form a linear pipeline with feedback loops: analyze → dataset →
-  run → review/optimize. eval-run is the hub — it executes skills, runs judges,
-  and produces summary.yaml consumed by review, optimize, and mlflow. eval-optimize
-  creates a closed loop by editing SKILL.md and re-running eval-run with regression
-  checks. eval-mlflow provides bidirectional sync with MLflow for datasets, results,
-  and feedback.
+  Seven skills form a linear pipeline with feedback loops: setup (optional) ->
+  analyze -> dataset -> run -> review/optimize, with mlflow available at any
+  point after run. eval-run is the central hub -- it executes skills headlessly,
+  runs judges (inline checks + LLM scoring + pairwise comparison), and produces
+  summary.yaml consumed by review, optimize, and mlflow.
+
+  eval-optimize creates a closed loop by reading judge rationale and execution
+  transcripts, forming hypotheses about SKILL.md deficiencies, making surgical
+  edits, and re-running eval-run with regression baseline checks. eval-review
+  complements this with human-in-the-loop feedback that catches qualitative
+  issues judges miss. eval-mlflow provides bidirectional sync -- pushing datasets,
+  results, and feedback to MLflow experiment tracking and pulling annotations
+  back for optimization.
+
+  Scripts live alongside each skill and share the agent_eval Python package
+  (auto-installed via SessionStart hook into an isolated venv at .eval-venv/).
+  The data flow is: eval.yaml config -> workspace creation (isolated per run) ->
+  skill execution via EvalRunner -> artifact collection -> judge scoring ->
+  summary.yaml + HTML report.
 skills:
   eval-setup:
     description: |
-      One-time environment setup for the evaluation framework. Installs dependencies,
-      configures MLflow tracking, verifies API keys, and runs preflight checks.
+      Optional environment configurator for the evaluation harness. Installs
+      dependencies into the isolated venv, configures MLflow tracking (local
+      server, file store, or remote), verifies API keys (Anthropic or Vertex AI),
+      sets up the runs directory, checks skill-specific environment variables
+      referenced in eval.yaml, and creates the MLflow experiment. Most users
+      can skip this -- dependencies auto-install via the plugin's SessionStart
+      hook and agent_eval is available via symlinks.
+    argument_hint: "[--tracking-uri <uri>] [--skip-mlflow] [--runs-dir <path>]"
+    arguments:
+      - name: "--tracking-uri"
+        type: "<uri>"
+        required: false
+        description: "MLflow tracking URI (skips interactive setup). Accepts local or remote URIs."
+      - name: "--skip-mlflow"
+        required: false
+        default: "false"
+        description: "Skip MLflow setup entirely. The harness works without MLflow."
+      - name: "--runs-dir"
+        type: "<path>"
+        required: false
+        default: "eval/runs"
+        description: "Directory where eval runs are stored. Configured via AGENT_EVAL_RUNS_DIR env var."
     usage_examples:
       - "/eval-setup"
+      - "/eval-setup --tracking-uri http://127.0.0.1:5000"
+      - "/eval-setup --skip-mlflow"
   eval-analyze:
     description: |
-      Deeply examines a target skill's SKILL.md, sub-skills, scripts, and test cases
-      to generate eval.yaml — the configuration that /eval-run needs.
+      Deep-reads a target skill and generates eval.yaml -- the configuration that
+      /eval-run needs. Examines the skill's SKILL.md, follows sub-skill chains
+      recursively (up to 5 levels), explores scripts and test cases, and produces
+      a complete config with execution mode, dataset schema, output descriptions,
+      judges, model defaults, and thresholds. Uses an Explore sub-agent for the
+      recursive skill analysis and caches the result in eval.md with a content
+      hash for staleness detection.
+    argument_hint: "[--skill <name>] [--config <path>] [--update]"
     arguments:
       - name: "--skill"
         type: "<name>"
         required: false
         default: "auto-detect"
-        description: "Which skill to analyze"
+        description: "Which skill to analyze. If omitted, lists all project skills and picks automatically if only one is found."
       - name: "--config"
         type: "<path>"
         required: false
         default: "eval.yaml"
-        description: "Output path for the eval config"
+        description: "Output path for the eval config file."
       - name: "--update"
         required: false
         default: "false"
-        description: "Fill in missing sections only, preserve user edits"
+        description: "Fill in missing sections only, preserving user edits. Useful for upgrading older configs."
     usage_examples:
       - "/eval-analyze --skill my-skill"
       - "/eval-analyze --update"
+      - "/eval-analyze --skill rfe.create --config eval-rfe.yaml"
   eval-dataset:
     description: |
-      Generate realistic test cases from the eval.yaml schema. Supports bootstrap
-      (from scratch), expand (fill gaps), and from-traces (extract from MLflow) strategies.
+      Generates realistic test cases based on the eval.yaml dataset schema and
+      judge criteria. Supports three strategies: bootstrap (from scratch with
+      simple/complex/edge case coverage), expand (fills gaps in existing datasets
+      by analyzing what judges check that no case tests), and from-traces (extracts
+      real inputs from MLflow production traces). Handles external-state fields
+      with TODO_ placeholders, generates answers.yaml for interactive skills using
+      AskUserQuestion, and creates annotations.yaml for outcome-aware judges.
+    argument_hint: "[--config <path>] [--count <N>] [--strategy <type>]"
     arguments:
+      - name: "--config"
+        type: "<path>"
+        required: false
+        default: "eval.yaml"
+        description: "Path to eval config."
       - name: "--count"
         type: "<N>"
         required: false
-        default: "3"
-        description: "Number of test cases to generate"
+        default: "5"
+        description: "Number of test cases to generate."
       - name: "--strategy"
         type: "bootstrap | expand | from-traces"
         required: false
-        default: "auto"
-        description: "Generation strategy"
-      - name: "--config"
-        type: "<path>"
-        required: false
-        default: "eval.yaml"
-        description: "Path to eval config"
+        default: "bootstrap"
+        description: "Generation strategy. bootstrap: from scratch. expand: fill gaps in existing dataset. from-traces: extract from MLflow traces."
     usage_examples:
       - "/eval-dataset"
-      - "/eval-dataset --count 5 --strategy expand"
+      - "/eval-dataset --count 10 --strategy expand"
       - "/eval-dataset --strategy from-traces"
   eval-run:
     description: |
-      Execute a skill against test cases, collect artifacts, score with inline and
-      LLM judges, detect regressions against a baseline, and generate an HTML report.
+      Executes a skill against test cases, collects artifacts, scores with judges,
+      and generates an HTML report. Orchestrates via scripts: preflight checks for
+      stale artifacts, workspace creation with isolated per-case directories, headless
+      skill execution (case mode: once per case; batch mode: single invocation),
+      artifact collection into per-case dirs, scoring with inline checks and LLM
+      judges, optional pairwise comparison against a baseline for regression detection,
+      and report generation. Supports concurrent case execution via parallelism setting,
+      tool interception for AskUserQuestion and external APIs, and configurable
+      reasoning effort levels.
+    argument_hint: "[--config <path>] [--model <model>] [--run-id <id>] [--baseline <run-id>] [--case <filter>] [--no-judge] [--gold] [--effort <level>] [--subagent-model <model>] [--skill <name>]"
     arguments:
       - name: "--config"
         type: "<path>"
         required: false
         default: "eval.yaml"
-        description: "Path to eval config"
+        description: "Path to eval config."
       - name: "--model"
         type: "<model>"
         required: false
         default: "models.skill from config"
-        description: "Model for skill execution"
+        description: "Model for skill execution. Required if models.skill is unset in eval.yaml."
       - name: "--subagent-model"
         type: "<model>"
         required: false
-        description: "Model for subagents (falls back to skill model)"
-      - name: "--judge-model"
-        type: "<model>"
-        required: false
-        default: "models.judge from config"
-        description: "Model for LLM judges"
-      - name: "--baseline"
-        type: "<run-id>"
-        required: false
-        description: "Compare against a previous run for regression detection"
-      - name: "--cases"
-        type: "<pattern>"
-        required: false
-        description: "Filter cases by glob pattern (e.g. case-001*)"
-      - name: "--no-judge"
-        required: false
-        description: "Skip judge scoring (execution only)"
-      - name: "--gold"
-        required: false
-        description: "Save outputs as gold references"
-    usage_examples:
-      - "/eval-run"
-      - "/eval-run --model claude-opus-4-6 --baseline 2026-05-01"
-      - "/eval-run --cases 'case-001*' --no-judge"
-  eval-review:
-    description: |
-      Interactive review of evaluation results. Presents judge scores and skill
-      outputs for human feedback, identifies judge gaps, and proposes SKILL.md improvements.
-    arguments:
+        default: "models.subagent, falls back to skill model"
+        description: "Model for subagents (e.g., claude-sonnet-4-6 while main is claude-opus-4-7)."
       - name: "--run-id"
         type: "<id>"
         required: false
-        default: "latest run"
-        description: "Which eval run to review"
+        default: "YYYY-MM-DD-<model>"
+        description: "Identifier for this run."
+      - name: "--case"
+        type: "<filter>"
+        required: false
+        description: "Substring match to select specific cases."
+      - name: "--baseline"
+        type: "<run-id>"
+        required: false
+        description: "Previous run to compare against for regression detection via pairwise comparison."
+      - name: "--no-judge"
+        required: false
+        default: "false"
+        description: "Skip LLM judges, run inline checks only."
+      - name: "--gold"
+        required: false
+        default: "false"
+        description: "Save outputs as gold references after the run."
+      - name: "--effort"
+        type: "low | medium | high | xhigh | max"
+        required: false
+        default: "runner.effort from config"
+        description: "Claude Code reasoning effort level."
+      - name: "--skill"
+        type: "<name>"
+        required: false
+        default: "from config"
+        description: "Override the skill to test."
     usage_examples:
-      - "/eval-review"
-      - "/eval-review --run-id 2026-05-01-claude-opus-4-6"
-  eval-mlflow:
+      - "/eval-run --model claude-opus-4-6"
+      - "/eval-run --model claude-opus-4-6 --baseline 2026-05-01-opus"
+      - "/eval-run --case case-001 --no-judge"
+      - "/eval-run --gold"
+  eval-review:
     description: |
-      Bidirectional MLflow sync. Syncs datasets, logs run results and metrics,
-      pushes judge scores and human feedback to execution traces.
+      Interactive human-in-the-loop review of evaluation results. Presents judge
+      scores and skill outputs case by case, collects qualitative feedback, delegates
+      transcript analysis to Explore sub-agents to identify inefficiencies (roundabout
+      paths, multiple approaches, unnecessary tools), identifies judge-human alignment
+      gaps, and proposes targeted SKILL.md improvements grounded in feedback evidence.
+      Complements /eval-optimize (automated) by catching tone, intent, and UX issues
+      that judges cannot measure.
+    argument_hint: "--run-id <id> [--config <path>] [--case <filter>]"
     arguments:
       - name: "--run-id"
         type: "<id>"
         required: true
-        description: "Which eval run to sync"
+        description: "Which eval run to review."
+      - name: "--config"
+        type: "<path>"
+        required: false
+        default: "eval.yaml"
+        description: "Path to eval config."
+      - name: "--case"
+        type: "<filter>"
+        required: false
+        description: "Substring match to select specific cases for review."
+    usage_examples:
+      - "/eval-review --run-id 2026-05-01-opus"
+      - "/eval-review --run-id 2026-05-01-opus --case case-003"
+  eval-mlflow:
+    description: |
+      Bidirectional MLflow integration for evaluation results, datasets, and
+      feedback. Syncs test cases to MLflow dataset registry with a schema mapping
+      you define (inputs vs expectations), logs run params/metrics/artifacts/traces
+      to MLflow experiments, pushes judge scores and human feedback to execution
+      traces, and pulls annotations added via the MLflow UI back into review.yaml
+      for /eval-optimize to consume. Resolves tracking URI from eval.yaml, then
+      MLFLOW_TRACKING_URI env var, then defaults to localhost:5000.
+    argument_hint: "[--action <action>] [--run-id <id>] [--config <path>]"
+    arguments:
       - name: "--action"
         type: "sync-dataset | log-results | push-feedback | pull-feedback | all"
         required: false
         default: "all"
-        description: "Which sync action to perform"
+        description: "Which sync action to perform."
+      - name: "--run-id"
+        type: "<id>"
+        required: false
+        description: "Which eval run to log or attach feedback to. Required for log-results, push-feedback, and pull-feedback."
       - name: "--config"
         type: "<path>"
         required: false
         default: "eval.yaml"
-        description: "Path to eval config"
+        description: "Path to eval config."
     usage_examples:
-      - "/eval-mlflow --run-id 2026-05-01"
-      - "/eval-mlflow --run-id latest --action sync-dataset"
+      - "/eval-mlflow --run-id 2026-05-01-opus"
+      - "/eval-mlflow --action sync-dataset"
+      - "/eval-mlflow --run-id 2026-05-01-opus --action push-feedback"
   eval-optimize:
     description: |
-      Automated improvement loop. Identifies judge failures, analyzes transcripts,
-      edits SKILL.md, re-runs evaluation with regression checks, and iterates.
+      Automated skill improvement loop. Runs evaluation, identifies judge failures
+      from summary.yaml, reads execution transcripts via Explore sub-agents to trace
+      root causes to specific SKILL.md instructions, makes surgical edits grounded
+      in evidence, re-runs evaluation with regression baseline checks, and iterates
+      up to a configurable maximum. Also reads human feedback from review.yaml
+      (from /eval-review) and MLflow annotations to prioritize issues flagged by
+      humans over automated judge failures. Stops when all judges pass or max
+      iterations reached.
+    argument_hint: "[--config <path>] [--model <model>] [--max-iterations <N>] [--run-id <id>] [--target-judge <name>]"
     arguments:
-      - name: "--max-iterations"
-        type: "<N>"
-        required: false
-        default: "3"
-        description: "Maximum optimization iterations"
       - name: "--config"
         type: "<path>"
         required: false
         default: "eval.yaml"
-        description: "Path to eval config"
+        description: "Path to eval config."
       - name: "--model"
         type: "<model>"
         required: false
         default: "models.skill from config"
-        description: "Model for skill execution"
+        description: "Model for skill execution across all iterations."
+      - name: "--max-iterations"
+        type: "<N>"
+        required: false
+        default: "3"
+        description: "Maximum optimization iterations before stopping."
+      - name: "--run-id"
+        type: "<id>"
+        required: false
+        default: "auto-generated"
+        description: "Base run ID. Iterations append -iter-N."
+      - name: "--target-judge"
+        type: "<name>"
+        required: false
+        description: "Focus optimization on a specific failing judge instead of all judges."
     usage_examples:
       - "/eval-optimize"
       - "/eval-optimize --max-iterations 5 --model claude-opus-4-6"
+      - "/eval-optimize --target-judge completeness"

--- a/site/docs/plugins/agent-eval-harness/eval-analyze.md
+++ b/site/docs/plugins/agent-eval-harness/eval-analyze.md
@@ -7,8 +7,13 @@ title: eval-analyze
 
 # eval-analyze
 
-Deeply examines a target skill's SKILL.md, sub-skills, scripts, and test cases
-to generate eval.yaml — the configuration that /eval-run needs.
+Deep-reads a target skill and generates eval.yaml -- the configuration that
+/eval-run needs. Examines the skill's SKILL.md, follows sub-skill chains
+recursively (up to 5 levels), explores scripts and test cases, and produces
+a complete config with execution mode, dataset schema, output descriptions,
+judges, model defaults, and thresholds. Uses an Explore sub-agent for the
+recursive skill analysis and caches the result in eval.md with a content
+hash for staleness detection.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +25,20 @@ to generate eval.yaml — the configuration that /eval-run needs.
 
 ## Arguments
 
+```
+/eval-analyze [--skill <name>] [--config <path>] [--update]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--skill` |  | `auto-detect` | Which skill to analyze |
-| `--config` |  | `eval.yaml` | Output path for the eval config |
-| `--update` |  | `false` | Fill in missing sections only, preserve user edits |
+| `--skill` |  | `auto-detect` | Which skill to analyze. If omitted, lists all project skills and picks automatically if only one is found. |
+| `--config` |  | `eval.yaml` | Output path for the eval config file. |
+| `--update` |  | `false` | Fill in missing sections only, preserving user edits. Useful for upgrading older configs. |
 
 ## Usage
 
 ```
 /eval-analyze --skill my-skill
 /eval-analyze --update
+/eval-analyze --skill rfe.create --config eval-rfe.yaml
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-dataset.md
+++ b/site/docs/plugins/agent-eval-harness/eval-dataset.md
@@ -7,8 +7,13 @@ title: eval-dataset
 
 # eval-dataset
 
-Generate realistic test cases from the eval.yaml schema. Supports bootstrap
-(from scratch), expand (fill gaps), and from-traces (extract from MLflow) strategies.
+Generates realistic test cases based on the eval.yaml dataset schema and
+judge criteria. Supports three strategies: bootstrap (from scratch with
+simple/complex/edge case coverage), expand (fills gaps in existing datasets
+by analyzing what judges check that no case tests), and from-traces (extracts
+real inputs from MLflow production traces). Handles external-state fields
+with TODO_ placeholders, generates answers.yaml for interactive skills using
+AskUserQuestion, and creates annotations.yaml for outcome-aware judges.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,16 +25,20 @@ Generate realistic test cases from the eval.yaml schema. Supports bootstrap
 
 ## Arguments
 
+```
+/eval-dataset [--config <path>] [--count <N>] [--strategy <type>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--count` |  | `3` | Number of test cases to generate |
-| `--strategy` |  | `auto` | Generation strategy |
-| `--config` |  | `eval.yaml` | Path to eval config |
+| `--config` |  | `eval.yaml` | Path to eval config. |
+| `--count` |  | `5` | Number of test cases to generate. |
+| `--strategy` |  | `bootstrap` | Generation strategy. bootstrap: from scratch. expand: fill gaps in existing dataset. from-traces: extract from MLflow traces. |
 
 ## Usage
 
 ```
 /eval-dataset
-/eval-dataset --count 5 --strategy expand
+/eval-dataset --count 10 --strategy expand
 /eval-dataset --strategy from-traces
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-mlflow.md
+++ b/site/docs/plugins/agent-eval-harness/eval-mlflow.md
@@ -7,8 +7,13 @@ title: eval-mlflow
 
 # eval-mlflow
 
-Bidirectional MLflow sync. Syncs datasets, logs run results and metrics,
-pushes judge scores and human feedback to execution traces.
+Bidirectional MLflow integration for evaluation results, datasets, and
+feedback. Syncs test cases to MLflow dataset registry with a schema mapping
+you define (inputs vs expectations), logs run params/metrics/artifacts/traces
+to MLflow experiments, pushes judge scores and human feedback to execution
+traces, and pulls annotations added via the MLflow UI back into review.yaml
+for /eval-optimize to consume. Resolves tracking URI from eval.yaml, then
+MLFLOW_TRACKING_URI env var, then defaults to localhost:5000.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +25,20 @@ pushes judge scores and human feedback to execution traces.
 
 ## Arguments
 
+```
+/eval-mlflow [--action <action>] [--run-id <id>] [--config <path>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--run-id` | :material-check: | — | Which eval run to sync |
-| `--action` |  | `all` | Which sync action to perform |
-| `--config` |  | `eval.yaml` | Path to eval config |
+| `--action` |  | `all` | Which sync action to perform. |
+| `--run-id` |  | — | Which eval run to log or attach feedback to. Required for log-results, push-feedback, and pull-feedback. |
+| `--config` |  | `eval.yaml` | Path to eval config. |
 
 ## Usage
 
 ```
-/eval-mlflow --run-id 2026-05-01
-/eval-mlflow --run-id latest --action sync-dataset
+/eval-mlflow --run-id 2026-05-01-opus
+/eval-mlflow --action sync-dataset
+/eval-mlflow --run-id 2026-05-01-opus --action push-feedback
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-optimize.md
+++ b/site/docs/plugins/agent-eval-harness/eval-optimize.md
@@ -7,8 +7,14 @@ title: eval-optimize
 
 # eval-optimize
 
-Automated improvement loop. Identifies judge failures, analyzes transcripts,
-edits SKILL.md, re-runs evaluation with regression checks, and iterates.
+Automated skill improvement loop. Runs evaluation, identifies judge failures
+from summary.yaml, reads execution transcripts via Explore sub-agents to trace
+root causes to specific SKILL.md instructions, makes surgical edits grounded
+in evidence, re-runs evaluation with regression baseline checks, and iterates
+up to a configurable maximum. Also reads human feedback from review.yaml
+(from /eval-review) and MLflow annotations to prioritize issues flagged by
+humans over automated judge failures. Stops when all judges pass or max
+iterations reached.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +26,22 @@ edits SKILL.md, re-runs evaluation with regression checks, and iterates.
 
 ## Arguments
 
+```
+/eval-optimize [--config <path>] [--model <model>] [--max-iterations <N>] [--run-id <id>] [--target-judge <name>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--max-iterations` |  | `3` | Maximum optimization iterations |
-| `--config` |  | `eval.yaml` | Path to eval config |
-| `--model` |  | `models.skill from config` | Model for skill execution |
+| `--config` |  | `eval.yaml` | Path to eval config. |
+| `--model` |  | `models.skill from config` | Model for skill execution across all iterations. |
+| `--max-iterations` |  | `3` | Maximum optimization iterations before stopping. |
+| `--run-id` |  | `auto-generated` | Base run ID. Iterations append -iter-N. |
+| `--target-judge` |  | — | Focus optimization on a specific failing judge instead of all judges. |
 
 ## Usage
 
 ```
 /eval-optimize
 /eval-optimize --max-iterations 5 --model claude-opus-4-6
+/eval-optimize --target-judge completeness
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-review.md
+++ b/site/docs/plugins/agent-eval-harness/eval-review.md
@@ -7,8 +7,13 @@ title: eval-review
 
 # eval-review
 
-Interactive review of evaluation results. Presents judge scores and skill
-outputs for human feedback, identifies judge gaps, and proposes SKILL.md improvements.
+Interactive human-in-the-loop review of evaluation results. Presents judge
+scores and skill outputs case by case, collects qualitative feedback, delegates
+transcript analysis to Explore sub-agents to identify inefficiencies (roundabout
+paths, multiple approaches, unnecessary tools), identifies judge-human alignment
+gaps, and proposes targeted SKILL.md improvements grounded in feedback evidence.
+Complements /eval-optimize (automated) by catching tone, intent, and UX issues
+that judges cannot measure.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,13 +25,19 @@ outputs for human feedback, identifies judge gaps, and proposes SKILL.md improve
 
 ## Arguments
 
+```
+/eval-review --run-id <id> [--config <path>] [--case <filter>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--run-id` |  | `latest run` | Which eval run to review |
+| `--run-id` | :material-check: | — | Which eval run to review. |
+| `--config` |  | `eval.yaml` | Path to eval config. |
+| `--case` |  | — | Substring match to select specific cases for review. |
 
 ## Usage
 
 ```
-/eval-review
-/eval-review --run-id 2026-05-01-claude-opus-4-6
+/eval-review --run-id 2026-05-01-opus
+/eval-review --run-id 2026-05-01-opus --case case-003
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-run.md
+++ b/site/docs/plugins/agent-eval-harness/eval-run.md
@@ -7,8 +7,15 @@ title: eval-run
 
 # eval-run
 
-Execute a skill against test cases, collect artifacts, score with inline and
-LLM judges, detect regressions against a baseline, and generate an HTML report.
+Executes a skill against test cases, collects artifacts, scores with judges,
+and generates an HTML report. Orchestrates via scripts: preflight checks for
+stale artifacts, workspace creation with isolated per-case directories, headless
+skill execution (case mode: once per case; batch mode: single invocation),
+artifact collection into per-case dirs, scoring with inline checks and LLM
+judges, optional pairwise comparison against a baseline for regression detection,
+and report generation. Supports concurrent case execution via parallelism setting,
+tool interception for AskUserQuestion and external APIs, and configurable
+reasoning effort levels.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -20,21 +27,28 @@ LLM judges, detect regressions against a baseline, and generate an HTML report.
 
 ## Arguments
 
+```
+/eval-run [--config <path>] [--model <model>] [--run-id <id>] [--baseline <run-id>] [--case <filter>] [--no-judge] [--gold] [--effort <level>] [--subagent-model <model>] [--skill <name>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--config` |  | `eval.yaml` | Path to eval config |
-| `--model` |  | `models.skill from config` | Model for skill execution |
-| `--subagent-model` |  | — | Model for subagents (falls back to skill model) |
-| `--judge-model` |  | `models.judge from config` | Model for LLM judges |
-| `--baseline` |  | — | Compare against a previous run for regression detection |
-| `--cases` |  | — | Filter cases by glob pattern (e.g. case-001*) |
-| `--no-judge` |  | — | Skip judge scoring (execution only) |
-| `--gold` |  | — | Save outputs as gold references |
+| `--config` |  | `eval.yaml` | Path to eval config. |
+| `--model` |  | `models.skill from config` | Model for skill execution. Required if models.skill is unset in eval.yaml. |
+| `--subagent-model` |  | `models.subagent, falls back to skill model` | Model for subagents (e.g., claude-sonnet-4-6 while main is claude-opus-4-7). |
+| `--run-id` |  | `YYYY-MM-DD-<model>` | Identifier for this run. |
+| `--case` |  | — | Substring match to select specific cases. |
+| `--baseline` |  | — | Previous run to compare against for regression detection via pairwise comparison. |
+| `--no-judge` |  | `false` | Skip LLM judges, run inline checks only. |
+| `--gold` |  | `false` | Save outputs as gold references after the run. |
+| `--effort` |  | `runner.effort from config` | Claude Code reasoning effort level. |
+| `--skill` |  | `from config` | Override the skill to test. |
 
 ## Usage
 
 ```
-/eval-run
-/eval-run --model claude-opus-4-6 --baseline 2026-05-01
-/eval-run --cases 'case-001*' --no-judge
+/eval-run --model claude-opus-4-6
+/eval-run --model claude-opus-4-6 --baseline 2026-05-01-opus
+/eval-run --case case-001 --no-judge
+/eval-run --gold
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-setup.md
+++ b/site/docs/plugins/agent-eval-harness/eval-setup.md
@@ -7,8 +7,13 @@ title: eval-setup
 
 # eval-setup
 
-One-time environment setup for the evaluation framework. Installs dependencies,
-configures MLflow tracking, verifies API keys, and runs preflight checks.
+Optional environment configurator for the evaluation harness. Installs
+dependencies into the isolated venv, configures MLflow tracking (local
+server, file store, or remote), verifies API keys (Anthropic or Vertex AI),
+sets up the runs directory, checks skill-specific environment variables
+referenced in eval.yaml, and creates the MLflow experiment. Most users
+can skip this -- dependencies auto-install via the plugin's SessionStart
+hook and agent_eval is available via symlinks.
 
 **Plugin**: [agent-eval-harness](index.md) | **:material-check: User-invocable**
 
@@ -18,8 +23,22 @@ configures MLflow tracking, verifies API keys, and runs preflight checks.
 ![eval-setup diagram](eval-setup.svg)
 </div>
 
+## Arguments
+
+```
+/eval-setup [--tracking-uri <uri>] [--skip-mlflow] [--runs-dir <path>]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--tracking-uri` |  | — | MLflow tracking URI (skips interactive setup). Accepts local or remote URIs. |
+| `--skip-mlflow` |  | `false` | Skip MLflow setup entirely. The harness works without MLflow. |
+| `--runs-dir` |  | `eval/runs` | Directory where eval runs are stored. Configured via AGENT_EVAL_RUNS_DIR env var. |
+
 ## Usage
 
 ```
 /eval-setup
+/eval-setup --tracking-uri http://127.0.0.1:5000
+/eval-setup --skip-mlflow
 ```

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -33,6 +33,24 @@ containerized execution.
     - **Repository**: [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
     - **Tags**: <span class="tag-pill">evaluation</span> <span class="tag-pill">testing</span> <span class="tag-pill">skills</span> <span class="tag-pill">agents</span> <span class="tag-pill">mlflow</span> <span class="tag-pill">optimization</span> <span class="tag-pill">scoring</span>
 
+## Pipeline
+
+<div class="diagram-container" markdown>
+![agent-eval-harness pipeline](pipeline.svg)
+</div>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/eval-setup`](eval-setup.md) | One-time environment setup for evaluation (dependencies, MLflow, API keys) | :material-check: |
+| [`/eval-analyze`](eval-analyze.md) | Deep-read a target skill and generate eval.yaml configuration with dataset schemas and judges | :material-check: |
+| [`/eval-dataset`](eval-dataset.md) | Generate realistic test cases from eval.yaml schema (bootstrap, expand, from-traces) | :material-check: |
+| [`/eval-run`](eval-run.md) | Execute skill against test cases, collect artifacts, run judges, and detect regressions | :material-check: |
+| [`/eval-review`](eval-review.md) | Human-in-the-loop review of scores and outputs with qualitative feedback collection | :material-check: |
+| [`/eval-mlflow`](eval-mlflow.md) | Bidirectional MLflow sync for results, datasets, and feedback | :material-check: |
+| [`/eval-optimize`](eval-optimize.md) | Automated improvement loop that identifies failures, edits SKILL.md, and re-runs with regression checks | :material-check: |
+
 ## Architecture
 
 Seven skills form a linear pipeline with feedback loops: setup (optional) ->
@@ -54,24 +72,6 @@ Scripts live alongside each skill and share the agent_eval Python package
 The data flow is: eval.yaml config -> workspace creation (isolated per run) ->
 skill execution via EvalRunner -> artifact collection -> judge scoring ->
 summary.yaml + HTML report.
-
-## Pipeline
-
-<div class="diagram-container" markdown>
-![agent-eval-harness pipeline](pipeline.svg)
-</div>
-
-## Skills
-
-| Skill | Description | Invocable |
-|-------|-------------|-----------|
-| [`/eval-setup`](eval-setup.md) | One-time environment setup for evaluation (dependencies, MLflow, API keys) | :material-check: |
-| [`/eval-analyze`](eval-analyze.md) | Deep-read a target skill and generate eval.yaml configuration with dataset schemas and judges | :material-check: |
-| [`/eval-dataset`](eval-dataset.md) | Generate realistic test cases from eval.yaml schema (bootstrap, expand, from-traces) | :material-check: |
-| [`/eval-run`](eval-run.md) | Execute skill against test cases, collect artifacts, run judges, and detect regressions | :material-check: |
-| [`/eval-review`](eval-review.md) | Human-in-the-loop review of scores and outputs with qualitative feedback collection | :material-check: |
-| [`/eval-mlflow`](eval-mlflow.md) | Bidirectional MLflow sync for results, datasets, and feedback | :material-check: |
-| [`/eval-optimize`](eval-optimize.md) | Automated improvement loop that identifies failures, edits SKILL.md, and re-runs with regression checks | :material-check: |
 
 ## Installation
 

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -51,6 +51,12 @@ containerized execution.
 | [`/eval-mlflow`](eval-mlflow.md) | Bidirectional MLflow sync for results, datasets, and feedback | :material-check: |
 | [`/eval-optimize`](eval-optimize.md) | Automated improvement loop that identifies failures, edits SKILL.md, and re-runs with regression checks | :material-check: |
 
+## Installation
+
+```bash
+/plugin install agent-eval-harness@opendatahub-skills
+```
+
 ## Architecture
 
 Seven skills form a linear pipeline with feedback loops: setup (optional) ->
@@ -72,9 +78,3 @@ Scripts live alongside each skill and share the agent_eval Python package
 The data flow is: eval.yaml config -> workspace creation (isolated per run) ->
 skill execution via EvalRunner -> artifact collection -> judge scoring ->
 summary.yaml + HTML report.
-
-## Installation
-
-```bash
-/plugin install agent-eval-harness@opendatahub-skills
-```

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -12,10 +12,17 @@ end-to-end pipeline to analyze skills, generate test cases, execute evaluations,
 review results with human feedback, sync with MLflow, and iteratively optimize
 skill quality with regression checks.
 
-The framework is schema-driven via eval.yaml, which defines execution mode,
-dataset schemas, output descriptions, judges, models, and thresholds. Supports
-inline, LLM-based, and external judges for scoring, with MLflow integration
-for experiment tracking and tracing.
+The framework is schema-driven via eval.yaml, which defines execution mode
+(case-by-case or batch), dataset schemas, output descriptions, judges (inline
+checks, LLM prompts, external modules), model selection per role (skill, subagent,
+judge, hook), thresholds for regression detection, and tool interception handlers.
+Supports AskUserQuestion answering via 3-tier resolution (exact overrides, LLM
+with case context, fallback) and annotation-aware judges that adapt scoring based
+on expected outcomes per test case.
+
+The harness also integrates with EvalHub for running evaluations on Red Hat
+OpenShift AI via a custom provider adapter, supporting S3-hosted datasets and
+containerized execution.
 
 
 !!! info "Plugin Details"
@@ -28,12 +35,25 @@ for experiment tracking and tracing.
 
 ## Architecture
 
-Seven skills form a linear pipeline with feedback loops: analyze → dataset →
-run → review/optimize. eval-run is the hub — it executes skills, runs judges,
-and produces summary.yaml consumed by review, optimize, and mlflow. eval-optimize
-creates a closed loop by editing SKILL.md and re-running eval-run with regression
-checks. eval-mlflow provides bidirectional sync with MLflow for datasets, results,
-and feedback.
+Seven skills form a linear pipeline with feedback loops: setup (optional) ->
+analyze -> dataset -> run -> review/optimize, with mlflow available at any
+point after run. eval-run is the central hub -- it executes skills headlessly,
+runs judges (inline checks + LLM scoring + pairwise comparison), and produces
+summary.yaml consumed by review, optimize, and mlflow.
+
+eval-optimize creates a closed loop by reading judge rationale and execution
+transcripts, forming hypotheses about SKILL.md deficiencies, making surgical
+edits, and re-running eval-run with regression baseline checks. eval-review
+complements this with human-in-the-loop feedback that catches qualitative
+issues judges miss. eval-mlflow provides bidirectional sync -- pushing datasets,
+results, and feedback to MLflow experiment tracking and pulling annotations
+back for optimization.
+
+Scripts live alongside each skill and share the agent_eval Python package
+(auto-installed via SessionStart hook into an isolated venv at .eval-venv/).
+The data flow is: eval.yaml config -> workspace creation (isolated per run) ->
+skill execution via EvalRunner -> artifact collection -> judge scoring ->
+summary.yaml + HTML report.
 
 ## Pipeline
 

--- a/site/docs/plugins/assess-rfe/_enriched.yaml
+++ b/site/docs/plugins/assess-rfe/_enriched.yaml
@@ -1,26 +1,79 @@
 description: |
-  Assess RFEs against quality criteria using a structured rubric. Supports
-  single-input mode (Jira key, file, URL, raw text) and bulk mode with
-  30 concurrent scorer agents and CSV results.
+  Structured quality assessment for RFEs (Requests for Enhancement) against
+  a five-criteria rubric: WHAT (clear customer need), WHY (business justification
+  with named customers or revenue data), Open to HOW (leaves architecture to
+  engineering), Not a Task (business need vs. activity), and Right-Sized (maps
+  to approximately one strategy feature). Each criterion is scored 0-2 for a
+  total out of 10, with pass requiring 7+ and no zeros.
+
+  Supports single-input mode accepting Jira issue keys (via MCP or REST API
+  fallback), file paths, URLs, or raw text. Bulk mode fetches all issues from
+  a Jira project, then dispatches up to 30 concurrent scorer sub-agents that
+  each apply the identical rubric from a single source-of-truth prompt file.
+  Results are written as individual markdown files into a timestamped run
+  directory, then aggregated into a CSV with summary statistics including
+  pass/fail rates, score distribution, criteria averages, what-if analysis,
+  and near-miss identification.
+
+  The scorer agents run with restricted tool access (Read and Write only) to
+  prevent prompt injection from untrusted Jira content. The rubric includes
+  detailed calibration examples for each criterion and a comprehensive list of
+  established RHOAI platform technologies that are considered vocabulary rather
+  than architecture prescription.
+architecture_notes: |
+  The plugin uses an orchestrator/agent pattern. The main assess-rfe skill acts
+  as a coordinator that handles input detection, Jira fetching, run directory
+  management, and agent lifecycle. Individual assessments are delegated to
+  rfe-scorer sub-agents (defined in agents/rfe-scorer.md) running with minimal
+  permissions (Read + Write only, acceptEdits permission mode) as a security
+  boundary against prompt injection from untrusted Jira content.
+
+  Bulk mode operates in phases: preflight checks (environment variables, run
+  state), Jira dump (all issues cached locally), run setup (timestamped
+  directory with queue file), concurrent agent dispatch (batches of 30 via
+  next_batch.py), and result aggregation (parse_results.py + summarize_run.py).
+  Resume support is built in via queue files and symlinked run directories.
+
+  Python scripts handle all data operations (Jira API calls, ADF-to-markdown
+  conversion, queue management, progress tracking, result parsing, CSV
+  generation, and summary statistics). The coordinator never uses shell pipes
+  or compound commands, relying instead on structured script output with
+  key=value parsing.
 skills:
   assess-rfe:
     description: |
-      Assess RFEs against quality criteria using a structured rubric. Supports
-      single-input mode (Jira key, file path, URL, raw text) and bulk mode
-      (wildcard pattern) with 30 concurrent parallel scorer agents.
+      Assess RFEs against quality criteria using a structured five-criteria
+      rubric (WHAT, WHY, HOW, Not a Task, Right-Sized) scored 0-2 each for
+      a total out of 10. Supports single-input mode (Jira issue key via MCP
+      or REST API, file path, URL, or raw text) and bulk mode (wildcard
+      pattern like RHAIRFE-*) with up to 30 concurrent parallel scorer
+      sub-agents. Bulk mode includes phased execution with preflight checks,
+      Jira project dump, timestamped run directories with resume support,
+      queue-based batch dispatching, and CSV result aggregation with summary
+      statistics (pass/fail rates, score distribution, criteria averages,
+      what-if analysis, and near-miss identification).
     arguments:
       - name: "input"
         type: "Jira key | file path | URL | raw text | wildcard"
         required: true
-        description: "RFE to assess — accepts multiple input formats"
+        description: >
+          The RFE to assess. Accepts multiple formats: a Jira issue key
+          (e.g., RHAIRFE-1234), a file path to a document, a URL, raw
+          pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk
+          assessment of an entire Jira project.
     usage_examples:
       - "/assess-rfe RHAIRFE-1234"
+      - "/assess-rfe PROJ-99"
       - "/assess-rfe /path/to/document.md"
       - "/assess-rfe https://some-url"
+      - "/assess-rfe <paste raw text>"
       - "/assess-rfe RHAIRFE-*"
   export-rubric:
     description: |
-      Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md
-      in the current working directory.
+      Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md in the
+      current working directory. Useful for reviewing the rubric criteria,
+      calibration examples, and scoring guidelines outside of an assessment
+      context, or for sharing the rubric with team members who want to
+      understand how RFEs are evaluated.
     usage_examples:
       - "/export-rubric"

--- a/site/docs/plugins/assess-rfe/assess-rfe.md
+++ b/site/docs/plugins/assess-rfe/assess-rfe.md
@@ -7,9 +7,16 @@ title: assess-rfe
 
 # assess-rfe
 
-Assess RFEs against quality criteria using a structured rubric. Supports
-single-input mode (Jira key, file path, URL, raw text) and bulk mode
-(wildcard pattern) with 30 concurrent parallel scorer agents.
+Assess RFEs against quality criteria using a structured five-criteria
+rubric (WHAT, WHY, HOW, Not a Task, Right-Sized) scored 0-2 each for
+a total out of 10. Supports single-input mode (Jira issue key via MCP
+or REST API, file path, URL, or raw text) and bulk mode (wildcard
+pattern like RHAIRFE-*) with up to 30 concurrent parallel scorer
+sub-agents. Bulk mode includes phased execution with preflight checks,
+Jira project dump, timestamped run directories with resume support,
+queue-based batch dispatching, and CSV result aggregation with summary
+statistics (pass/fail rates, score distribution, criteria averages,
+what-if analysis, and near-miss identification).
 
 **Plugin**: [assess-rfe](index.md) | **:material-check: User-invocable**
 
@@ -21,15 +28,22 @@ single-input mode (Jira key, file path, URL, raw text) and bulk mode
 
 ## Arguments
 
+```
+/assess-rfe <input>
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `input` | :material-check: | — | RFE to assess — accepts multiple input formats |
+| `input` | :material-check: | — | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project.
+ |
 
 ## Usage
 
 ```
 /assess-rfe RHAIRFE-1234
+/assess-rfe PROJ-99
 /assess-rfe /path/to/document.md
 /assess-rfe https://some-url
+/assess-rfe <paste raw text>
 /assess-rfe RHAIRFE-*
 ```

--- a/site/docs/plugins/assess-rfe/export-rubric.md
+++ b/site/docs/plugins/assess-rfe/export-rubric.md
@@ -7,8 +7,11 @@ title: export-rubric
 
 # export-rubric
 
-Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md
-in the current working directory.
+Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md in the
+current working directory. Useful for reviewing the rubric criteria,
+calibration examples, and scoring guidelines outside of an assessment
+context, or for sharing the rubric with team members who want to
+understand how RFEs are evaluated.
 
 **Plugin**: [assess-rfe](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/assess-rfe/index.md
+++ b/site/docs/plugins/assess-rfe/index.md
@@ -38,6 +38,19 @@ than architecture prescription.
     - **Repository**: [n1hility/assess-rfe](https://github.com/n1hility/assess-rfe)
     - **Tags**: <span class="tag-pill">rfe</span> <span class="tag-pill">rubric</span> <span class="tag-pill">quality</span> <span class="tag-pill">assessment</span>
 
+## Pipeline
+
+<div class="diagram-container" markdown>
+![assess-rfe pipeline](pipeline.svg)
+</div>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/assess-rfe`](assess-rfe.md) | Assess RFEs against quality criteria using a structured rubric | :material-check: |
+| [`/export-rubric`](export-rubric.md) | Export the assessment rubric | :material-check: |
+
 ## Architecture
 
 The plugin uses an orchestrator/agent pattern. The main assess-rfe skill acts
@@ -58,19 +71,6 @@ conversion, queue management, progress tracking, result parsing, CSV
 generation, and summary statistics). The coordinator never uses shell pipes
 or compound commands, relying instead on structured script output with
 key=value parsing.
-
-## Pipeline
-
-<div class="diagram-container" markdown>
-![assess-rfe pipeline](pipeline.svg)
-</div>
-
-## Skills
-
-| Skill | Description | Invocable |
-|-------|-------------|-----------|
-| [`/assess-rfe`](assess-rfe.md) | Assess RFEs against quality criteria using a structured rubric | :material-check: |
-| [`/export-rubric`](export-rubric.md) | Export the assessment rubric | :material-check: |
 
 ## Installation
 

--- a/site/docs/plugins/assess-rfe/index.md
+++ b/site/docs/plugins/assess-rfe/index.md
@@ -7,9 +7,27 @@ title: assess-rfe
 
 # assess-rfe
 
-Assess RFEs against quality criteria using a structured rubric. Supports
-single-input mode (Jira key, file, URL, raw text) and bulk mode with
-30 concurrent scorer agents and CSV results.
+Structured quality assessment for RFEs (Requests for Enhancement) against
+a five-criteria rubric: WHAT (clear customer need), WHY (business justification
+with named customers or revenue data), Open to HOW (leaves architecture to
+engineering), Not a Task (business need vs. activity), and Right-Sized (maps
+to approximately one strategy feature). Each criterion is scored 0-2 for a
+total out of 10, with pass requiring 7+ and no zeros.
+
+Supports single-input mode accepting Jira issue keys (via MCP or REST API
+fallback), file paths, URLs, or raw text. Bulk mode fetches all issues from
+a Jira project, then dispatches up to 30 concurrent scorer sub-agents that
+each apply the identical rubric from a single source-of-truth prompt file.
+Results are written as individual markdown files into a timestamped run
+directory, then aggregated into a CSV with summary statistics including
+pass/fail rates, score distribution, criteria averages, what-if analysis,
+and near-miss identification.
+
+The scorer agents run with restricted tool access (Read and Write only) to
+prevent prompt injection from untrusted Jira content. The rubric includes
+detailed calibration examples for each criterion and a comprehensive list of
+established RHOAI platform technologies that are considered vocabulary rather
+than architecture prescription.
 
 
 !!! info "Plugin Details"
@@ -19,6 +37,27 @@ single-input mode (Jira key, file, URL, raw text) and bulk mode with
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
     - **Repository**: [n1hility/assess-rfe](https://github.com/n1hility/assess-rfe)
     - **Tags**: <span class="tag-pill">rfe</span> <span class="tag-pill">rubric</span> <span class="tag-pill">quality</span> <span class="tag-pill">assessment</span>
+
+## Architecture
+
+The plugin uses an orchestrator/agent pattern. The main assess-rfe skill acts
+as a coordinator that handles input detection, Jira fetching, run directory
+management, and agent lifecycle. Individual assessments are delegated to
+rfe-scorer sub-agents (defined in agents/rfe-scorer.md) running with minimal
+permissions (Read + Write only, acceptEdits permission mode) as a security
+boundary against prompt injection from untrusted Jira content.
+
+Bulk mode operates in phases: preflight checks (environment variables, run
+state), Jira dump (all issues cached locally), run setup (timestamped
+directory with queue file), concurrent agent dispatch (batches of 30 via
+next_batch.py), and result aggregation (parse_results.py + summarize_run.py).
+Resume support is built in via queue files and symlinked run directories.
+
+Python scripts handle all data operations (Jira API calls, ADF-to-markdown
+conversion, queue management, progress tracking, result parsing, CSV
+generation, and summary statistics). The coordinator never uses shell pipes
+or compound commands, relying instead on structured script output with
+key=value parsing.
 
 ## Pipeline
 

--- a/site/docs/plugins/assess-rfe/index.md
+++ b/site/docs/plugins/assess-rfe/index.md
@@ -51,6 +51,12 @@ than architecture prescription.
 | [`/assess-rfe`](assess-rfe.md) | Assess RFEs against quality criteria using a structured rubric | :material-check: |
 | [`/export-rubric`](export-rubric.md) | Export the assessment rubric | :material-check: |
 
+## Installation
+
+```bash
+/plugin install assess-rfe@opendatahub-skills
+```
+
 ## Architecture
 
 The plugin uses an orchestrator/agent pattern. The main assess-rfe skill acts
@@ -71,9 +77,3 @@ conversion, queue management, progress tracking, result parsing, CSV
 generation, and summary statistics). The coordinator never uses shell pipes
 or compound commands, relying instead on structured script output with
 key=value parsing.
-
-## Installation
-
-```bash
-/plugin install assess-rfe@opendatahub-skills
-```

--- a/site/docs/plugins/meeting-quality-skills/_enriched.yaml
+++ b/site/docs/plugins/meeting-quality-skills/_enriched.yaml
@@ -1,40 +1,76 @@
 description: |
-  Skills for evaluating meeting quality and optimizing async collaboration.
-  Analyzes meeting agendas for risk factors and checks whether meetings
-  could be replaced with async updates.
+  Pre-meeting skills for improving meeting quality by shifting recurring status
+  meetings away from general reporting and toward exception-based discussion.
+  The plugin provides two complementary skills: one checks a shared update
+  document to identify attendees who have not provided async updates, and the
+  other analyzes collected updates to generate a risk-focused agenda that
+  prioritizes blockers and at-risk items.
+
+  Both skills work with Google Docs or pasted text, and handle edge cases such
+  as Jira-exported content (issue keys, dashboards, JQL output) by attempting
+  to extract owners from fields like Assignee or Owner. When ownership cannot
+  be determined, items are flagged as uncertain rather than silently dropped.
+architecture_notes: |
+  The two skills operate independently but form a natural pre-meeting workflow:
+  first run meeting-async-update-check to ensure updates are in, then run
+  meeting-risk-agenda to build a focused agenda from those updates. Both skills
+  are purely prompt-driven with no external tool dependencies — they rely on
+  the LLM's ability to parse unstructured document content and apply
+  classification heuristics (name matching, risk-signal detection).
 skills:
+  meeting-async-update-check:
+    description: |
+      Checks a shared pre-meeting update document and identifies attendees who
+      have not provided an async update before a status meeting. For each
+      attendee, the skill determines whether they appear to have contributed by
+      looking for section headers with their name, email alias references, or
+      attributed bullet lists. When the document contains Jira-exported content,
+      it attempts to identify owners from Assignee/Owner fields and marks
+      ambiguous items as uncertain.
+
+      Produces three sections: attendees with updates, attendees missing updates,
+      and uncertain matches needing organizer review. Also drafts a professional
+      reminder message the organizer can send to those who haven't updated yet.
+    arguments:
+      - name: "meeting_title"
+        required: true
+        description: "Title of the meeting being checked"
+      - name: "meeting_datetime"
+        required: true
+        description: "Date and time of the upcoming meeting"
+      - name: "attendee_list"
+        required: true
+        description: "List of meeting attendees to check for updates"
+      - name: "update_document"
+        required: true
+        description: "Shared meeting update document content or link (Google Doc or pasted text)"
+      - name: "update_format"
+        required: false
+        description: "Optional expected format for updates, if one exists"
+    usage_examples:
+      - "/meeting-async-update-check"
+      - "Check who hasn't updated the weekly sync doc yet"
   meeting-risk-agenda:
     description: |
-      Analyze a meeting agenda or update document for risk factors that
-      indicate low-quality meetings. Provides recommendations for improvement.
+      Analyzes pre-meeting updates and generates a risk-focused agenda by
+      classifying each update into Blocked, At Risk, or No Issues categories.
+      Detects risk signals such as "blocked", "stuck", "waiting", "dependency",
+      lack of progress, and unclear ownership. Extracts owner names when present
+      and organizes the agenda with blocked items first, at-risk items second,
+      and no-issues items deprioritized or summarized.
+
+      If no risks are found, the skill suggests the meeting may not be necessary
+      or could be shortened. If ownership is unclear, it explicitly calls that out.
     arguments:
       - name: "meeting_title"
         required: false
-        description: "Title of the meeting"
+        description: "Title of the meeting (optional context)"
       - name: "update_document"
         required: true
         description: "Meeting update document content (Google Doc or pasted text)"
       - name: "attendee_list"
         required: false
-        description: "List of meeting attendees"
+        description: "List of meeting attendees (optional, helps with owner matching)"
     usage_examples:
       - "/meeting-risk-agenda"
-  meeting-async-update-check:
-    description: |
-      Check whether a meeting could be replaced with an async update.
-      Validates that attendees have provided their updates in the shared document.
-    arguments:
-      - name: "meeting_title"
-        required: true
-        description: "Title of the meeting"
-      - name: "meeting_datetime"
-        required: true
-        description: "Meeting date and time"
-      - name: "attendee_list"
-        required: true
-        description: "List of meeting attendees"
-      - name: "update_document"
-        required: true
-        description: "Shared meeting update document content or link"
-    usage_examples:
-      - "/meeting-async-update-check"
+      - "Build a focused agenda from our team's weekly updates"

--- a/site/docs/plugins/meeting-quality-skills/index.md
+++ b/site/docs/plugins/meeting-quality-skills/index.md
@@ -29,15 +29,6 @@ be determined, items are flagged as uncertain rather than silently dropped.
     - **Repository**: [ahinek/meeting-quality-skills](https://github.com/ahinek/meeting-quality-skills)
     - **Tags**: <span class="tag-pill">meeting</span> <span class="tag-pill">google-workspace</span> <span class="tag-pill">agenda</span> <span class="tag-pill">async-updates</span> <span class="tag-pill">productivity</span>
 
-## Architecture
-
-The two skills operate independently but form a natural pre-meeting workflow:
-first run meeting-async-update-check to ensure updates are in, then run
-meeting-risk-agenda to build a focused agenda from those updates. Both skills
-are purely prompt-driven with no external tool dependencies — they rely on
-the LLM's ability to parse unstructured document content and apply
-classification heuristics (name matching, risk-signal detection).
-
 ## Pipeline
 
 <div class="diagram-container" markdown>
@@ -50,6 +41,15 @@ classification heuristics (name matching, risk-signal detection).
 |-------|-------------|-----------|
 | [`/meeting-async-update-check`](meeting-async-update-check.md) | Check a shared update doc and identify attendees missing async updates before a status meeting | :material-check: |
 | [`/meeting-risk-agenda`](meeting-risk-agenda.md) | Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items | :material-check: |
+
+## Architecture
+
+The two skills operate independently but form a natural pre-meeting workflow:
+first run meeting-async-update-check to ensure updates are in, then run
+meeting-risk-agenda to build a focused agenda from those updates. Both skills
+are purely prompt-driven with no external tool dependencies — they rely on
+the LLM's ability to parse unstructured document content and apply
+classification heuristics (name matching, risk-signal detection).
 
 ## Installation
 

--- a/site/docs/plugins/meeting-quality-skills/index.md
+++ b/site/docs/plugins/meeting-quality-skills/index.md
@@ -42,6 +42,12 @@ be determined, items are flagged as uncertain rather than silently dropped.
 | [`/meeting-async-update-check`](meeting-async-update-check.md) | Check a shared update doc and identify attendees missing async updates before a status meeting | :material-check: |
 | [`/meeting-risk-agenda`](meeting-risk-agenda.md) | Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items | :material-check: |
 
+## Installation
+
+```bash
+/plugin install meeting-quality-skills@opendatahub-skills
+```
+
 ## Architecture
 
 The two skills operate independently but form a natural pre-meeting workflow:
@@ -50,9 +56,3 @@ meeting-risk-agenda to build a focused agenda from those updates. Both skills
 are purely prompt-driven with no external tool dependencies — they rely on
 the LLM's ability to parse unstructured document content and apply
 classification heuristics (name matching, risk-signal detection).
-
-## Installation
-
-```bash
-/plugin install meeting-quality-skills@opendatahub-skills
-```

--- a/site/docs/plugins/meeting-quality-skills/index.md
+++ b/site/docs/plugins/meeting-quality-skills/index.md
@@ -7,9 +7,17 @@ title: meeting-quality-skills
 
 # meeting-quality-skills
 
-Skills for evaluating meeting quality and optimizing async collaboration.
-Analyzes meeting agendas for risk factors and checks whether meetings
-could be replaced with async updates.
+Pre-meeting skills for improving meeting quality by shifting recurring status
+meetings away from general reporting and toward exception-based discussion.
+The plugin provides two complementary skills: one checks a shared update
+document to identify attendees who have not provided async updates, and the
+other analyzes collected updates to generate a risk-focused agenda that
+prioritizes blockers and at-risk items.
+
+Both skills work with Google Docs or pasted text, and handle edge cases such
+as Jira-exported content (issue keys, dashboards, JQL output) by attempting
+to extract owners from fields like Assignee or Owner. When ownership cannot
+be determined, items are flagged as uncertain rather than silently dropped.
 
 
 !!! info "Plugin Details"
@@ -20,6 +28,15 @@ could be replaced with async updates.
     - **Category**: [Product Planning](../../categories/planning.md)
     - **Repository**: [ahinek/meeting-quality-skills](https://github.com/ahinek/meeting-quality-skills)
     - **Tags**: <span class="tag-pill">meeting</span> <span class="tag-pill">google-workspace</span> <span class="tag-pill">agenda</span> <span class="tag-pill">async-updates</span> <span class="tag-pill">productivity</span>
+
+## Architecture
+
+The two skills operate independently but form a natural pre-meeting workflow:
+first run meeting-async-update-check to ensure updates are in, then run
+meeting-risk-agenda to build a focused agenda from those updates. Both skills
+are purely prompt-driven with no external tool dependencies — they rely on
+the LLM's ability to parse unstructured document content and apply
+classification heuristics (name matching, risk-signal detection).
 
 ## Pipeline
 

--- a/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
@@ -7,8 +7,17 @@ title: meeting-async-update-check
 
 # meeting-async-update-check
 
-Check whether a meeting could be replaced with an async update.
-Validates that attendees have provided their updates in the shared document.
+Checks a shared pre-meeting update document and identifies attendees who
+have not provided an async update before a status meeting. For each
+attendee, the skill determines whether they appear to have contributed by
+looking for section headers with their name, email alias references, or
+attributed bullet lists. When the document contains Jira-exported content,
+it attempts to identify owners from Assignee/Owner fields and marks
+ambiguous items as uncertain.
+
+Produces three sections: attendees with updates, attendees missing updates,
+and uncertain matches needing organizer review. Also drafts a professional
+reminder message the organizer can send to those who haven't updated yet.
 
 **Plugin**: [meeting-quality-skills](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +29,21 @@ Validates that attendees have provided their updates in the shared document.
 
 ## Arguments
 
+```
+/meeting-async-update-check <meeting_title> <meeting_datetime> <attendee_list> <update_document> [update_format]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `meeting_title` | :material-check: | — | Title of the meeting |
-| `meeting_datetime` | :material-check: | — | Meeting date and time |
-| `attendee_list` | :material-check: | — | List of meeting attendees |
-| `update_document` | :material-check: | — | Shared meeting update document content or link |
+| `meeting_title` | :material-check: | — | Title of the meeting being checked |
+| `meeting_datetime` | :material-check: | — | Date and time of the upcoming meeting |
+| `attendee_list` | :material-check: | — | List of meeting attendees to check for updates |
+| `update_document` | :material-check: | — | Shared meeting update document content or link (Google Doc or pasted text) |
+| `update_format` |  | — | Optional expected format for updates, if one exists |
 
 ## Usage
 
 ```
 /meeting-async-update-check
+Check who hasn't updated the weekly sync doc yet
 ```

--- a/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
@@ -7,8 +7,15 @@ title: meeting-risk-agenda
 
 # meeting-risk-agenda
 
-Analyze a meeting agenda or update document for risk factors that
-indicate low-quality meetings. Provides recommendations for improvement.
+Analyzes pre-meeting updates and generates a risk-focused agenda by
+classifying each update into Blocked, At Risk, or No Issues categories.
+Detects risk signals such as "blocked", "stuck", "waiting", "dependency",
+lack of progress, and unclear ownership. Extracts owner names when present
+and organizes the agenda with blocked items first, at-risk items second,
+and no-issues items deprioritized or summarized.
+
+If no risks are found, the skill suggests the meeting may not be necessary
+or could be shortened. If ownership is unclear, it explicitly calls that out.
 
 **Plugin**: [meeting-quality-skills](index.md) | **:material-check: User-invocable**
 
@@ -20,14 +27,19 @@ indicate low-quality meetings. Provides recommendations for improvement.
 
 ## Arguments
 
+```
+/meeting-risk-agenda [meeting_title] <update_document> [attendee_list]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `meeting_title` |  | — | Title of the meeting |
+| `meeting_title` |  | — | Title of the meeting (optional context) |
 | `update_document` | :material-check: | — | Meeting update document content (Google Doc or pasted text) |
-| `attendee_list` |  | — | List of meeting attendees |
+| `attendee_list` |  | — | List of meeting attendees (optional, helps with owner matching) |
 
 ## Usage
 
 ```
 /meeting-risk-agenda
+Build a focused agenda from our team's weekly updates
 ```

--- a/site/docs/plugins/odh-ai-helpers/_enriched.yaml
+++ b/site/docs/plugins/odh-ai-helpers/_enriched.yaml
@@ -1,150 +1,438 @@
 description: |
-  Developer productivity tools for Python packaging, CI/CD debugging, and
-  workflow automation. Includes skills for analyzing package build complexity,
-  resolving dependencies, finding licenses, debugging GitLab pipelines,
-  reviewing ADRs, and more.
+  A comprehensive suite of developer productivity tools for Python packaging,
+  CI/CD debugging, upstream maintenance, and workflow automation. The plugin
+  spans three functional domains: (1) a Python packaging toolchain that can
+  analyze build complexity, resolve full dependency trees, locate source repos,
+  find and check licenses against Red Hat redistribution policy, discover build
+  environment variables, and surface known packaging bugs; (2) a vLLM backport
+  triage pipeline that fetches upstream bugfix PRs, classifies them, checks
+  for existing cherry-picks, scores and ranks candidates, auto-cherry-picks
+  clean fixes, pushes reports, compares requirements across versions, and
+  summarizes Slack channel activity; and (3) general-purpose skills for ADR
+  review panels, GitLab CI debugging, Jira chat-log uploads, and Git
+  shallow-cloning.
+
+  The Python packaging skills are designed to work both independently and as a
+  coordinated pipeline through the python-packaging-investigator agent, which
+  orchestrates all packaging skills in parallel and produces a standardized
+  build analysis report. The vLLM backport skills form a linear pipeline from
+  PR fetching through classification, deduplication, scoring, and cherry-picking,
+  with each stage producing JSON artifacts consumed by the next.
+architecture_notes: |
+  The plugin follows a modular architecture with three distinct skill families:
+
+  **Python Packaging Toolchain** -- Seven skills that share a common pattern of
+  wrapping helper scripts (Python/Bash) and chaining through skill invocations.
+  The source-finder locates repositories, the shallow-clone skill provides local
+  access, and downstream skills (complexity, license-finder, license-checker,
+  env-finder, bug-finder) analyze different facets. The investigator agent
+  orchestrates all of them in parallel sub-agents.
+
+  **vLLM Backport Pipeline** -- Eight skills forming a linear data pipeline.
+  Each produces a JSON artifact (raw-prs.json -> filtered.json -> candidates.json
+  -> analyzed.json -> ranked.json -> cherry-pick-result.json) consumed by the
+  next stage. The pipeline combines deterministic script-based steps with
+  agent-driven semantic analysis for unclear classifications.
+
+  **Utility Skills** -- Standalone skills (adr-review, gitlab-pipeline-debugger,
+  jira-upload-chat-log, git-shallow-clone) that operate independently with no
+  inter-skill dependencies. The adr-review skill uses six parallel reviewer
+  sub-agents with human-in-the-loop correction before synthesis.
 skills:
   adr-review:
     description: |
-      Review an Architectural Decision Record using a team of 6 specialist
-      reviewer subagents (architecture, security, performance, maintainability,
-      testing, documentation). Produces consolidated PDF and PPTX reports.
+      Review an Architectural Decision Record (ADR) using a panel of six
+      specialist reviewer sub-agents running in parallel. The reviewers cover
+      Context & Problem Framing, Technical Soundness, Operational & Reliability,
+      Security & Compliance, Cost & Performance, and Consequences & Reversibility.
+      After the panel runs, a human-in-the-loop step lets the user agree, disagree,
+      or refine each finding before synthesis. Produces consolidated outputs as
+      both a detailed PDF report and a scannable PPTX slide deck. Handles
+      Markdown files, .docx documents, and directories of multiple ADRs.
+    arguments:
+      - name: "ADR_PATH"
+        required: true
+        description: "Path to an ADR file (.md or .docx) or a directory containing multiple ADRs"
     usage_examples:
       - "/adr-review /path/to/adr.md"
+      - "/adr-review /path/to/adr-directory/"
   gitlab-pipeline-debugger:
     description: |
       Debug and monitor GitLab CI/CD pipelines for merge requests. Check
-      pipeline status, view job logs, and troubleshoot CI failures using glab CLI.
+      pipeline status, view job logs, and troubleshoot CI failures using the
+      glab CLI. Supports auto-detection of the GitLab project from the local
+      git remote, or targeting a specific project via URL or -R flag. Can
+      parse full GitLab pipeline and job URLs to extract project paths and IDs.
     arguments:
-      - name: "repository_url"
+      - name: "PIPELINE_URL"
         required: false
-        default: "auto-detected from git remote"
-        description: "GitLab repository URL or branch name"
-      - name: "--p"
-        type: "<pipeline-id>"
+        description: "Full GitLab pipeline or job URL to debug"
+      - name: "-b"
+        type: "branch-name"
+        required: false
+        description: "Branch name to check pipeline for"
+      - name: "-p"
+        type: "pipeline-id"
         required: false
         description: "Specific pipeline ID to inspect"
+      - name: "-R"
+        type: "owner/group/project"
+        required: false
+        default: "auto-detected from git remote"
+        description: "GitLab project path to target"
     usage_examples:
       - "/gitlab-pipeline-debugger"
-      - "/gitlab-pipeline-debugger https://gitlab.com/org/repo"
+      - "/gitlab-pipeline-debugger https://gitlab.com/org/project/-/pipelines/123456"
+      - "/gitlab-pipeline-debugger -b feature-branch"
   git-shallow-clone:
     description: |
       Perform a shallow clone of a Git repository to a temporary location
-      for local analysis instead of using web APIs.
+      for local analysis instead of using web APIs. Uses a helper script that
+      prints the clone path to stdout for downstream consumption.
     arguments:
-      - name: "repository_url"
+      - name: "REPOSITORY_URL"
         required: true
         description: "URL of the Git repository to clone"
-      - name: "tag_or_branch"
+      - name: "TAG_OR_BRANCH"
         required: false
         default: "HEAD"
-        description: "Git tag or branch to shallow clone"
+        description: "Git tag or branch to shallow-clone"
     usage_examples:
       - "/git-shallow-clone https://github.com/psf/requests.git"
       - "/git-shallow-clone https://github.com/psf/requests.git v2.28.0"
   jira-upload-chat-log:
     description: |
-      Export the current chat conversation as a markdown file and attach
-      it to a Jira ticket.
+      Export the current chat conversation as a formatted markdown document
+      (with both a summary and full transcript) and upload it as a file
+      attachment to a Jira ticket. Automatically detects ticket keys from
+      conversation context, or prompts the user if none is found. Delegates
+      the actual upload to the jira-workitem-attach skill.
     arguments:
-      - name: "ticket_key"
+      - name: "TICKET_KEY"
         required: false
-        default: "auto-detected from conversation"
+        default: "auto-detected from conversation context"
         description: "Jira ticket key (e.g., AIPCC-1234)"
     usage_examples:
       - "/jira-upload-chat-log AIPCC-7354"
       - "/jira-upload-chat-log"
   python-full-deps:
     description: |
-      Resolve the full install-time dependency tree for a Python package
-      with environment markers, using uv or pip as resolver.
+      Resolve the full install-time transitive dependency tree for a Python
+      package, respecting environment markers for a specific Python version.
+      Uses uv pip compile (preferred) with fallback to pip install --dry-run
+      --report. Outputs a sorted, deduplicated list of name==version pairs.
+      Complements python-packaging-complexity which only shows direct
+      dependencies from metadata.
     arguments:
-      - name: "package_name"
+      - name: "PACKAGE_NAME"
         required: true
-        description: "PyPI project name (e.g., vllm)"
-      - name: "version"
+        description: "PyPI project name (e.g., vllm, requests)"
+      - name: "VERSION"
         required: false
         default: "latest"
-        description: "Specific package version"
-      - name: "python_version"
+        description: "Specific package version (e.g., 0.4.0)"
+      - name: "PYTHON_VERSION"
         required: false
         default: "3.12"
-        description: "Python version for resolution"
+        description: "Python version for environment marker resolution (e.g., 3.11)"
     usage_examples:
       - "/python-full-deps requests"
-      - "/python-full-deps requests 2.32.3 3.11"
-  python-packaging-source-finder:
+      - "/python-full-deps vllm 0.4.0 3.11"
+  python-packaging-bug-finder:
     description: |
-      Locate source code repositories for Python packages by analyzing
-      PyPI metadata and code hosting platforms.
+      Find known packaging bugs, fixes, and workarounds for Python projects
+      by searching GitHub issues. First uses source-finder to locate the repo,
+      then searches issues for build, installation, dependency, compiler, and
+      platform-specific problems. Analyzes resolution status, version impact,
+      and available workarounds for each issue found.
     arguments:
-      - name: "package_name"
+      - name: "PACKAGE_NAME"
         required: true
-        description: "Python package name to find repository for"
+        description: "Python package name to search issues for"
     usage_examples:
-      - "/python-packaging-source-finder requests"
-  python-packaging-license-finder:
-    description: |
-      Deterministically find license information for Python packages
-      by checking PyPI metadata and Git repository LICENSE files.
-    arguments:
-      - name: "package_name"
-        required: true
-        description: "Python package name"
-      - name: "version"
-        required: false
-        default: "latest"
-        description: "Specific package version"
-    usage_examples:
-      - "/python-packaging-license-finder requests"
-      - "/python-packaging-license-finder django 4.2.0"
-  python-packaging-license-checker:
-    description: |
-      Check whether a Python package license is compatible with
-      redistribution in Red Hat products using Fedora License Data policy.
-    arguments:
-      - name: "package_name"
-        required: true
-        description: "Python package name to check"
-    usage_examples:
-      - "/python-packaging-license-checker requests"
+      - "/python-packaging-bug-finder torch"
+      - "/python-packaging-bug-finder numpy"
   python-packaging-complexity:
     description: |
-      Analyze Python package build complexity by inspecting PyPI metadata,
-      compilation requirements, and distribution types.
+      Analyze Python package build complexity by inspecting PyPI metadata.
+      Evaluates compilation requirements (C/C++/Rust/Fortran), dependency
+      complexity, distribution types (sdist, platform-specific wheels, universal
+      wheels), and produces a numerical complexity score (0-10+). Provides
+      actionable recommendations for wheel building strategies.
     arguments:
-      - name: "package_name"
+      - name: "PACKAGE_NAME"
         required: true
         description: "Python package name to analyze"
-      - name: "version"
+      - name: "VERSION"
         required: false
         default: "latest"
         description: "Specific package version"
       - name: "--json"
         required: false
-        description: "Output as structured JSON"
+        description: "Output as structured JSON for programmatic processing"
     usage_examples:
       - "/python-packaging-complexity torch"
-      - "/python-packaging-complexity numpy 1.24.3 --json"
+      - "/python-packaging-complexity numpy 1.24.3"
+      - "/python-packaging-complexity tensorflow --json"
   python-packaging-env-finder:
     description: |
-      Investigate environment variables that can be set when building
-      Python wheels by analyzing setup.py, CMake, and build config files.
+      Investigate environment variables that can be set when building Python
+      wheels for a given project. Analyzes setup.py, CMake files, and other
+      build configuration files to discover compiler variables (CC, CXX, CFLAGS),
+      path configuration, feature control flags (ENABLE_*, WITH_*, USE_*), and
+      Python-specific build variables.
     arguments:
-      - name: "project_path"
+      - name: "PROJECT_PATH"
         required: false
         default: "current directory"
-        description: "Path to Python project"
+        description: "Path to the Python project to analyze"
     usage_examples:
       - "/python-packaging-env-finder"
       - "/python-packaging-env-finder /path/to/project"
-  python-packaging-bug-finder:
+  python-packaging-license-checker:
     description: |
-      Find known packaging bugs, fixes, and workarounds for Python projects
-      by searching GitHub issues.
+      Check whether a Python package license is compatible with redistribution
+      in Red Hat products, using the Fedora License Data as the authoritative
+      policy source. Clones the source repo to read the actual LICENSE file
+      (not just PyPI metadata), normalizes to SPDX identifiers, handles
+      compound AND/OR expressions, checks vendor agreements (NVIDIA, Intel
+      Gaudi, IBM Spyre), and performs build and export compliance checks.
+      Produces a structured six-field verdict: License, Source verified,
+      Verdict, Build compliance, Export compliance, and Notes.
     arguments:
-      - name: "package_name"
+      - name: "PACKAGE_NAME"
         required: true
-        description: "Python package name to search issues for"
+        description: "Python package name to check"
+      - name: "--repo-url"
+        type: "URL"
+        required: false
+        description: "Source repository URL (skips source-finder step)"
+      - name: "--source-available"
+        type: "boolean"
+        required: false
+        description: "Whether buildable source exists"
+      - name: "--upstream-org"
+        type: "string"
+        required: false
+        description: "Name and primary country of the maintaining organization"
     usage_examples:
-      - "/python-packaging-bug-finder torch"
+      - "/python-packaging-license-checker requests"
+      - "/python-packaging-license-checker some-package --repo-url https://github.com/org/repo"
+  python-packaging-license-finder:
+    description: |
+      Deterministically find license information for Python packages using a
+      two-step approach: first check PyPI metadata via a helper script, then
+      fall back to cloning the source repository and reading LICENSE files
+      directly. Can also accept a source URL to skip PyPI lookup entirely.
+    arguments:
+      - name: "PACKAGE_NAME"
+        required: true
+        description: "Python package name"
+      - name: "VERSION"
+        required: false
+        default: "latest"
+        description: "Specific package version"
+      - name: "--source-url"
+        type: "URL"
+        required: false
+        description: "Source repository URL (skips PyPI lookup)"
+    usage_examples:
+      - "/python-packaging-license-finder requests"
+      - "/python-packaging-license-finder django 4.2.0"
+      - "/python-packaging-license-finder some-pkg --source-url https://github.com/org/repo"
+  python-packaging-source-finder:
+    description: |
+      Locate source code repositories for Python packages by analyzing PyPI
+      metadata, project URLs, and code hosting platforms (GitHub, GitLab,
+      Bitbucket). Returns a JSON result with repository URL, confidence level
+      (high/medium/low), and the method used to find it. Falls back to web
+      search when PyPI metadata is insufficient.
+    arguments:
+      - name: "PACKAGE_NAME"
+        required: true
+        description: "Python package name to find the repository for"
+    usage_examples:
+      - "/python-packaging-source-finder requests"
+      - "/python-packaging-source-finder vllm"
+  vllm-backport-fetch-prs:
+    description: |
+      Fetch merged bugfix PRs from vllm-project/vllm within a configurable
+      date window using GitHub CLI. Uses multiple search queries (label:bug,
+      [Bugfix]/[BugFix]/[Bug Fix] title patterns) and deduplicates results.
+      Also detects reverted PRs. Outputs a JSON array of PR objects to stdout.
+    arguments:
+      - name: "DAYS_BACK"
+        required: false
+        default: "7"
+        description: "Number of days to look back for merged PRs"
+    usage_examples:
+      - "/vllm-backport-fetch-prs"
+      - "/vllm-backport-fetch-prs 14"
+  vllm-backport-classify:
+    description: |
+      Classify bugfix PRs by type (runtime_bug, platform_specific, unclear,
+      not_bugfix) and filter by file existence at a release tag. Applies
+      deterministic regex rules, checks which files existed at the target tag,
+      detects subsystems, and filters PRs touching only post-release or
+      non-runtime code. PRs classified as "unclear" require agent review.
+    arguments:
+      - name: "--input"
+        type: "path"
+        required: true
+        description: "Path to raw-prs.json from fetch-prs step"
+      - name: "--repo"
+        type: "path"
+        required: true
+        description: "Path to local vllm repository clone"
+      - name: "--tag"
+        type: "string"
+        required: true
+        description: "Release tag to check file existence against (e.g., v0.13.0)"
+      - name: "--output"
+        type: "path"
+        required: true
+        description: "Output path for filtered.json"
+    usage_examples:
+      - "/vllm-backport-classify --input artifacts/raw-prs.json --repo /path/to/vllm --tag v0.13.0 --output artifacts/filtered.json"
+  vllm-backport-check-backported:
+    description: |
+      Check which candidate PRs have already been cherry-picked into a
+      downstream branch. Uses two detection methods: SHA match (via git log
+      --grep for cherry-pick messages) and title match (via gh pr list on
+      the downstream branch). Adds an already_backported boolean to each PR.
+    arguments:
+      - name: "--input"
+        type: "path"
+        required: true
+        description: "Path to filtered.json from classify step"
+      - name: "--downstream"
+        type: "path"
+        required: true
+        description: "Path to downstream repository"
+      - name: "--branch"
+        type: "string"
+        required: true
+        description: "Downstream branch name (e.g., rhai/0.13.0)"
+      - name: "--output"
+        type: "path"
+        required: true
+        description: "Output path for candidates.json"
+    usage_examples:
+      - "/vllm-backport-check-backported --input artifacts/filtered.json --downstream /path/to/downstream --branch rhai/0.13.0 --output artifacts/candidates.json"
+  vllm-backport-score-rank:
+    description: |
+      Score and rank backport candidates using a deterministic composite
+      formula (max 100 points) based on verdict (0-30), severity (5-25),
+      affected scope (3-20), backport risk (0-15), and self-containedness
+      (0-10). Filters out SKIP/already_backported PRs and assigns
+      backport_ease labels (ai-fixable if self-contained and safe/moderate risk).
+    arguments:
+      - name: "--input"
+        type: "path"
+        required: true
+        description: "Path to analyzed.json with agent-added semantic fields"
+      - name: "--output"
+        type: "path"
+        required: true
+        description: "Output path for ranked.json"
+    usage_examples:
+      - "/vllm-backport-score-rank --input artifacts/analyzed.json --output artifacts/ranked.json"
+  vllm-backport-push-report:
+    description: |
+      Push a triage report to a GitHub repository under a timestamped
+      directory in reports/. Copies the report markdown and candidates JSON,
+      commits, pushes, and prints the GitHub URL to stdout.
+    arguments:
+      - name: "--report"
+        type: "path"
+        required: true
+        description: "Path to report markdown file"
+      - name: "--candidates"
+        type: "path"
+        required: true
+        description: "Path to ranked.json"
+      - name: "--version"
+        type: "string"
+        required: true
+        description: "Release version (e.g., v0.13.0)"
+    usage_examples:
+      - "/vllm-backport-push-report --report artifacts/report.md --candidates artifacts/ranked.json --version v0.13.0"
+  vllm-backport-cherry-pick:
+    description: |
+      Attempt automatic cherry-pick of clean backport candidates to a
+      downstream release branch. Selects eligible PRs (ai-fixable, score >= 50,
+      not already backported, verdict is must_backport or likely_relevant),
+      cherry-picks each, and creates a draft PR if any succeed. Requires agent
+      follow-up for semantic validation of the cherry-picked diff.
+    arguments:
+      - name: "--input"
+        type: "path"
+        required: true
+        description: "Path to ranked.json from score-rank step"
+      - name: "--downstream"
+        type: "path"
+        required: true
+        description: "Path to downstream repository"
+      - name: "--branch"
+        type: "string"
+        required: true
+        description: "Downstream branch name (e.g., rhai/0.13.0)"
+      - name: "--jira-url"
+        type: "URL"
+        required: false
+        description: "Jira ticket URL to link in the PR"
+      - name: "--report-url"
+        type: "URL"
+        required: false
+        description: "GitHub report URL to link in the PR"
+      - name: "--output"
+        type: "path"
+        required: true
+        description: "Output path for cherry-pick-result.json"
+    usage_examples:
+      - "/vllm-backport-cherry-pick --input artifacts/ranked.json --downstream /path/to/repo --branch rhai/0.13.0 --output artifacts/cherry-pick-result.json"
+  vllm-compare-reqs:
+    description: |
+      Compare Python requirements files and Dockerfiles between vLLM versions
+      to identify dependency changes. Supports variant-based comparison (rocm,
+      cuda, cpu, tpu, xpu) which auto-includes runtime, build, and Dockerfile
+      differences, or single-file comparison. Produces a categorized summary
+      table followed by detailed per-file change listings. Designed for AIPCC
+      package onboarding workflows.
+    arguments:
+      - name: "VERSION1"
+        required: true
+        description: "First version to compare (e.g., v0.13.0)"
+      - name: "VERSION2"
+        required: true
+        description: "Second version to compare (e.g., v0.14.0)"
+      - name: "VARIANT_OR_FILE"
+        required: true
+        description: "Variant name (rocm, cuda, cpu, tpu, xpu) or specific file (common.txt, rocm-build.txt)"
+      - name: "--pretty"
+        required: false
+        default: "true"
+        description: "Show clean categorized output (use --no-pretty for simple diff)"
+    usage_examples:
+      - "/vllm-compare-reqs v0.13.0 v0.14.0 rocm"
+      - "/vllm-compare-reqs v0.13.0 v0.14.0 cuda"
+      - "/vllm-compare-reqs v0.13.0 v0.14.0 common.txt"
+  vllm-slack-summary:
+    description: |
+      Generate a summary of the vLLM CI SIG Slack channel activity for the
+      RHAIIS midstream release team. Uses slackdump to export channel messages,
+      generates a markdown transcript, then analyzes it for breaking changes,
+      hardware issues, CI/CD infrastructure changes, dependency updates,
+      performance regressions, and upstream release stability.
+    arguments:
+      - name: "--days"
+        required: false
+        default: "7"
+        description: "Number of days of Slack history to export"
+      - name: "--output-dir"
+        required: false
+        default: "vllm_slack_summary"
+        description: "Output directory for transcript and summary"
+    usage_examples:
+      - "/vllm-slack-summary"
+      - "/vllm-slack-summary --days 14"

--- a/site/docs/plugins/odh-ai-helpers/adr-review.md
+++ b/site/docs/plugins/odh-ai-helpers/adr-review.md
@@ -7,9 +7,14 @@ title: adr-review
 
 # adr-review
 
-Review an Architectural Decision Record using a team of 6 specialist
-reviewer subagents (architecture, security, performance, maintainability,
-testing, documentation). Produces consolidated PDF and PPTX reports.
+Review an Architectural Decision Record (ADR) using a panel of six
+specialist reviewer sub-agents running in parallel. The reviewers cover
+Context & Problem Framing, Technical Soundness, Operational & Reliability,
+Security & Compliance, Cost & Performance, and Consequences & Reversibility.
+After the panel runs, a human-in-the-loop step lets the user agree, disagree,
+or refine each finding before synthesis. Produces consolidated outputs as
+both a detailed PDF report and a scannable PPTX slide deck. Handles
+Markdown files, .docx documents, and directories of multiple ADRs.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -19,8 +24,19 @@ testing, documentation). Produces consolidated PDF and PPTX reports.
 ![adr-review diagram](adr-review.svg)
 </div>
 
+## Arguments
+
+```
+/adr-review <ADR_PATH>
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ADR_PATH` | :material-check: | — | Path to an ADR file (.md or .docx) or a directory containing multiple ADRs |
+
 ## Usage
 
 ```
 /adr-review /path/to/adr.md
+/adr-review /path/to/adr-directory/
 ```

--- a/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
+++ b/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
@@ -8,7 +8,8 @@ title: git-shallow-clone
 # git-shallow-clone
 
 Perform a shallow clone of a Git repository to a temporary location
-for local analysis instead of using web APIs.
+for local analysis instead of using web APIs. Uses a helper script that
+prints the clone path to stdout for downstream consumption.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,10 +21,14 @@ for local analysis instead of using web APIs.
 
 ## Arguments
 
+```
+/git-shallow-clone <REPOSITORY_URL> [TAG_OR_BRANCH]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository_url` | :material-check: | — | URL of the Git repository to clone |
-| `tag_or_branch` |  | `HEAD` | Git tag or branch to shallow clone |
+| `REPOSITORY_URL` | :material-check: | — | URL of the Git repository to clone |
+| `TAG_OR_BRANCH` |  | `HEAD` | Git tag or branch to shallow-clone |
 
 ## Usage
 

--- a/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
+++ b/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
@@ -8,7 +8,10 @@ title: gitlab-pipeline-debugger
 # gitlab-pipeline-debugger
 
 Debug and monitor GitLab CI/CD pipelines for merge requests. Check
-pipeline status, view job logs, and troubleshoot CI failures using glab CLI.
+pipeline status, view job logs, and troubleshoot CI failures using the
+glab CLI. Supports auto-detection of the GitLab project from the local
+git remote, or targeting a specific project via URL or -R flag. Can
+parse full GitLab pipeline and job URLs to extract project paths and IDs.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,14 +23,21 @@ pipeline status, view job logs, and troubleshoot CI failures using glab CLI.
 
 ## Arguments
 
+```
+/gitlab-pipeline-debugger [PIPELINE_URL] [-b] [-p] [-R]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository_url` |  | `auto-detected from git remote` | GitLab repository URL or branch name |
-| `--p` |  | — | Specific pipeline ID to inspect |
+| `PIPELINE_URL` |  | — | Full GitLab pipeline or job URL to debug |
+| `-b` |  | — | Branch name to check pipeline for |
+| `-p` |  | — | Specific pipeline ID to inspect |
+| `-R` |  | `auto-detected from git remote` | GitLab project path to target |
 
 ## Usage
 
 ```
 /gitlab-pipeline-debugger
-/gitlab-pipeline-debugger https://gitlab.com/org/repo
+/gitlab-pipeline-debugger https://gitlab.com/org/project/-/pipelines/123456
+/gitlab-pipeline-debugger -b feature-branch
 ```

--- a/site/docs/plugins/odh-ai-helpers/index.md
+++ b/site/docs/plugins/odh-ai-helpers/index.md
@@ -37,28 +37,6 @@ with each stage producing JSON artifacts consumed by the next.
     - **Repository**: [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
     - **Tags**: <span class="tag-pill">python-packaging</span> <span class="tag-pill">licensing</span> <span class="tag-pill">dependencies</span> <span class="tag-pill">gitlab</span> <span class="tag-pill">jira</span> <span class="tag-pill">adr</span> <span class="tag-pill">git</span> <span class="tag-pill">automation</span>
 
-## Architecture
-
-The plugin follows a modular architecture with three distinct skill families:
-
-**Python Packaging Toolchain** -- Seven skills that share a common pattern of
-wrapping helper scripts (Python/Bash) and chaining through skill invocations.
-The source-finder locates repositories, the shallow-clone skill provides local
-access, and downstream skills (complexity, license-finder, license-checker,
-env-finder, bug-finder) analyze different facets. The investigator agent
-orchestrates all of them in parallel sub-agents.
-
-**vLLM Backport Pipeline** -- Eight skills forming a linear data pipeline.
-Each produces a JSON artifact (raw-prs.json -> filtered.json -> candidates.json
--> analyzed.json -> ranked.json -> cherry-pick-result.json) consumed by the
-next stage. The pipeline combines deterministic script-based steps with
-agent-driven semantic analysis for unclear classifications.
-
-**Utility Skills** -- Standalone skills (adr-review, gitlab-pipeline-debugger,
-jira-upload-chat-log, git-shallow-clone) that operate independently with no
-inter-skill dependencies. The adr-review skill uses six parallel reviewer
-sub-agents with human-in-the-loop correction before synthesis.
-
 ## Pipeline
 
 <div class="diagram-container" markdown>
@@ -94,6 +72,28 @@ sub-agents with human-in-the-loop correction before synthesis.
 | Agent | Description |
 |-------|-------------|
 | python-packaging-investigator | Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity |
+
+## Architecture
+
+The plugin follows a modular architecture with three distinct skill families:
+
+**Python Packaging Toolchain** -- Seven skills that share a common pattern of
+wrapping helper scripts (Python/Bash) and chaining through skill invocations.
+The source-finder locates repositories, the shallow-clone skill provides local
+access, and downstream skills (complexity, license-finder, license-checker,
+env-finder, bug-finder) analyze different facets. The investigator agent
+orchestrates all of them in parallel sub-agents.
+
+**vLLM Backport Pipeline** -- Eight skills forming a linear data pipeline.
+Each produces a JSON artifact (raw-prs.json -> filtered.json -> candidates.json
+-> analyzed.json -> ranked.json -> cherry-pick-result.json) consumed by the
+next stage. The pipeline combines deterministic script-based steps with
+agent-driven semantic analysis for unclear classifications.
+
+**Utility Skills** -- Standalone skills (adr-review, gitlab-pipeline-debugger,
+jira-upload-chat-log, git-shallow-clone) that operate independently with no
+inter-skill dependencies. The adr-review skill uses six parallel reviewer
+sub-agents with human-in-the-loop correction before synthesis.
 
 ## Installation
 

--- a/site/docs/plugins/odh-ai-helpers/index.md
+++ b/site/docs/plugins/odh-ai-helpers/index.md
@@ -73,6 +73,12 @@ with each stage producing JSON artifacts consumed by the next.
 |-------|-------------|
 | python-packaging-investigator | Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity |
 
+## Installation
+
+```bash
+/plugin install odh-ai-helpers@opendatahub-skills
+```
+
 ## Architecture
 
 The plugin follows a modular architecture with three distinct skill families:
@@ -94,9 +100,3 @@ agent-driven semantic analysis for unclear classifications.
 jira-upload-chat-log, git-shallow-clone) that operate independently with no
 inter-skill dependencies. The adr-review skill uses six parallel reviewer
 sub-agents with human-in-the-loop correction before synthesis.
-
-## Installation
-
-```bash
-/plugin install odh-ai-helpers@opendatahub-skills
-```

--- a/site/docs/plugins/odh-ai-helpers/index.md
+++ b/site/docs/plugins/odh-ai-helpers/index.md
@@ -7,10 +7,25 @@ title: odh-ai-helpers
 
 # odh-ai-helpers
 
-Developer productivity tools for Python packaging, CI/CD debugging, and
-workflow automation. Includes skills for analyzing package build complexity,
-resolving dependencies, finding licenses, debugging GitLab pipelines,
-reviewing ADRs, and more.
+A comprehensive suite of developer productivity tools for Python packaging,
+CI/CD debugging, upstream maintenance, and workflow automation. The plugin
+spans three functional domains: (1) a Python packaging toolchain that can
+analyze build complexity, resolve full dependency trees, locate source repos,
+find and check licenses against Red Hat redistribution policy, discover build
+environment variables, and surface known packaging bugs; (2) a vLLM backport
+triage pipeline that fetches upstream bugfix PRs, classifies them, checks
+for existing cherry-picks, scores and ranks candidates, auto-cherry-picks
+clean fixes, pushes reports, compares requirements across versions, and
+summarizes Slack channel activity; and (3) general-purpose skills for ADR
+review panels, GitLab CI debugging, Jira chat-log uploads, and Git
+shallow-cloning.
+
+The Python packaging skills are designed to work both independently and as a
+coordinated pipeline through the python-packaging-investigator agent, which
+orchestrates all packaging skills in parallel and produces a standardized
+build analysis report. The vLLM backport skills form a linear pipeline from
+PR fetching through classification, deduplication, scoring, and cherry-picking,
+with each stage producing JSON artifacts consumed by the next.
 
 
 !!! info "Plugin Details"
@@ -21,6 +36,28 @@ reviewing ADRs, and more.
     - **Category**: [Development Tools](../../categories/development-tools.md)
     - **Repository**: [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
     - **Tags**: <span class="tag-pill">python-packaging</span> <span class="tag-pill">licensing</span> <span class="tag-pill">dependencies</span> <span class="tag-pill">gitlab</span> <span class="tag-pill">jira</span> <span class="tag-pill">adr</span> <span class="tag-pill">git</span> <span class="tag-pill">automation</span>
+
+## Architecture
+
+The plugin follows a modular architecture with three distinct skill families:
+
+**Python Packaging Toolchain** -- Seven skills that share a common pattern of
+wrapping helper scripts (Python/Bash) and chaining through skill invocations.
+The source-finder locates repositories, the shallow-clone skill provides local
+access, and downstream skills (complexity, license-finder, license-checker,
+env-finder, bug-finder) analyze different facets. The investigator agent
+orchestrates all of them in parallel sub-agents.
+
+**vLLM Backport Pipeline** -- Eight skills forming a linear data pipeline.
+Each produces a JSON artifact (raw-prs.json -> filtered.json -> candidates.json
+-> analyzed.json -> ranked.json -> cherry-pick-result.json) consumed by the
+next stage. The pipeline combines deterministic script-based steps with
+agent-driven semantic analysis for unclear classifications.
+
+**Utility Skills** -- Standalone skills (adr-review, gitlab-pipeline-debugger,
+jira-upload-chat-log, git-shallow-clone) that operate independently with no
+inter-skill dependencies. The adr-review skill uses six parallel reviewer
+sub-agents with human-in-the-loop correction before synthesis.
 
 ## Pipeline
 

--- a/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
+++ b/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
@@ -7,8 +7,11 @@ title: jira-upload-chat-log
 
 # jira-upload-chat-log
 
-Export the current chat conversation as a markdown file and attach
-it to a Jira ticket.
+Export the current chat conversation as a formatted markdown document
+(with both a summary and full transcript) and upload it as a file
+attachment to a Jira ticket. Automatically detects ticket keys from
+conversation context, or prompts the user if none is found. Delegates
+the actual upload to the jira-workitem-attach skill.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,9 +23,13 @@ it to a Jira ticket.
 
 ## Arguments
 
+```
+/jira-upload-chat-log [TICKET_KEY]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ticket_key` |  | `auto-detected from conversation` | Jira ticket key (e.g., AIPCC-1234) |
+| `TICKET_KEY` |  | `auto-detected from conversation context` | Jira ticket key (e.g., AIPCC-1234) |
 
 ## Usage
 

--- a/site/docs/plugins/odh-ai-helpers/python-full-deps.md
+++ b/site/docs/plugins/odh-ai-helpers/python-full-deps.md
@@ -7,8 +7,12 @@ title: python-full-deps
 
 # python-full-deps
 
-Resolve the full install-time dependency tree for a Python package
-with environment markers, using uv or pip as resolver.
+Resolve the full install-time transitive dependency tree for a Python
+package, respecting environment markers for a specific Python version.
+Uses uv pip compile (preferred) with fallback to pip install --dry-run
+--report. Outputs a sorted, deduplicated list of name==version pairs.
+Complements python-packaging-complexity which only shows direct
+dependencies from metadata.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +24,19 @@ with environment markers, using uv or pip as resolver.
 
 ## Arguments
 
+```
+/python-full-deps <PACKAGE_NAME> [VERSION] [PYTHON_VERSION]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | PyPI project name (e.g., vllm) |
-| `version` |  | `latest` | Specific package version |
-| `python_version` |  | `3.12` | Python version for resolution |
+| `PACKAGE_NAME` | :material-check: | — | PyPI project name (e.g., vllm, requests) |
+| `VERSION` |  | `latest` | Specific package version (e.g., 0.4.0) |
+| `PYTHON_VERSION` |  | `3.12` | Python version for environment marker resolution (e.g., 3.11) |
 
 ## Usage
 
 ```
 /python-full-deps requests
-/python-full-deps requests 2.32.3 3.11
+/python-full-deps vllm 0.4.0 3.11
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
@@ -8,7 +8,10 @@ title: python-packaging-bug-finder
 # python-packaging-bug-finder
 
 Find known packaging bugs, fixes, and workarounds for Python projects
-by searching GitHub issues.
+by searching GitHub issues. First uses source-finder to locate the repo,
+then searches issues for build, installation, dependency, compiler, and
+platform-specific problems. Analyzes resolution status, version impact,
+and available workarounds for each issue found.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,12 +23,17 @@ by searching GitHub issues.
 
 ## Arguments
 
+```
+/python-packaging-bug-finder <PACKAGE_NAME>
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | Python package name to search issues for |
+| `PACKAGE_NAME` | :material-check: | — | Python package name to search issues for |
 
 ## Usage
 
 ```
 /python-packaging-bug-finder torch
+/python-packaging-bug-finder numpy
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
@@ -7,8 +7,11 @@ title: python-packaging-complexity
 
 # python-packaging-complexity
 
-Analyze Python package build complexity by inspecting PyPI metadata,
-compilation requirements, and distribution types.
+Analyze Python package build complexity by inspecting PyPI metadata.
+Evaluates compilation requirements (C/C++/Rust/Fortran), dependency
+complexity, distribution types (sdist, platform-specific wheels, universal
+wheels), and produces a numerical complexity score (0-10+). Provides
+actionable recommendations for wheel building strategies.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,15 +23,20 @@ compilation requirements, and distribution types.
 
 ## Arguments
 
+```
+/python-packaging-complexity <PACKAGE_NAME> [VERSION] [--json]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | Python package name to analyze |
-| `version` |  | `latest` | Specific package version |
-| `--json` |  | — | Output as structured JSON |
+| `PACKAGE_NAME` | :material-check: | — | Python package name to analyze |
+| `VERSION` |  | `latest` | Specific package version |
+| `--json` |  | — | Output as structured JSON for programmatic processing |
 
 ## Usage
 
 ```
 /python-packaging-complexity torch
-/python-packaging-complexity numpy 1.24.3 --json
+/python-packaging-complexity numpy 1.24.3
+/python-packaging-complexity tensorflow --json
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
@@ -7,8 +7,11 @@ title: python-packaging-env-finder
 
 # python-packaging-env-finder
 
-Investigate environment variables that can be set when building
-Python wheels by analyzing setup.py, CMake, and build config files.
+Investigate environment variables that can be set when building Python
+wheels for a given project. Analyzes setup.py, CMake files, and other
+build configuration files to discover compiler variables (CC, CXX, CFLAGS),
+path configuration, feature control flags (ENABLE_*, WITH_*, USE_*), and
+Python-specific build variables.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,9 +23,13 @@ Python wheels by analyzing setup.py, CMake, and build config files.
 
 ## Arguments
 
+```
+/python-packaging-env-finder [PROJECT_PATH]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `project_path` |  | `current directory` | Path to Python project |
+| `PROJECT_PATH` |  | `current directory` | Path to the Python project to analyze |
 
 ## Usage
 

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
@@ -7,8 +7,14 @@ title: python-packaging-license-checker
 
 # python-packaging-license-checker
 
-Check whether a Python package license is compatible with
-redistribution in Red Hat products using Fedora License Data policy.
+Check whether a Python package license is compatible with redistribution
+in Red Hat products, using the Fedora License Data as the authoritative
+policy source. Clones the source repo to read the actual LICENSE file
+(not just PyPI metadata), normalizes to SPDX identifiers, handles
+compound AND/OR expressions, checks vendor agreements (NVIDIA, Intel
+Gaudi, IBM Spyre), and performs build and export compliance checks.
+Produces a structured six-field verdict: License, Source verified,
+Verdict, Build compliance, Export compliance, and Notes.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,12 +26,20 @@ redistribution in Red Hat products using Fedora License Data policy.
 
 ## Arguments
 
+```
+/python-packaging-license-checker <PACKAGE_NAME> [--repo-url] [--source-available] [--upstream-org]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | Python package name to check |
+| `PACKAGE_NAME` | :material-check: | — | Python package name to check |
+| `--repo-url` |  | — | Source repository URL (skips source-finder step) |
+| `--source-available` |  | — | Whether buildable source exists |
+| `--upstream-org` |  | — | Name and primary country of the maintaining organization |
 
 ## Usage
 
 ```
 /python-packaging-license-checker requests
+/python-packaging-license-checker some-package --repo-url https://github.com/org/repo
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
@@ -7,8 +7,10 @@ title: python-packaging-license-finder
 
 # python-packaging-license-finder
 
-Deterministically find license information for Python packages
-by checking PyPI metadata and Git repository LICENSE files.
+Deterministically find license information for Python packages using a
+two-step approach: first check PyPI metadata via a helper script, then
+fall back to cloning the source repository and reading LICENSE files
+directly. Can also accept a source URL to skip PyPI lookup entirely.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,14 +22,20 @@ by checking PyPI metadata and Git repository LICENSE files.
 
 ## Arguments
 
+```
+/python-packaging-license-finder <PACKAGE_NAME> [VERSION] [--source-url]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | Python package name |
-| `version` |  | `latest` | Specific package version |
+| `PACKAGE_NAME` | :material-check: | — | Python package name |
+| `VERSION` |  | `latest` | Specific package version |
+| `--source-url` |  | — | Source repository URL (skips PyPI lookup) |
 
 ## Usage
 
 ```
 /python-packaging-license-finder requests
 /python-packaging-license-finder django 4.2.0
+/python-packaging-license-finder some-pkg --source-url https://github.com/org/repo
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
@@ -7,8 +7,11 @@ title: python-packaging-source-finder
 
 # python-packaging-source-finder
 
-Locate source code repositories for Python packages by analyzing
-PyPI metadata and code hosting platforms.
+Locate source code repositories for Python packages by analyzing PyPI
+metadata, project URLs, and code hosting platforms (GitHub, GitLab,
+Bitbucket). Returns a JSON result with repository URL, confidence level
+(high/medium/low), and the method used to find it. Falls back to web
+search when PyPI metadata is insufficient.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -20,12 +23,17 @@ PyPI metadata and code hosting platforms.
 
 ## Arguments
 
+```
+/python-packaging-source-finder <PACKAGE_NAME>
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `package_name` | :material-check: | — | Python package name to find repository for |
+| `PACKAGE_NAME` | :material-check: | — | Python package name to find the repository for |
 
 ## Usage
 
 ```
 /python-packaging-source-finder requests
+/python-packaging-source-finder vllm
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
@@ -7,7 +7,10 @@ title: vllm-backport-check-backported
 
 # vllm-backport-check-backported
 
-Check if PRs are already cherry-picked in a downstream release branch via SHA and title matching
+Check which candidate PRs have already been cherry-picked into a
+downstream branch. Uses two detection methods: SHA match (via git log
+--grep for cherry-pick messages) and title match (via gh pr list on
+the downstream branch). Adds an already_backported boolean to each PR.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +19,22 @@ Check if PRs are already cherry-picked in a downstream release branch via SHA an
 <div class="diagram-container" markdown>
 ![vllm-backport-check-backported diagram](vllm-backport-check-backported.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-check-backported [--input] [--downstream] [--branch] [--output]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--input` | :material-check: | — | Path to filtered.json from classify step |
+| `--downstream` | :material-check: | — | Path to downstream repository |
+| `--branch` | :material-check: | — | Downstream branch name (e.g., rhai/0.13.0) |
+| `--output` | :material-check: | — | Output path for candidates.json |
+
+## Usage
+
+```
+/vllm-backport-check-backported --input artifacts/filtered.json --downstream /path/to/downstream --branch rhai/0.13.0 --output artifacts/candidates.json
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
@@ -7,7 +7,11 @@ title: vllm-backport-cherry-pick
 
 # vllm-backport-cherry-pick
 
-Attempt automatic cherry-pick of clean backport candidates to a downstream release branch
+Attempt automatic cherry-pick of clean backport candidates to a
+downstream release branch. Selects eligible PRs (ai-fixable, score >= 50,
+not already backported, verdict is must_backport or likely_relevant),
+cherry-picks each, and creates a draft PR if any succeed. Requires agent
+follow-up for semantic validation of the cherry-picked diff.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,24 @@ Attempt automatic cherry-pick of clean backport candidates to a downstream relea
 <div class="diagram-container" markdown>
 ![vllm-backport-cherry-pick diagram](vllm-backport-cherry-pick.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-cherry-pick [--input] [--downstream] [--branch] [--jira-url] [--report-url] [--output]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--input` | :material-check: | — | Path to ranked.json from score-rank step |
+| `--downstream` | :material-check: | — | Path to downstream repository |
+| `--branch` | :material-check: | — | Downstream branch name (e.g., rhai/0.13.0) |
+| `--jira-url` |  | — | Jira ticket URL to link in the PR |
+| `--report-url` |  | — | GitHub report URL to link in the PR |
+| `--output` | :material-check: | — | Output path for cherry-pick-result.json |
+
+## Usage
+
+```
+/vllm-backport-cherry-pick --input artifacts/ranked.json --downstream /path/to/repo --branch rhai/0.13.0 --output artifacts/cherry-pick-result.json
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
@@ -7,7 +7,11 @@ title: vllm-backport-classify
 
 # vllm-backport-classify
 
-Classify PRs by backport relevance using labels, title patterns, and file-existence heuristics
+Classify bugfix PRs by type (runtime_bug, platform_specific, unclear,
+not_bugfix) and filter by file existence at a release tag. Applies
+deterministic regex rules, checks which files existed at the target tag,
+detects subsystems, and filters PRs touching only post-release or
+non-runtime code. PRs classified as "unclear" require agent review.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,22 @@ Classify PRs by backport relevance using labels, title patterns, and file-existe
 <div class="diagram-container" markdown>
 ![vllm-backport-classify diagram](vllm-backport-classify.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-classify [--input] [--repo] [--tag] [--output]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--input` | :material-check: | — | Path to raw-prs.json from fetch-prs step |
+| `--repo` | :material-check: | — | Path to local vllm repository clone |
+| `--tag` | :material-check: | — | Release tag to check file existence against (e.g., v0.13.0) |
+| `--output` | :material-check: | — | Output path for filtered.json |
+
+## Usage
+
+```
+/vllm-backport-classify --input artifacts/raw-prs.json --repo /path/to/vllm --tag v0.13.0 --output artifacts/filtered.json
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
@@ -7,7 +7,10 @@ title: vllm-backport-fetch-prs
 
 # vllm-backport-fetch-prs
 
-Fetch merged bugfix PRs from upstream vLLM within a configurable date window using GitHub CLI
+Fetch merged bugfix PRs from vllm-project/vllm within a configurable
+date window using GitHub CLI. Uses multiple search queries (label:bug,
+[Bugfix]/[BugFix]/[Bug Fix] title patterns) and deduplicates results.
+Also detects reverted PRs. Outputs a JSON array of PR objects to stdout.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +19,20 @@ Fetch merged bugfix PRs from upstream vLLM within a configurable date window usi
 <div class="diagram-container" markdown>
 ![vllm-backport-fetch-prs diagram](vllm-backport-fetch-prs.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-fetch-prs [DAYS_BACK]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DAYS_BACK` |  | `7` | Number of days to look back for merged PRs |
+
+## Usage
+
+```
+/vllm-backport-fetch-prs
+/vllm-backport-fetch-prs 14
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
@@ -7,7 +7,9 @@ title: vllm-backport-push-report
 
 # vllm-backport-push-report
 
-Push triage report to a GitHub repository with timestamped directory structure
+Push a triage report to a GitHub repository under a timestamped
+directory in reports/. Copies the report markdown and candidates JSON,
+commits, pushes, and prints the GitHub URL to stdout.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +18,21 @@ Push triage report to a GitHub repository with timestamped directory structure
 <div class="diagram-container" markdown>
 ![vllm-backport-push-report diagram](vllm-backport-push-report.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-push-report [--report] [--candidates] [--version]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--report` | :material-check: | — | Path to report markdown file |
+| `--candidates` | :material-check: | — | Path to ranked.json |
+| `--version` | :material-check: | — | Release version (e.g., v0.13.0) |
+
+## Usage
+
+```
+/vllm-backport-push-report --report artifacts/report.md --candidates artifacts/ranked.json --version v0.13.0
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
@@ -7,7 +7,11 @@ title: vllm-backport-score-rank
 
 # vllm-backport-score-rank
 
-Score and rank backport candidates by severity, scope, and risk using a deterministic composite score
+Score and rank backport candidates using a deterministic composite
+formula (max 100 points) based on verdict (0-30), severity (5-25),
+affected scope (3-20), backport risk (0-15), and self-containedness
+(0-10). Filters out SKIP/already_backported PRs and assigns
+backport_ease labels (ai-fixable if self-contained and safe/moderate risk).
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,20 @@ Score and rank backport candidates by severity, scope, and risk using a determin
 <div class="diagram-container" markdown>
 ![vllm-backport-score-rank diagram](vllm-backport-score-rank.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-backport-score-rank [--input] [--output]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--input` | :material-check: | — | Path to analyzed.json with agent-added semantic fields |
+| `--output` | :material-check: | — | Output path for ranked.json |
+
+## Usage
+
+```
+/vllm-backport-score-rank --input artifacts/analyzed.json --output artifacts/ranked.json
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
@@ -7,7 +7,12 @@ title: vllm-compare-reqs
 
 # vllm-compare-reqs
 
-Compare Python requirements between upstream vLLM and a downstream fork to identify version mismatches and missing packages
+Compare Python requirements files and Dockerfiles between vLLM versions
+to identify dependency changes. Supports variant-based comparison (rocm,
+cuda, cpu, tpu, xpu) which auto-includes runtime, build, and Dockerfile
+differences, or single-file comparison. Produces a categorized summary
+table followed by detailed per-file change listings. Designed for AIPCC
+package onboarding workflows.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +21,24 @@ Compare Python requirements between upstream vLLM and a downstream fork to ident
 <div class="diagram-container" markdown>
 ![vllm-compare-reqs diagram](vllm-compare-reqs.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-compare-reqs <VERSION1> <VERSION2> <VARIANT_OR_FILE> [--pretty]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VERSION1` | :material-check: | — | First version to compare (e.g., v0.13.0) |
+| `VERSION2` | :material-check: | — | Second version to compare (e.g., v0.14.0) |
+| `VARIANT_OR_FILE` | :material-check: | — | Variant name (rocm, cuda, cpu, tpu, xpu) or specific file (common.txt, rocm-build.txt) |
+| `--pretty` |  | `true` | Show clean categorized output (use --no-pretty for simple diff) |
+
+## Usage
+
+```
+/vllm-compare-reqs v0.13.0 v0.14.0 rocm
+/vllm-compare-reqs v0.13.0 v0.14.0 cuda
+/vllm-compare-reqs v0.13.0 v0.14.0 common.txt
+```

--- a/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
@@ -7,7 +7,11 @@ title: vllm-slack-summary
 
 # vllm-slack-summary
 
-Generate a concise Slack-formatted summary of vLLM backport triage results
+Generate a summary of the vLLM CI SIG Slack channel activity for the
+RHAIIS midstream release team. Uses slackdump to export channel messages,
+generates a markdown transcript, then analyzes it for breaking changes,
+hardware issues, CI/CD infrastructure changes, dependency updates,
+performance regressions, and upstream release stability.
 
 **Plugin**: [odh-ai-helpers](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,21 @@ Generate a concise Slack-formatted summary of vLLM backport triage results
 <div class="diagram-container" markdown>
 ![vllm-slack-summary diagram](vllm-slack-summary.svg)
 </div>
+
+## Arguments
+
+```
+/vllm-slack-summary [--days] [--output-dir]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--days` |  | `7` | Number of days of Slack history to export |
+| `--output-dir` |  | `vllm_slack_summary` | Output directory for transcript and summary |
+
+## Usage
+
+```
+/vllm-slack-summary
+/vllm-slack-summary --days 14
+```

--- a/site/docs/plugins/quality-tooling/_enriched.yaml
+++ b/site/docs/plugins/quality-tooling/_enriched.yaml
@@ -1,41 +1,168 @@
 description: |
-  Quality tooling and automation for RHOAI component development. Includes
-  automated repository analysis against gold standards, Konflux build simulation
-  for PR validation, and test pattern extraction for agent rules.
+  Quality tooling and automation suite for RHOAI component development. Provides
+  five complementary skills that span the full quality lifecycle: repository-wide
+  quality assessment against gold standards, Konflux build simulation for catching
+  failures at PR time, test pattern extraction for generating agent rules,
+  historical bug coverage analysis with Jira integration, and multi-dimensional
+  PR risk assessment with parallel analyzer agents.
+
+  The plugin targets Red Hat OpenShift AI repositories and understands RHOAI-specific
+  concerns such as FIPS compliance, hermetic builds, module federation, operator
+  packaging, and cross-repo test dependencies. All skills produce rich output
+  artifacts -- interactive HTML reports, GitHub Actions workflows, or markdown
+  rule files -- that are immediately actionable without manual post-processing.
+architecture_notes: |
+  Each skill operates independently as a standalone analysis pipeline invoked via
+  slash command. The common pattern is: clone or access a target repository, perform
+  deep structural analysis, and generate output artifacts (HTML reports, YAML configs,
+  GitHub Actions workflows, or markdown rule files).
+
+  The risk-assessment skill is the most architecturally complex: it uses an
+  orchestrator pattern that launches four parallel sub-agents (risk analyzer, test
+  validator, impact analyzer, cross-repo analyzer) via the Agent tool, then
+  aggregates their results through a decision engine. Shell scripts handle PR
+  extraction, context loading, output verification, and result reporting.
+
+  The historical-bug-coverage skill integrates with Jira via environment-configured
+  credentials and uses Python modules for deep test analysis (Jest, Cypress, pytest,
+  Go test), confidence scoring, and HTML report generation.
+
+  Several skills share conceptual overlap (quality-repo-analysis and test-rules-generator
+  both analyze test infrastructure) but operate at different abstraction levels --
+  scoring vs. pattern extraction.
 skills:
   quality-repo-analysis:
     description: |
-      Comprehensive quality assessment across 7 dimensions: CI/CD, test coverage,
-      code quality, container image testing, security practices, agent rules, and
-      testing frameworks. Produces markdown report and interactive HTML visualization.
+      Comprehensive quality assessment that evaluates a repository across seven
+      dimensions: CI/CD pipeline analysis, test coverage assessment, code quality
+      tools, container image testing, security practices, agent rules assessment,
+      and testing frameworks. Compares findings against gold standard repositories
+      (odh-dashboard, notebooks, kserve) and produces a weighted overall score.
+
+      Generates two output formats automatically: a markdown report with YAML
+      frontmatter containing structured scorecard data, and an interactive HTML
+      report with animated score visualizations, collapsible sections, and
+      color-coded severity indicators. The HTML report opens in the default
+      browser upon completion.
     arguments:
       - name: "repository-url"
-        required: true
-        description: "GitHub repository URL to analyze"
+        required: false
+        description: "GitHub repository URL to analyze (prompted if omitted)"
     usage_examples:
       - "/quality-repo-analysis https://github.com/opendatahub-io/kserve"
       - "/quality-repo-analysis https://github.com/kubeflow/training-operator"
   konflux-build-simulator:
     description: |
-      Simulates Konflux build environment on PRs to catch build failures before
-      production. Generates GitHub Actions workflows for hermetic build validation,
-      Docker checks, FIPS compliance, and operator integration testing.
+      Analyzes a repository and generates GitHub Actions workflows that simulate
+      the Konflux build environment at PR time, catching failures before they
+      reach production. Performs validation across six phases: static checks
+      (hermetic lockfiles, workspace dependencies, FIPS compliance), Docker build
+      validation, runtime validation (crashloop detection, API endpoint testing,
+      WebSocket compatibility), module federation validation (remoteEntry.js,
+      chunk integrity, load performance), operator integration (Kind cluster),
+      and manifest validation (kustomize, ConfigMap, overlays).
+
+      Automatically detects repository type (monorepo, Kubernetes operator, or
+      component/library) and generates appropriate validation phases. Key
+      RHOAI-specific checks include Hermeto/Cachi2 hermetic build compatibility,
+      FIPS strictfipsruntime enforcement, and fastify v5 regression testing.
     arguments:
       - name: "repository-url"
-        required: true
-        description: "GitHub repository URL to simulate builds for"
+        required: false
+        description: "GitHub repository URL to generate build simulation for (prompted if omitted)"
     usage_examples:
       - "/konflux-build-simulator https://github.com/opendatahub-io/odh-dashboard"
       - "/konflux-build-simulator https://github.com/opendatahub-io/kserve"
+      - "/konflux-build-simulator https://github.com/kubeflow/training-operator"
   test-rules-generator:
     description: |
       Analyzes existing test patterns in a repository and generates Claude Code
-      agent rules (.claude/rules/) for consistent test creation across unit,
-      mock, E2E, and contract tests.
+      agent rules in .claude/rules/ for consistent test creation. Covers unit,
+      mock, E2E, and contract test types with framework-specific awareness
+      (Jest, Cypress, Go testing, React Testing Library, pytest).
+
+      The generation process has three phases: repository analysis (identify test
+      directories, frameworks, and test types), pattern extraction (sample 5-10
+      representative files per type, extract structure, naming, setup/teardown,
+      assertion styles), and rule generation (produce markdown files with
+      description, structure, examples, conventions, and checklists). The output
+      serves as living documentation that enables agents to auto-create tests
+      following established repository conventions.
     arguments:
       - name: "repository-url"
-        required: true
-        description: "GitHub repository URL to analyze test patterns from"
+        required: false
+        description: "GitHub repository URL to extract test patterns from (prompted if omitted)"
     usage_examples:
       - "/test-rules-generator https://github.com/opendatahub-io/odh-dashboard"
+      - "/test-rules-generator https://github.com/opendatahub-io/kserve"
       - "/test-rules-generator https://github.com/kubeflow/training-operator"
+  historical-bug-coverage:
+    description: |
+      Analyzes historical blocking and critical bugs from Jira and determines
+      what test coverage exists today through deep test inspection with confidence
+      scoring. Reads matched test files, extracts actual assertions, and calculates
+      0-100% confidence scores based on entity matches and scenario validation.
+
+      Coverage thresholds are strict: COVERED requires 80%+ confidence that a test
+      explicitly validates the failure scenario, PARTIALLY COVERED is 60-80%, and
+      GAP is below 60%. Supports granular test levels (unit, mock, component,
+      integration, E2E upstream/downstream, contract) and auto-categorizes bugs
+      by type (upgrade, platform-specific, FIPS, performance, security, disconnected).
+
+      Generates a standalone HTML report with sortable/filterable tables, SVG charts,
+      color-coded confidence badges, E2E breakdown by category, and prioritized
+      recommendations for test gaps. Supports external test repositories for
+      cross-repo coverage analysis.
+    argument_hint: "--jql JQL_QUERY --repo REPO_PATH [--external-tests PATH] [--filter FILTER_ID] [--output PATH]"
+    arguments:
+      - name: "--jql"
+        required: true
+        description: "JQL query string to fetch bugs from Jira (mutually exclusive with --filter)"
+      - name: "--repo"
+        required: true
+        description: "Path to the target repository to analyze for test coverage"
+      - name: "--external-tests"
+        required: false
+        description: "Path to an external test repository for cross-repo coverage analysis"
+      - name: "--filter"
+        required: false
+        description: "Saved Jira filter ID (alternative to --jql)"
+      - name: "--output"
+        required: false
+        description: "Output HTML file path (defaults to {repo-name}-bug-coverage.html)"
+    usage_examples:
+      - "/historical-bug-coverage --jql \"project = MYPROJECT AND priority in (Blocker, Critical)\" --repo /path/to/repo"
+      - "/historical-bug-coverage --jql \"project = MYPROJECT AND component = 'Dashboard'\" --repo /path/to/repo --external-tests /path/to/e2e-tests"
+      - "/historical-bug-coverage --jql \"project = MYPROJECT AND created >= -90d\" --repo /path/to/repo"
+  risk-assessment:
+    description: |
+      Multi-agent PR risk assessment orchestrator that coordinates four parallel
+      analyzer sub-agents to evaluate a GitHub pull request across complementary
+      dimensions: security risk and breaking changes, test coverage validation,
+      architecture impact and blast radius, and cross-repository intelligence
+      for affected test repos.
+
+      The orchestrator extracts PR metadata via gh CLI, loads context from
+      architecture docs and Jira, launches all four analyzers in parallel using
+      the Agent tool, then aggregates results through a decision engine. This is
+      an advisory-only system -- it provides recommendations but never blocks PRs.
+
+      Supports headless mode for CI integration and dry-run mode for testing
+      without publishing. Results are published as PR comments and status checks
+      on GitHub.
+    arguments:
+      - name: "PR_NUMBER"
+        required: true
+        description: "GitHub pull request number to analyze"
+      - name: "REPO"
+        required: true
+        description: "Repository identifier (owner/repo format)"
+      - name: "--headless"
+        required: false
+        description: "Run in headless mode for CI integration"
+      - name: "--dry-run"
+        required: false
+        description: "Run analysis without publishing results to GitHub"
+    usage_examples:
+      - "/risk-assessment 123 opendatahub-io/odh-dashboard"
+      - "/risk-assessment 456 opendatahub-io/kserve --dry-run"

--- a/site/docs/plugins/quality-tooling/historical-bug-coverage.md
+++ b/site/docs/plugins/quality-tooling/historical-bug-coverage.md
@@ -7,7 +7,21 @@ title: historical-bug-coverage
 
 # historical-bug-coverage
 
-Analyzes historical blocking and critical bugs from Jira, determines what test coverage exists today with deep test inspection and confidence scoring, and generates standalone HTML reports
+Analyzes historical blocking and critical bugs from Jira and determines
+what test coverage exists today through deep test inspection with confidence
+scoring. Reads matched test files, extracts actual assertions, and calculates
+0-100% confidence scores based on entity matches and scenario validation.
+
+Coverage thresholds are strict: COVERED requires 80%+ confidence that a test
+explicitly validates the failure scenario, PARTIALLY COVERED is 60-80%, and
+GAP is below 60%. Supports granular test levels (unit, mock, component,
+integration, E2E upstream/downstream, contract) and auto-categorizes bugs
+by type (upgrade, platform-specific, FIPS, performance, security, disconnected).
+
+Generates a standalone HTML report with sortable/filterable tables, SVG charts,
+color-coded confidence badges, E2E breakdown by category, and prioritized
+recommendations for test gaps. Supports external test repositories for
+cross-repo coverage analysis.
 
 **Plugin**: [quality-tooling](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +30,25 @@ Analyzes historical blocking and critical bugs from Jira, determines what test c
 <div class="diagram-container" markdown>
 ![historical-bug-coverage diagram](historical-bug-coverage.svg)
 </div>
+
+## Arguments
+
+```
+/historical-bug-coverage --jql JQL_QUERY --repo REPO_PATH [--external-tests PATH] [--filter FILTER_ID] [--output PATH]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--jql` | :material-check: | — | JQL query string to fetch bugs from Jira (mutually exclusive with --filter) |
+| `--repo` | :material-check: | — | Path to the target repository to analyze for test coverage |
+| `--external-tests` |  | — | Path to an external test repository for cross-repo coverage analysis |
+| `--filter` |  | — | Saved Jira filter ID (alternative to --jql) |
+| `--output` |  | — | Output HTML file path (defaults to {repo-name}-bug-coverage.html) |
+
+## Usage
+
+```
+/historical-bug-coverage --jql "project = MYPROJECT AND priority in (Blocker, Critical)" --repo /path/to/repo
+/historical-bug-coverage --jql "project = MYPROJECT AND component = 'Dashboard'" --repo /path/to/repo --external-tests /path/to/e2e-tests
+/historical-bug-coverage --jql "project = MYPROJECT AND created >= -90d" --repo /path/to/repo
+```

--- a/site/docs/plugins/quality-tooling/index.md
+++ b/site/docs/plugins/quality-tooling/index.md
@@ -29,6 +29,22 @@ rule files -- that are immediately actionable without manual post-processing.
     - **Repository**: [antowaddle/Red-Hat-Quality-Tiger-Team](https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team)
     - **Tags**: <span class="tag-pill">quality</span> <span class="tag-pill">testing</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">build-validation</span> <span class="tag-pill">analysis</span>
 
+## Pipeline
+
+<div class="diagram-container" markdown>
+![quality-tooling pipeline](pipeline.svg)
+</div>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/quality-repo-analysis`](quality-repo-analysis.md) | Automated analysis tool that evaluates CI/CD, testing, security, and best practices against gold standards | :material-check: |
+| [`/konflux-build-simulator`](konflux-build-simulator.md) | Generate GitHub Actions workflows that simulate Konflux builds at PR time to catch failures before merge | :material-check: |
+| [`/test-rules-generator`](test-rules-generator.md) | Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency | :material-check: |
+| [`/historical-bug-coverage`](historical-bug-coverage.md) | Analyzes historical blocking and critical bugs from Jira, determines what test coverage exists today with deep test inspection and confidence scoring, and generates standalone HTML reports | :material-check: |
+| [`/risk-assessment`](risk-assessment.md) | Analyze PR for risk, test coverage, architecture impact, and cross-repo intelligence | :material-check: |
+
 ## Architecture
 
 Each skill operates independently as a standalone analysis pipeline invoked via
@@ -49,22 +65,6 @@ Go test), confidence scoring, and HTML report generation.
 Several skills share conceptual overlap (quality-repo-analysis and test-rules-generator
 both analyze test infrastructure) but operate at different abstraction levels --
 scoring vs. pattern extraction.
-
-## Pipeline
-
-<div class="diagram-container" markdown>
-![quality-tooling pipeline](pipeline.svg)
-</div>
-
-## Skills
-
-| Skill | Description | Invocable |
-|-------|-------------|-----------|
-| [`/quality-repo-analysis`](quality-repo-analysis.md) | Automated analysis tool that evaluates CI/CD, testing, security, and best practices against gold standards | :material-check: |
-| [`/konflux-build-simulator`](konflux-build-simulator.md) | Generate GitHub Actions workflows that simulate Konflux builds at PR time to catch failures before merge | :material-check: |
-| [`/test-rules-generator`](test-rules-generator.md) | Extract test patterns from existing tests and generate .claude/rules/ documentation for consistency | :material-check: |
-| [`/historical-bug-coverage`](historical-bug-coverage.md) | Analyzes historical blocking and critical bugs from Jira, determines what test coverage exists today with deep test inspection and confidence scoring, and generates standalone HTML reports | :material-check: |
-| [`/risk-assessment`](risk-assessment.md) | Analyze PR for risk, test coverage, architecture impact, and cross-repo intelligence | :material-check: |
 
 ## Installation
 

--- a/site/docs/plugins/quality-tooling/index.md
+++ b/site/docs/plugins/quality-tooling/index.md
@@ -45,6 +45,12 @@ rule files -- that are immediately actionable without manual post-processing.
 | [`/historical-bug-coverage`](historical-bug-coverage.md) | Analyzes historical blocking and critical bugs from Jira, determines what test coverage exists today with deep test inspection and confidence scoring, and generates standalone HTML reports | :material-check: |
 | [`/risk-assessment`](risk-assessment.md) | Analyze PR for risk, test coverage, architecture impact, and cross-repo intelligence | :material-check: |
 
+## Installation
+
+```bash
+/plugin install quality-tooling@opendatahub-skills
+```
+
 ## Architecture
 
 Each skill operates independently as a standalone analysis pipeline invoked via
@@ -65,9 +71,3 @@ Go test), confidence scoring, and HTML report generation.
 Several skills share conceptual overlap (quality-repo-analysis and test-rules-generator
 both analyze test infrastructure) but operate at different abstraction levels --
 scoring vs. pattern extraction.
-
-## Installation
-
-```bash
-/plugin install quality-tooling@opendatahub-skills
-```

--- a/site/docs/plugins/quality-tooling/index.md
+++ b/site/docs/plugins/quality-tooling/index.md
@@ -7,9 +7,18 @@ title: quality-tooling
 
 # quality-tooling
 
-Quality tooling and automation for RHOAI component development. Includes
-automated repository analysis against gold standards, Konflux build simulation
-for PR validation, and test pattern extraction for agent rules.
+Quality tooling and automation suite for RHOAI component development. Provides
+five complementary skills that span the full quality lifecycle: repository-wide
+quality assessment against gold standards, Konflux build simulation for catching
+failures at PR time, test pattern extraction for generating agent rules,
+historical bug coverage analysis with Jira integration, and multi-dimensional
+PR risk assessment with parallel analyzer agents.
+
+The plugin targets Red Hat OpenShift AI repositories and understands RHOAI-specific
+concerns such as FIPS compliance, hermetic builds, module federation, operator
+packaging, and cross-repo test dependencies. All skills produce rich output
+artifacts -- interactive HTML reports, GitHub Actions workflows, or markdown
+rule files -- that are immediately actionable without manual post-processing.
 
 
 !!! info "Plugin Details"
@@ -19,6 +28,27 @@ for PR validation, and test pattern extraction for agent rules.
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
     - **Repository**: [antowaddle/Red-Hat-Quality-Tiger-Team](https://github.com/antowaddle/Red-Hat-Quality-Tiger-Team)
     - **Tags**: <span class="tag-pill">quality</span> <span class="tag-pill">testing</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">build-validation</span> <span class="tag-pill">analysis</span>
+
+## Architecture
+
+Each skill operates independently as a standalone analysis pipeline invoked via
+slash command. The common pattern is: clone or access a target repository, perform
+deep structural analysis, and generate output artifacts (HTML reports, YAML configs,
+GitHub Actions workflows, or markdown rule files).
+
+The risk-assessment skill is the most architecturally complex: it uses an
+orchestrator pattern that launches four parallel sub-agents (risk analyzer, test
+validator, impact analyzer, cross-repo analyzer) via the Agent tool, then
+aggregates their results through a decision engine. Shell scripts handle PR
+extraction, context loading, output verification, and result reporting.
+
+The historical-bug-coverage skill integrates with Jira via environment-configured
+credentials and uses Python modules for deep test analysis (Jest, Cypress, pytest,
+Go test), confidence scoring, and HTML report generation.
+
+Several skills share conceptual overlap (quality-repo-analysis and test-rules-generator
+both analyze test infrastructure) but operate at different abstraction levels --
+scoring vs. pattern extraction.
 
 ## Pipeline
 

--- a/site/docs/plugins/quality-tooling/konflux-build-simulator.md
+++ b/site/docs/plugins/quality-tooling/konflux-build-simulator.md
@@ -7,9 +7,19 @@ title: konflux-build-simulator
 
 # konflux-build-simulator
 
-Simulates Konflux build environment on PRs to catch build failures before
-production. Generates GitHub Actions workflows for hermetic build validation,
-Docker checks, FIPS compliance, and operator integration testing.
+Analyzes a repository and generates GitHub Actions workflows that simulate
+the Konflux build environment at PR time, catching failures before they
+reach production. Performs validation across six phases: static checks
+(hermetic lockfiles, workspace dependencies, FIPS compliance), Docker build
+validation, runtime validation (crashloop detection, API endpoint testing,
+WebSocket compatibility), module federation validation (remoteEntry.js,
+chunk integrity, load performance), operator integration (Kind cluster),
+and manifest validation (kustomize, ConfigMap, overlays).
+
+Automatically detects repository type (monorepo, Kubernetes operator, or
+component/library) and generates appropriate validation phases. Key
+RHOAI-specific checks include Hermeto/Cachi2 hermetic build compatibility,
+FIPS strictfipsruntime enforcement, and fastify v5 regression testing.
 
 **Plugin**: [quality-tooling](index.md) | **:material-check: User-invocable**
 
@@ -21,13 +31,18 @@ Docker checks, FIPS compliance, and operator integration testing.
 
 ## Arguments
 
+```
+/konflux-build-simulator [repository-url]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` | :material-check: | — | GitHub repository URL to simulate builds for |
+| `repository-url` |  | — | GitHub repository URL to generate build simulation for (prompted if omitted) |
 
 ## Usage
 
 ```
 /konflux-build-simulator https://github.com/opendatahub-io/odh-dashboard
 /konflux-build-simulator https://github.com/opendatahub-io/kserve
+/konflux-build-simulator https://github.com/kubeflow/training-operator
 ```

--- a/site/docs/plugins/quality-tooling/quality-repo-analysis.md
+++ b/site/docs/plugins/quality-tooling/quality-repo-analysis.md
@@ -7,9 +7,17 @@ title: quality-repo-analysis
 
 # quality-repo-analysis
 
-Comprehensive quality assessment across 7 dimensions: CI/CD, test coverage,
-code quality, container image testing, security practices, agent rules, and
-testing frameworks. Produces markdown report and interactive HTML visualization.
+Comprehensive quality assessment that evaluates a repository across seven
+dimensions: CI/CD pipeline analysis, test coverage assessment, code quality
+tools, container image testing, security practices, agent rules assessment,
+and testing frameworks. Compares findings against gold standard repositories
+(odh-dashboard, notebooks, kserve) and produces a weighted overall score.
+
+Generates two output formats automatically: a markdown report with YAML
+frontmatter containing structured scorecard data, and an interactive HTML
+report with animated score visualizations, collapsible sections, and
+color-coded severity indicators. The HTML report opens in the default
+browser upon completion.
 
 **Plugin**: [quality-tooling](index.md) | **:material-check: User-invocable**
 
@@ -21,9 +29,13 @@ testing frameworks. Produces markdown report and interactive HTML visualization.
 
 ## Arguments
 
+```
+/quality-repo-analysis [repository-url]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` | :material-check: | — | GitHub repository URL to analyze |
+| `repository-url` |  | — | GitHub repository URL to analyze (prompted if omitted) |
 
 ## Usage
 

--- a/site/docs/plugins/quality-tooling/risk-assessment.md
+++ b/site/docs/plugins/quality-tooling/risk-assessment.md
@@ -7,7 +7,20 @@ title: risk-assessment
 
 # risk-assessment
 
-Analyze PR for risk, test coverage, architecture impact, and cross-repo intelligence
+Multi-agent PR risk assessment orchestrator that coordinates four parallel
+analyzer sub-agents to evaluate a GitHub pull request across complementary
+dimensions: security risk and breaking changes, test coverage validation,
+architecture impact and blast radius, and cross-repository intelligence
+for affected test repos.
+
+The orchestrator extracts PR metadata via gh CLI, loads context from
+architecture docs and Jira, launches all four analyzers in parallel using
+the Agent tool, then aggregates results through a decision engine. This is
+an advisory-only system -- it provides recommendations but never blocks PRs.
+
+Supports headless mode for CI integration and dry-run mode for testing
+without publishing. Results are published as PR comments and status checks
+on GitHub.
 
 **Plugin**: [quality-tooling](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +29,23 @@ Analyze PR for risk, test coverage, architecture impact, and cross-repo intellig
 <div class="diagram-container" markdown>
 ![risk-assessment diagram](risk-assessment.svg)
 </div>
+
+## Arguments
+
+```
+/risk-assessment <PR_NUMBER> <REPO> [--headless] [--dry-run]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PR_NUMBER` | :material-check: | — | GitHub pull request number to analyze |
+| `REPO` | :material-check: | — | Repository identifier (owner/repo format) |
+| `--headless` |  | — | Run in headless mode for CI integration |
+| `--dry-run` |  | — | Run analysis without publishing results to GitHub |
+
+## Usage
+
+```
+/risk-assessment 123 opendatahub-io/odh-dashboard
+/risk-assessment 456 opendatahub-io/kserve --dry-run
+```

--- a/site/docs/plugins/quality-tooling/test-rules-generator.md
+++ b/site/docs/plugins/quality-tooling/test-rules-generator.md
@@ -8,8 +8,17 @@ title: test-rules-generator
 # test-rules-generator
 
 Analyzes existing test patterns in a repository and generates Claude Code
-agent rules (.claude/rules/) for consistent test creation across unit,
-mock, E2E, and contract tests.
+agent rules in .claude/rules/ for consistent test creation. Covers unit,
+mock, E2E, and contract test types with framework-specific awareness
+(Jest, Cypress, Go testing, React Testing Library, pytest).
+
+The generation process has three phases: repository analysis (identify test
+directories, frameworks, and test types), pattern extraction (sample 5-10
+representative files per type, extract structure, naming, setup/teardown,
+assertion styles), and rule generation (produce markdown files with
+description, structure, examples, conventions, and checklists). The output
+serves as living documentation that enables agents to auto-create tests
+following established repository conventions.
 
 **Plugin**: [quality-tooling](index.md) | **:material-check: User-invocable**
 
@@ -21,13 +30,18 @@ mock, E2E, and contract tests.
 
 ## Arguments
 
+```
+/test-rules-generator [repository-url]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` | :material-check: | — | GitHub repository URL to analyze test patterns from |
+| `repository-url` |  | — | GitHub repository URL to extract test patterns from (prompted if omitted) |
 
 ## Usage
 
 ```
 /test-rules-generator https://github.com/opendatahub-io/odh-dashboard
+/test-rules-generator https://github.com/opendatahub-io/kserve
 /test-rules-generator https://github.com/kubeflow/training-operator
 ```

--- a/site/docs/plugins/rfe-creator/_enriched.yaml
+++ b/site/docs/plugins/rfe-creator/_enriched.yaml
@@ -6,34 +6,56 @@ description: |
   (RHAISTRAT) for refining approved RFEs into implementation strategies with
   adversarial multi-reviewer validation.
 
-  The plugin uses a shared artifact convention — all skills read from and write to
+  The plugin uses a shared artifact convention -- all skills read from and write to
   an `artifacts/` directory with YAML frontmatter for structured metadata. Jira
   write operations use deterministic Python scripts rather than LLM tool-calling,
-  while read operations support both Atlassian MCP and REST API fallback.
+  while read operations support both Atlassian MCP and REST API fallback. A
+  dependency on the `assess-rfe` plugin provides the scoring rubric, bootstrapped
+  automatically on first use.
 architecture_notes: |
   Two skill families: RFE skills (rfe.*) for the requirements pipeline and
   Strategy skills (strat.*) for implementation planning. A speedrun skill
   orchestrates the full end-to-end flow by invoking other skills.
 
-  Review skills use a forked reviewer pattern — independent sub-agents
+  Review skills use a forked reviewer pattern -- independent sub-agents
   (feasibility, testability, scope, architecture) run in isolated contexts
-  and produce separate assessments. State persistence uses scripts/state.py
-  for long-running operations, and scripts/frontmatter.py manages YAML
-  frontmatter on all artifact files.
+  and produce separate assessments that are synthesized into a consolidated
+  review. The rfe.review skill is the central orchestrator: it launches
+  parallel waves of fetch, assess, feasibility, review, and revise agents,
+  polling for completion via scripts/check_review_progress.py.
+
+  State persistence uses scripts/state.py for long-running operations across
+  context compression boundaries, and scripts/frontmatter.py manages YAML
+  frontmatter on all artifact files. The rfe.auto-fix skill wraps this into
+  a pipeline state machine (scripts/pipeline_state.py) that handles batching,
+  resumption, and multi-phase dispatch with launch_wave/wait-for-wave
+  synchronization.
+
+  Architecture context is fetched from opendatahub-io/architecture-context
+  into .context/architecture-context/ and used by review and strategy skills
+  to ground assessments in actual platform components and APIs.
 skills:
   rfe.create:
     description: |
-      Generate new RFEs from problem statements. Asks clarifying questions
-      (unless --headless), then produces well-formed RFEs with YAML frontmatter.
+      Generate new RFEs from problem statements or ideas. Loads the assess-rfe
+      rubric (bootstrapping it if needed), asks 2-5 clarifying questions about
+      customers, business justification, user problems, scope, and success
+      criteria, then produces well-formed RFEs using a template. Each RFE
+      describes WHAT and WHY (business needs), never HOW (implementation).
+      Supports headless mode for batch/CI use.
+    argument_hint: "<problem-statement> [--headless] [--priority <value>] [--labels <csv>] [--rfe-id <ID>]"
     arguments:
+      - name: "problem-statement"
+        required: true
+        description: "The problem statement, idea, or need to turn into RFEs"
       - name: "--headless"
         required: false
-        description: "Skip clarifying questions, generate directly from input"
+        description: "Skip clarifying questions (Step 2), generate RFEs directly from the input"
       - name: "--priority"
         type: "Blocker | Critical | Major | Normal | Minor"
         required: false
         default: "Normal"
-        description: "Override default priority"
+        description: "Override default priority for created RFEs"
       - name: "--labels"
         type: "<comma-separated>"
         required: false
@@ -41,54 +63,99 @@ skills:
       - name: "--rfe-id"
         type: "<ID>"
         required: false
-        description: "Pre-assigned RFE ID (placeholder file must exist)"
+        description: "Pre-assigned RFE ID; use this instead of allocating a new one. The placeholder file must already exist."
     usage_examples:
-      - "/rfe.create Users need better error messages"
-      - "/rfe.create --headless --priority Critical Fix dashboard latency"
+      - "/rfe.create Users need better error messages when model serving fails"
+      - "/rfe.create --headless --priority Critical Fix dashboard latency for large clusters"
+      - "/rfe.create --headless --rfe-id RFE-003 --labels candidate-3.5 Support GPU sharing"
   rfe.review:
     description: |
-      Score and improve RFEs with rubric-based assessment, feasibility check,
-      and auto-revision loop.
+      Score and improve RFEs with a multi-phase agent pipeline. Accepts one or
+      more Jira keys (RHAIRFE-NNNN) or local IDs (RFE-NNN). Fetches missing
+      RFEs from Jira, runs rubric-based assessment via assess-rfe, launches
+      parallel feasibility checks, synthesizes review files with scored
+      criteria, auto-revises failing RFEs, and re-assesses (up to 2 cycles).
+      The orchestrator never reads RFE content directly -- all content-heavy
+      work is delegated to sub-agents (fetch, assess, feasibility, review,
+      revise).
+    argument_hint: "<ID> [ID2 ...] [--headless] [--caller <name>]"
     arguments:
+      - name: "ID"
+        required: true
+        description: "One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN)"
       - name: "--headless"
         required: false
-        description: "Suppress end-of-run summary"
+        description: "Suppress end-of-run summary; used when called from rfe.auto-fix or rfe.split"
       - name: "--caller"
         type: "autofix | split | none"
         required: false
         default: "none"
-        description: "Identifies calling skill for headless return"
+        description: "Identifies calling skill for headless return routing"
     usage_examples:
       - "/rfe.review RHAIRFE-1234"
-      - "/rfe.review --headless RFE-001 RFE-002"
+      - "/rfe.review RFE-001 RFE-002 RFE-003"
+      - "/rfe.review --headless --caller autofix RHAIRFE-1234 RHAIRFE-5678"
   rfe.split:
     description: |
-      Decompose oversized RFEs into appropriately-scoped pieces. Generates
-      child RFEs, reviews them, and validates coverage.
+      Decompose oversized RFEs into appropriately-scoped pieces. Launches
+      parallel split agents that analyze the parent RFE and generate child
+      RFEs, then invokes rfe.review on all children. Includes a self-correction
+      loop (1 cycle max) that re-splits children still scoring poorly on
+      right-sizing. Validates coverage to ensure all original scope items
+      are represented in the children.
+    argument_hint: "<ID> [ID2 ...] [--headless]"
     arguments:
+      - name: "ID"
+        required: true
+        description: "One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) to split"
       - name: "--headless"
         required: false
-        description: "Suppress end-of-run summary"
+        description: "Suppress end-of-run summary; used when called from rfe.auto-fix"
     usage_examples:
       - "/rfe.split RHAIRFE-1234"
+      - "/rfe.split RHAIRFE-1234 RHAIRFE-5678"
   rfe.submit:
     description: |
-      Push RFEs to Jira via REST API. Creates new RHAIRFE tickets or
-      updates existing ones, renames local files after submission.
+      Push RFEs to Jira via deterministic Python scripts using the REST API
+      with Basic Auth. Creates new RHAIRFE tickets for new RFEs or updates
+      existing tickets for fetched RFEs. Applies labels automatically based
+      on pipeline outcomes (auto-created, auto-revised, split-original,
+      split-result, needs-attention, feasibility verdicts). Non-interactive --
+      invoking this skill is the confirmation. Requires JIRA_SERVER,
+      JIRA_USER, and JIRA_TOKEN environment variables.
+    argument_hint: "[--dry-run] [--artifacts-dir <path>]"
+    arguments:
+      - name: "--dry-run"
+        required: false
+        description: "Validate locally without writing to Jira"
+      - name: "--artifacts-dir"
+        type: "<path>"
+        required: false
+        default: "artifacts"
+        description: "Path to the artifacts directory"
     usage_examples:
       - "/rfe.submit"
+      - "/rfe.submit --dry-run"
   rfe.speedrun:
     description: |
-      Execute the full RFE pipeline end-to-end: create, review, auto-fix,
-      and submit. Supports single ideas, Jira keys, or batch YAML input.
+      Execute the full RFE pipeline end-to-end: create, auto-fix (review +
+      revise + split), and submit. Supports three modes: batch YAML input
+      (multiple ideas in a file), existing Jira keys, or a single free-text
+      idea. In batch mode, pre-allocates all RFE IDs and launches parallel
+      create agents. Orchestrates by invoking rfe.create, rfe.auto-fix, and
+      rfe.submit as sub-skills.
+    argument_hint: "<idea-or-key> [--input <path>] [--headless] [--dry-run] [--batch-size N] [--announce-complete]"
     arguments:
+      - name: "idea-or-key"
+        required: false
+        description: "A free-text idea or Jira key (RHAIRFE-NNNN). Mutually exclusive with --input."
       - name: "--input"
         type: "<path>"
         required: false
-        description: "Path to YAML file with batch entries"
+        description: "Path to a YAML file with batch entries (prompt, priority, labels per entry)"
       - name: "--headless"
         required: false
-        description: "Non-interactive mode for CI/eval"
+        description: "Suppress questions and confirmations (for CI/eval)"
       - name: "--dry-run"
         required: false
         description: "Skip Jira writes in submit phase"
@@ -96,18 +163,29 @@ skills:
         type: "<N>"
         required: false
         default: "5"
-        description: "Override batch size for auto-fix"
+        description: "Override batch size for auto-fix phase"
       - name: "--announce-complete"
         required: false
-        description: "Print completion marker when done"
+        description: "Print completion marker when done (for CI/eval harnesses)"
     usage_examples:
-      - "/rfe.speedrun Better dashboard for ML models"
+      - "/rfe.speedrun Better dashboard for ML model monitoring"
+      - "/rfe.speedrun RHAIRFE-1234"
       - "/rfe.speedrun --input batch.yaml --headless --dry-run"
+      - "/rfe.speedrun --input batch.yaml --headless --batch-size 10 --announce-complete"
   rfe.auto-fix:
     description: |
-      Batch review, revise, and split operations across many RFEs.
-      Supports JQL queries for bulk processing.
+      Non-interactive batch pipeline for reviewing, revising, and splitting
+      RFEs at scale. Accepts explicit IDs or a JQL query to fetch from Jira.
+      Uses a pipeline state machine (pipeline_state.py) with phased dispatch:
+      fetch, bootstrap, assess, feasibility, review, revise, re-assess, and
+      split. Processes in configurable batch sizes with resume support via
+      snapshot-based incremental fetch. Supports reprocessing previously
+      handled RFEs and random sampling.
+    argument_hint: "<IDs...> | --jql <query> [--limit N] [--batch-size N] [--headless] [--reprocess] [--random N] [--announce-complete] [--data-dir <path>]"
     arguments:
+      - name: "IDs"
+        required: false
+        description: "Explicit RFE IDs to process (space-separated)"
       - name: "--jql"
         type: "<query>"
         required: false
@@ -115,12 +193,16 @@ skills:
       - name: "--limit"
         type: "<N>"
         required: false
-        description: "Max number of results from JQL"
+        description: "Max number of results from JQL query"
       - name: "--batch-size"
         type: "<N>"
         required: false
         default: "50"
         description: "Process IDs in batches of this size"
+      - name: "--data-dir"
+        type: "<path>"
+        required: false
+        description: "Directory for snapshot data"
       - name: "--headless"
         required: false
         description: "Non-interactive mode"
@@ -130,58 +212,105 @@ skills:
       - name: "--random"
         type: "<N>"
         required: false
-        description: "Process N random RFEs from the batch"
+        description: "Process N random RFEs from the result set"
+      - name: "--announce-complete"
+        required: false
+        description: "Print completion marker when done"
     usage_examples:
-      - "/rfe.auto-fix RFE-001 RFE-002"
+      - "/rfe.auto-fix RFE-001 RFE-002 RFE-003"
       - '/rfe.auto-fix --jql "project=RHAIRFE AND status=New" --limit 20'
+      - '/rfe.auto-fix --jql "project=RHAIRFE" --reprocess --random 5'
   strat.create:
     description: |
-      Create strategies from approved RFEs by cloning them to RHAISTRAT
-      in Jira and creating local strategy artifacts.
+      Create strategies from approved RFEs by cloning them to the RHAISTRAT
+      project in Jira. Supports both Atlassian MCP and REST API fallback for
+      reading RFE data. When Jira MCP is available, clones issues directly;
+      otherwise generates a manual cloning guide. Creates local strategy stub
+      files in artifacts/strat-tasks/ with the business need copied from the
+      source RFE, ready for refinement with strat.refine.
     usage_examples:
       - "/strat.create RHAIRFE-1234"
+      - "/strat.create"
   strat.refine:
     description: |
-      Refine strategy documents — add the HOW section, dependencies,
-      impacted teams/components, and non-functional requirements.
+      Refine strategy documents by adding the HOW -- technical approach,
+      affected components, impacted teams, dependencies, non-functional
+      requirements, effort estimates, risks, and open questions. Uses
+      architecture context from opendatahub-io/architecture-context to ground
+      the strategy in actual platform components and APIs. Supports revision
+      mode: if prior reviews exist, addresses specific reviewer concerns
+      without regenerating from scratch. Uses a fork context for isolated
+      execution.
     usage_examples:
       - "/strat.refine"
   strat.review:
     description: |
-      Adversarial review of refined strategies. Spawns 4 independent
-      forked reviewers (architecture, feasibility, scope, testability)
-      and synthesizes a consolidated review.
+      Adversarial review of refined strategies. Spawns 4 independent forked
+      reviewers in parallel -- architecture-review, feasibility-review,
+      scope-review, and testability-review -- each running in isolated context.
+      Synthesizes findings into per-strategy review files preserving both
+      agreements and disagreements between reviewers. Supports re-review
+      after revisions.
     usage_examples:
       - "/strat.review"
   strat.prioritize:
     description: |
-      Prioritize strategies against the existing RHAISTRAT backlog.
-      Not yet implemented.
+      Prioritize strategies against the existing RHAISTRAT backlog in Jira.
+      Not yet implemented -- returns a message explaining the design intent
+      and open questions (JQL filtering, backlog ordering representation).
     usage_examples:
-      - "/strat.prioritize (not yet implemented)"
+      - "/strat.prioritize"
   rfe-creator.update-deps:
     description: |
-      Force update all vendored dependencies — assess-rfe skills and
-      architecture context.
+      Force update all vendored dependencies by removing cached copies and
+      re-fetching. Updates the assess-rfe skills (from the assess-rfe plugin)
+      and architecture context (from opendatahub-io/architecture-context).
+      Has disable-model-invocation set, meaning it can only be triggered
+      explicitly by the user.
     usage_examples:
       - "/rfe-creator.update-deps"
   architecture-review:
     description: |
-      Internal forked reviewer. Checks strategy features for architectural
-      correctness — dependencies, integration patterns, component interactions.
+      Internal forked reviewer sub-agent for strat.review. Checks strategy
+      features for architectural correctness -- verifies dependencies against
+      architecture docs, validates integration patterns match actual component
+      communication, checks component boundaries are respected, verifies
+      deployment model correctness, identifies architectural conflicts, and
+      flags cross-component coordination needs. Requires architecture context;
+      skips if unavailable. Runs with model: opus.
   feasibility-review:
     description: |
-      Internal forked reviewer. Assesses technical feasibility, implementation
-      complexity, and effort estimate credibility.
+      Internal forked reviewer sub-agent for strat.review. Assesses technical
+      feasibility of refined strategies -- whether the proposed approach works,
+      whether it delivers what the RFE asks for, whether effort estimates are
+      credible, and identifies hidden dependencies or integration challenges.
+      Adversarial stance: flags things that are harder than they look and
+      optimistic estimates. Runs with model: opus.
   rfe-feasibility-review:
     description: |
-      Internal forked reviewer. Reviews RFEs for technical feasibility,
-      blockers, and alignment with technical strategy.
+      Internal sub-agent launched by rfe.review. Reviews individual RFEs for
+      technical feasibility against platform architecture. Uses three verdicts:
+      feasible (can be built), infeasible (platform architecture fundamentally
+      conflicts), indeterminate (RFE too ambiguous to assess). Distinguishes
+      between capabilities not yet existing (feasible) and architectural
+      incompatibilities (infeasible). Reads Jira comment history for additional
+      context. Outputs to artifacts/rfe-reviews/{ID}-feasibility.md. Runs
+      with model: opus.
   scope-review:
     description: |
-      Internal forked reviewer. Checks if strategies are right-sized and
-      effort matches scope.
+      Internal forked reviewer sub-agent for strat.review. Assesses whether
+      each strategy is right-sized -- not too big (needs splitting), not too
+      small (just a task), and scoped to match its effort estimate. Checks
+      that scope is clearly bounded, deliverables are complete capabilities,
+      and flags scope traps like "and related functionality" or "full support
+      for". Verifies the strategy neither silently expands nor shrinks the
+      original RFE scope.
   testability-review:
     description: |
-      Internal forked reviewer. Assesses whether acceptance criteria are
-      measurable, edge cases covered, and validation approach defined.
+      Internal forked reviewer sub-agent for strat.review. Determines whether
+      strategy acceptance criteria are testable and measurable, identifies
+      missing edge cases (failure modes, boundary conditions, concurrent
+      access, large-scale scenarios), assesses test complexity, and evaluates
+      whether non-functional requirements (performance, security, scalability)
+      can be validated with concrete tests. Suggests specific rewrites for
+      vague criteria.

--- a/site/docs/plugins/rfe-creator/architecture-review.md
+++ b/site/docs/plugins/rfe-creator/architecture-review.md
@@ -22,3 +22,9 @@ skips if unavailable. Runs with model: opus.
 <div class="diagram-container" markdown>
 ![architecture-review diagram](architecture-review.svg)
 </div>
+
+## Usage
+
+```
+/architecture-review
+```

--- a/site/docs/plugins/rfe-creator/architecture-review.md
+++ b/site/docs/plugins/rfe-creator/architecture-review.md
@@ -7,8 +7,13 @@ title: architecture-review
 
 # architecture-review
 
-Internal forked reviewer. Checks strategy features for architectural
-correctness — dependencies, integration patterns, component interactions.
+Internal forked reviewer sub-agent for strat.review. Checks strategy
+features for architectural correctness -- verifies dependencies against
+architecture docs, validates integration patterns match actual component
+communication, checks component boundaries are respected, verifies
+deployment model correctness, identifies architectural conflicts, and
+flags cross-component coordination needs. Requires architecture context;
+skips if unavailable. Runs with model: opus.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/feasibility-review.md
@@ -7,8 +7,12 @@ title: feasibility-review
 
 # feasibility-review
 
-Internal forked reviewer. Assesses technical feasibility, implementation
-complexity, and effort estimate credibility.
+Internal forked reviewer sub-agent for strat.review. Assesses technical
+feasibility of refined strategies -- whether the proposed approach works,
+whether it delivers what the RFE asks for, whether effort estimates are
+credible, and identifies hidden dependencies or integration challenges.
+Adversarial stance: flags things that are harder than they look and
+optimistic estimates. Runs with model: opus.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/feasibility-review.md
@@ -21,3 +21,9 @@ optimistic estimates. Runs with model: opus.
 <div class="diagram-container" markdown>
 ![feasibility-review diagram](feasibility-review.svg)
 </div>
+
+## Usage
+
+```
+/feasibility-review
+```

--- a/site/docs/plugins/rfe-creator/index.md
+++ b/site/docs/plugins/rfe-creator/index.md
@@ -30,30 +30,6 @@ automatically on first use.
     - **Repository**: [jwforres/rfe-creator](https://github.com/jwforres/rfe-creator)
     - **Tags**: <span class="tag-pill">rfe</span> <span class="tag-pill">jira</span> <span class="tag-pill">review</span> <span class="tag-pill">strategy</span> <span class="tag-pill">pipeline</span>
 
-## Architecture
-
-Two skill families: RFE skills (rfe.*) for the requirements pipeline and
-Strategy skills (strat.*) for implementation planning. A speedrun skill
-orchestrates the full end-to-end flow by invoking other skills.
-
-Review skills use a forked reviewer pattern -- independent sub-agents
-(feasibility, testability, scope, architecture) run in isolated contexts
-and produce separate assessments that are synthesized into a consolidated
-review. The rfe.review skill is the central orchestrator: it launches
-parallel waves of fetch, assess, feasibility, review, and revise agents,
-polling for completion via scripts/check_review_progress.py.
-
-State persistence uses scripts/state.py for long-running operations across
-context compression boundaries, and scripts/frontmatter.py manages YAML
-frontmatter on all artifact files. The rfe.auto-fix skill wraps this into
-a pipeline state machine (scripts/pipeline_state.py) that handles batching,
-resumption, and multi-phase dispatch with launch_wave/wait-for-wave
-synchronization.
-
-Architecture context is fetched from opendatahub-io/architecture-context
-into .context/architecture-context/ and used by review and strategy skills
-to ground assessments in actual platform components and APIs.
-
 ## Pipeline
 
 <div class="diagram-container" markdown>
@@ -84,6 +60,30 @@ to ground assessments in actual platform components and APIs.
 | [`/rfe-feasibility-review`](rfe-feasibility-review.md) | RFE feasibility review | :material-check: |
 | [`/scope-review`](scope-review.md) | Scope review skill | :material-check: |
 | [`/testability-review`](testability-review.md) | Testability review skill | :material-check: |
+
+## Architecture
+
+Two skill families: RFE skills (rfe.*) for the requirements pipeline and
+Strategy skills (strat.*) for implementation planning. A speedrun skill
+orchestrates the full end-to-end flow by invoking other skills.
+
+Review skills use a forked reviewer pattern -- independent sub-agents
+(feasibility, testability, scope, architecture) run in isolated contexts
+and produce separate assessments that are synthesized into a consolidated
+review. The rfe.review skill is the central orchestrator: it launches
+parallel waves of fetch, assess, feasibility, review, and revise agents,
+polling for completion via scripts/check_review_progress.py.
+
+State persistence uses scripts/state.py for long-running operations across
+context compression boundaries, and scripts/frontmatter.py manages YAML
+frontmatter on all artifact files. The rfe.auto-fix skill wraps this into
+a pipeline state machine (scripts/pipeline_state.py) that handles batching,
+resumption, and multi-phase dispatch with launch_wave/wait-for-wave
+synchronization.
+
+Architecture context is fetched from opendatahub-io/architecture-context
+into .context/architecture-context/ and used by review and strategy skills
+to ground assessments in actual platform components and APIs.
 
 ## Installation
 

--- a/site/docs/plugins/rfe-creator/index.md
+++ b/site/docs/plugins/rfe-creator/index.md
@@ -61,6 +61,12 @@ automatically on first use.
 | [`/scope-review`](scope-review.md) | Scope review skill | :material-check: |
 | [`/testability-review`](testability-review.md) | Testability review skill | :material-check: |
 
+## Installation
+
+```bash
+/plugin install rfe-creator@opendatahub-skills
+```
+
 ## Architecture
 
 Two skill families: RFE skills (rfe.*) for the requirements pipeline and
@@ -84,9 +90,3 @@ synchronization.
 Architecture context is fetched from opendatahub-io/architecture-context
 into .context/architecture-context/ and used by review and strategy skills
 to ground assessments in actual platform components and APIs.
-
-## Installation
-
-```bash
-/plugin install rfe-creator@opendatahub-skills
-```

--- a/site/docs/plugins/rfe-creator/index.md
+++ b/site/docs/plugins/rfe-creator/index.md
@@ -14,10 +14,12 @@ oversized RFEs, and submission to Jira. Also provides strategy document skills
 (RHAISTRAT) for refining approved RFEs into implementation strategies with
 adversarial multi-reviewer validation.
 
-The plugin uses a shared artifact convention — all skills read from and write to
+The plugin uses a shared artifact convention -- all skills read from and write to
 an `artifacts/` directory with YAML frontmatter for structured metadata. Jira
 write operations use deterministic Python scripts rather than LLM tool-calling,
-while read operations support both Atlassian MCP and REST API fallback.
+while read operations support both Atlassian MCP and REST API fallback. A
+dependency on the `assess-rfe` plugin provides the scoring rubric, bootstrapped
+automatically on first use.
 
 
 !!! info "Plugin Details"
@@ -34,11 +36,23 @@ Two skill families: RFE skills (rfe.*) for the requirements pipeline and
 Strategy skills (strat.*) for implementation planning. A speedrun skill
 orchestrates the full end-to-end flow by invoking other skills.
 
-Review skills use a forked reviewer pattern — independent sub-agents
+Review skills use a forked reviewer pattern -- independent sub-agents
 (feasibility, testability, scope, architecture) run in isolated contexts
-and produce separate assessments. State persistence uses scripts/state.py
-for long-running operations, and scripts/frontmatter.py manages YAML
-frontmatter on all artifact files.
+and produce separate assessments that are synthesized into a consolidated
+review. The rfe.review skill is the central orchestrator: it launches
+parallel waves of fetch, assess, feasibility, review, and revise agents,
+polling for completion via scripts/check_review_progress.py.
+
+State persistence uses scripts/state.py for long-running operations across
+context compression boundaries, and scripts/frontmatter.py manages YAML
+frontmatter on all artifact files. The rfe.auto-fix skill wraps this into
+a pipeline state machine (scripts/pipeline_state.py) that handles batching,
+resumption, and multi-phase dispatch with launch_wave/wait-for-wave
+synchronization.
+
+Architecture context is fetched from opendatahub-io/architecture-context
+into .context/architecture-context/ and used by review and strategy skills
+to ground assessments in actual platform components and APIs.
 
 ## Pipeline
 

--- a/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
+++ b/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
@@ -7,8 +7,11 @@ title: rfe-creator.update-deps
 
 # rfe-creator.update-deps
 
-Force update all vendored dependencies — assess-rfe skills and
-architecture context.
+Force update all vendored dependencies by removing cached copies and
+re-fetching. Updates the assess-rfe skills (from the assess-rfe plugin)
+and architecture context (from opendatahub-io/architecture-context).
+Has disable-model-invocation set, meaning it can only be triggered
+explicitly by the user.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
@@ -23,3 +23,9 @@ with model: opus.
 <div class="diagram-container" markdown>
 ![rfe-feasibility-review diagram](rfe-feasibility-review.svg)
 </div>
+
+## Usage
+
+```
+/rfe-feasibility-review
+```

--- a/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
@@ -7,8 +7,14 @@ title: rfe-feasibility-review
 
 # rfe-feasibility-review
 
-Internal forked reviewer. Reviews RFEs for technical feasibility,
-blockers, and alignment with technical strategy.
+Internal sub-agent launched by rfe.review. Reviews individual RFEs for
+technical feasibility against platform architecture. Uses three verdicts:
+feasible (can be built), infeasible (platform architecture fundamentally
+conflicts), indeterminate (RFE too ambiguous to assess). Distinguishes
+between capabilities not yet existing (feasible) and architectural
+incompatibilities (infeasible). Reads Jira comment history for additional
+context. Outputs to artifacts/rfe-reviews/{ID}-feasibility.md. Runs
+with model: opus.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/rfe.auto-fix.md
+++ b/site/docs/plugins/rfe-creator/rfe.auto-fix.md
@@ -7,8 +7,13 @@ title: rfe.auto-fix
 
 # rfe.auto-fix
 
-Batch review, revise, and split operations across many RFEs.
-Supports JQL queries for bulk processing.
+Non-interactive batch pipeline for reviewing, revising, and splitting
+RFEs at scale. Accepts explicit IDs or a JQL query to fetch from Jira.
+Uses a pipeline state machine (pipeline_state.py) with phased dispatch:
+fetch, bootstrap, assess, feasibility, review, revise, re-assess, and
+split. Processes in configurable batch sizes with resume support via
+snapshot-based incremental fetch. Supports reprocessing previously
+handled RFEs and random sampling.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -20,18 +25,26 @@ Supports JQL queries for bulk processing.
 
 ## Arguments
 
+```
+/rfe.auto-fix <IDs...> | --jql <query> [--limit N] [--batch-size N] [--headless] [--reprocess] [--random N] [--announce-complete] [--data-dir <path>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
+| `IDs` |  | — | Explicit RFE IDs to process (space-separated) |
 | `--jql` |  | — | JQL query to fetch RFE IDs from Jira |
-| `--limit` |  | — | Max number of results from JQL |
+| `--limit` |  | — | Max number of results from JQL query |
 | `--batch-size` |  | `50` | Process IDs in batches of this size |
+| `--data-dir` |  | — | Directory for snapshot data |
 | `--headless` |  | — | Non-interactive mode |
 | `--reprocess` |  | — | Reprocess RFEs that had prior runs |
-| `--random` |  | — | Process N random RFEs from the batch |
+| `--random` |  | — | Process N random RFEs from the result set |
+| `--announce-complete` |  | — | Print completion marker when done |
 
 ## Usage
 
 ```
-/rfe.auto-fix RFE-001 RFE-002
+/rfe.auto-fix RFE-001 RFE-002 RFE-003
 /rfe.auto-fix --jql "project=RHAIRFE AND status=New" --limit 20
+/rfe.auto-fix --jql "project=RHAIRFE" --reprocess --random 5
 ```

--- a/site/docs/plugins/rfe-creator/rfe.create.md
+++ b/site/docs/plugins/rfe-creator/rfe.create.md
@@ -7,8 +7,12 @@ title: rfe.create
 
 # rfe.create
 
-Generate new RFEs from problem statements. Asks clarifying questions
-(unless --headless), then produces well-formed RFEs with YAML frontmatter.
+Generate new RFEs from problem statements or ideas. Loads the assess-rfe
+rubric (bootstrapping it if needed), asks 2-5 clarifying questions about
+customers, business justification, user problems, scope, and success
+criteria, then produces well-formed RFEs using a template. Each RFE
+describes WHAT and WHY (business needs), never HOW (implementation).
+Supports headless mode for batch/CI use.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -20,16 +24,22 @@ Generate new RFEs from problem statements. Asks clarifying questions
 
 ## Arguments
 
+```
+/rfe.create <problem-statement> [--headless] [--priority <value>] [--labels <csv>] [--rfe-id <ID>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--headless` |  | — | Skip clarifying questions, generate directly from input |
-| `--priority` |  | `Normal` | Override default priority |
+| `problem-statement` | :material-check: | — | The problem statement, idea, or need to turn into RFEs |
+| `--headless` |  | — | Skip clarifying questions (Step 2), generate RFEs directly from the input |
+| `--priority` |  | `Normal` | Override default priority for created RFEs |
 | `--labels` |  | — | Labels to apply to created RFEs |
-| `--rfe-id` |  | — | Pre-assigned RFE ID (placeholder file must exist) |
+| `--rfe-id` |  | — | Pre-assigned RFE ID; use this instead of allocating a new one. The placeholder file must already exist. |
 
 ## Usage
 
 ```
-/rfe.create Users need better error messages
-/rfe.create --headless --priority Critical Fix dashboard latency
+/rfe.create Users need better error messages when model serving fails
+/rfe.create --headless --priority Critical Fix dashboard latency for large clusters
+/rfe.create --headless --rfe-id RFE-003 --labels candidate-3.5 Support GPU sharing
 ```

--- a/site/docs/plugins/rfe-creator/rfe.review.md
+++ b/site/docs/plugins/rfe-creator/rfe.review.md
@@ -7,8 +7,14 @@ title: rfe.review
 
 # rfe.review
 
-Score and improve RFEs with rubric-based assessment, feasibility check,
-and auto-revision loop.
+Score and improve RFEs with a multi-phase agent pipeline. Accepts one or
+more Jira keys (RHAIRFE-NNNN) or local IDs (RFE-NNN). Fetches missing
+RFEs from Jira, runs rubric-based assessment via assess-rfe, launches
+parallel feasibility checks, synthesizes review files with scored
+criteria, auto-revises failing RFEs, and re-assesses (up to 2 cycles).
+The orchestrator never reads RFE content directly -- all content-heavy
+work is delegated to sub-agents (fetch, assess, feasibility, review,
+revise).
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -20,14 +26,20 @@ and auto-revision loop.
 
 ## Arguments
 
+```
+/rfe.review <ID> [ID2 ...] [--headless] [--caller <name>]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--headless` |  | — | Suppress end-of-run summary |
-| `--caller` |  | `none` | Identifies calling skill for headless return |
+| `ID` | :material-check: | — | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) |
+| `--headless` |  | — | Suppress end-of-run summary; used when called from rfe.auto-fix or rfe.split |
+| `--caller` |  | `none` | Identifies calling skill for headless return routing |
 
 ## Usage
 
 ```
 /rfe.review RHAIRFE-1234
-/rfe.review --headless RFE-001 RFE-002
+/rfe.review RFE-001 RFE-002 RFE-003
+/rfe.review --headless --caller autofix RHAIRFE-1234 RHAIRFE-5678
 ```

--- a/site/docs/plugins/rfe-creator/rfe.speedrun.md
+++ b/site/docs/plugins/rfe-creator/rfe.speedrun.md
@@ -7,8 +7,12 @@ title: rfe.speedrun
 
 # rfe.speedrun
 
-Execute the full RFE pipeline end-to-end: create, review, auto-fix,
-and submit. Supports single ideas, Jira keys, or batch YAML input.
+Execute the full RFE pipeline end-to-end: create, auto-fix (review +
+revise + split), and submit. Supports three modes: batch YAML input
+(multiple ideas in a file), existing Jira keys, or a single free-text
+idea. In batch mode, pre-allocates all RFE IDs and launches parallel
+create agents. Orchestrates by invoking rfe.create, rfe.auto-fix, and
+rfe.submit as sub-skills.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -20,17 +24,24 @@ and submit. Supports single ideas, Jira keys, or batch YAML input.
 
 ## Arguments
 
+```
+/rfe.speedrun <idea-or-key> [--input <path>] [--headless] [--dry-run] [--batch-size N] [--announce-complete]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--input` |  | — | Path to YAML file with batch entries |
-| `--headless` |  | — | Non-interactive mode for CI/eval |
+| `idea-or-key` |  | — | A free-text idea or Jira key (RHAIRFE-NNNN). Mutually exclusive with --input. |
+| `--input` |  | — | Path to a YAML file with batch entries (prompt, priority, labels per entry) |
+| `--headless` |  | — | Suppress questions and confirmations (for CI/eval) |
 | `--dry-run` |  | — | Skip Jira writes in submit phase |
-| `--batch-size` |  | `5` | Override batch size for auto-fix |
-| `--announce-complete` |  | — | Print completion marker when done |
+| `--batch-size` |  | `5` | Override batch size for auto-fix phase |
+| `--announce-complete` |  | — | Print completion marker when done (for CI/eval harnesses) |
 
 ## Usage
 
 ```
-/rfe.speedrun Better dashboard for ML models
+/rfe.speedrun Better dashboard for ML model monitoring
+/rfe.speedrun RHAIRFE-1234
 /rfe.speedrun --input batch.yaml --headless --dry-run
+/rfe.speedrun --input batch.yaml --headless --batch-size 10 --announce-complete
 ```

--- a/site/docs/plugins/rfe-creator/rfe.split.md
+++ b/site/docs/plugins/rfe-creator/rfe.split.md
@@ -7,8 +7,12 @@ title: rfe.split
 
 # rfe.split
 
-Decompose oversized RFEs into appropriately-scoped pieces. Generates
-child RFEs, reviews them, and validates coverage.
+Decompose oversized RFEs into appropriately-scoped pieces. Launches
+parallel split agents that analyze the parent RFE and generate child
+RFEs, then invokes rfe.review on all children. Includes a self-correction
+loop (1 cycle max) that re-splits children still scoring poorly on
+right-sizing. Validates coverage to ensure all original scope items
+are represented in the children.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -20,12 +24,18 @@ child RFEs, reviews them, and validates coverage.
 
 ## Arguments
 
+```
+/rfe.split <ID> [ID2 ...] [--headless]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--headless` |  | — | Suppress end-of-run summary |
+| `ID` | :material-check: | — | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) to split |
+| `--headless` |  | — | Suppress end-of-run summary; used when called from rfe.auto-fix |
 
 ## Usage
 
 ```
 /rfe.split RHAIRFE-1234
+/rfe.split RHAIRFE-1234 RHAIRFE-5678
 ```

--- a/site/docs/plugins/rfe-creator/rfe.submit.md
+++ b/site/docs/plugins/rfe-creator/rfe.submit.md
@@ -7,8 +7,13 @@ title: rfe.submit
 
 # rfe.submit
 
-Push RFEs to Jira via REST API. Creates new RHAIRFE tickets or
-updates existing ones, renames local files after submission.
+Push RFEs to Jira via deterministic Python scripts using the REST API
+with Basic Auth. Creates new RHAIRFE tickets for new RFEs or updates
+existing tickets for fetched RFEs. Applies labels automatically based
+on pipeline outcomes (auto-created, auto-revised, split-original,
+split-result, needs-attention, feasibility verdicts). Non-interactive --
+invoking this skill is the confirmation. Requires JIRA_SERVER,
+JIRA_USER, and JIRA_TOKEN environment variables.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -18,8 +23,20 @@ updates existing ones, renames local files after submission.
 ![rfe.submit diagram](rfe.submit.svg)
 </div>
 
+## Arguments
+
+```
+/rfe.submit [--dry-run] [--artifacts-dir <path>]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--dry-run` |  | — | Validate locally without writing to Jira |
+| `--artifacts-dir` |  | `artifacts` | Path to the artifacts directory |
+
 ## Usage
 
 ```
 /rfe.submit
+/rfe.submit --dry-run
 ```

--- a/site/docs/plugins/rfe-creator/scope-review.md
+++ b/site/docs/plugins/rfe-creator/scope-review.md
@@ -7,8 +7,13 @@ title: scope-review
 
 # scope-review
 
-Internal forked reviewer. Checks if strategies are right-sized and
-effort matches scope.
+Internal forked reviewer sub-agent for strat.review. Assesses whether
+each strategy is right-sized -- not too big (needs splitting), not too
+small (just a task), and scoped to match its effort estimate. Checks
+that scope is clearly bounded, deliverables are complete capabilities,
+and flags scope traps like "and related functionality" or "full support
+for". Verifies the strategy neither silently expands nor shrinks the
+original RFE scope.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/scope-review.md
+++ b/site/docs/plugins/rfe-creator/scope-review.md
@@ -22,3 +22,9 @@ original RFE scope.
 <div class="diagram-container" markdown>
 ![scope-review diagram](scope-review.svg)
 </div>
+
+## Usage
+
+```
+/scope-review
+```

--- a/site/docs/plugins/rfe-creator/strat.create.md
+++ b/site/docs/plugins/rfe-creator/strat.create.md
@@ -7,8 +7,12 @@ title: strat.create
 
 # strat.create
 
-Create strategies from approved RFEs by cloning them to RHAISTRAT
-in Jira and creating local strategy artifacts.
+Create strategies from approved RFEs by cloning them to the RHAISTRAT
+project in Jira. Supports both Atlassian MCP and REST API fallback for
+reading RFE data. When Jira MCP is available, clones issues directly;
+otherwise generates a manual cloning guide. Creates local strategy stub
+files in artifacts/strat-tasks/ with the business need copied from the
+source RFE, ready for refinement with strat.refine.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -22,4 +26,5 @@ in Jira and creating local strategy artifacts.
 
 ```
 /strat.create RHAIRFE-1234
+/strat.create
 ```

--- a/site/docs/plugins/rfe-creator/strat.prioritize.md
+++ b/site/docs/plugins/rfe-creator/strat.prioritize.md
@@ -7,8 +7,9 @@ title: strat.prioritize
 
 # strat.prioritize
 
-Prioritize strategies against the existing RHAISTRAT backlog.
-Not yet implemented.
+Prioritize strategies against the existing RHAISTRAT backlog in Jira.
+Not yet implemented -- returns a message explaining the design intent
+and open questions (JQL filtering, backlog ordering representation).
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 
@@ -21,5 +22,5 @@ Not yet implemented.
 ## Usage
 
 ```
-/strat.prioritize (not yet implemented)
+/strat.prioritize
 ```

--- a/site/docs/plugins/rfe-creator/strat.refine.md
+++ b/site/docs/plugins/rfe-creator/strat.refine.md
@@ -7,8 +7,14 @@ title: strat.refine
 
 # strat.refine
 
-Refine strategy documents — add the HOW section, dependencies,
-impacted teams/components, and non-functional requirements.
+Refine strategy documents by adding the HOW -- technical approach,
+affected components, impacted teams, dependencies, non-functional
+requirements, effort estimates, risks, and open questions. Uses
+architecture context from opendatahub-io/architecture-context to ground
+the strategy in actual platform components and APIs. Supports revision
+mode: if prior reviews exist, addresses specific reviewer concerns
+without regenerating from scratch. Uses a fork context for isolated
+execution.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/strat.review.md
+++ b/site/docs/plugins/rfe-creator/strat.review.md
@@ -7,9 +7,12 @@ title: strat.review
 
 # strat.review
 
-Adversarial review of refined strategies. Spawns 4 independent
-forked reviewers (architecture, feasibility, scope, testability)
-and synthesizes a consolidated review.
+Adversarial review of refined strategies. Spawns 4 independent forked
+reviewers in parallel -- architecture-review, feasibility-review,
+scope-review, and testability-review -- each running in isolated context.
+Synthesizes findings into per-strategy review files preserving both
+agreements and disagreements between reviewers. Supports re-review
+after revisions.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rfe-creator/testability-review.md
+++ b/site/docs/plugins/rfe-creator/testability-review.md
@@ -22,3 +22,9 @@ vague criteria.
 <div class="diagram-container" markdown>
 ![testability-review diagram](testability-review.svg)
 </div>
+
+## Usage
+
+```
+/testability-review
+```

--- a/site/docs/plugins/rfe-creator/testability-review.md
+++ b/site/docs/plugins/rfe-creator/testability-review.md
@@ -7,8 +7,13 @@ title: testability-review
 
 # testability-review
 
-Internal forked reviewer. Assesses whether acceptance criteria are
-measurable, edge cases covered, and validation approach defined.
+Internal forked reviewer sub-agent for strat.review. Determines whether
+strategy acceptance criteria are testable and measurable, identifies
+missing edge cases (failure modes, boundary conditions, concurrent
+access, large-scale scenarios), assesses test complexity, and evaluates
+whether non-functional requirements (performance, security, scalability)
+can be validated with concrete tests. Suggests specific rewrites for
+vague criteria.
 
 **Plugin**: [rfe-creator](index.md) | **:material-check: User-invocable**
 

--- a/site/docs/plugins/rhoai-security-reviewer/_enriched.yaml
+++ b/site/docs/plugins/rhoai-security-reviewer/_enriched.yaml
@@ -1,42 +1,121 @@
 description: |
-  Consensus-based security review for RHOAI strategy documents. An orchestrator
-  extracts threat surfaces, spawns three independent reviewers in parallel,
-  synthesizes findings with confidence tagging, and produces a PASS/CONCERNS/FAIL
-  verdict covering 39 catalog patterns.
+  Consensus-based security review system for RHOAI strategy documents (STRATs).
+  Rather than relying on a single reviewer pass, this plugin uses an orchestrator
+  that extracts a mechanical threat surface inventory from the STRAT, then spawns
+  three independent security reviewers running in isolated forked contexts. Each
+  reviewer checks the STRAT against all 39 catalog risk patterns covering
+  authentication, data protection, cryptographic compliance (FIPS 140-3),
+  network security, supply chain, infrastructure, multi-tenant isolation,
+  agentic AI security, MCP security, and upstream component risk. Reviewers
+  also perform creative exploration for risks not covered by the catalog.
+
+  The orchestrator synthesizes reviewer findings using confidence tagging based
+  on cross-reviewer agreement: risks found by all three reviewers are HIGH
+  confidence, by two are MEDIUM, and by one are LOW. Severity is resolved by
+  majority vote. The final output includes a verdict (PASS / CONCERNS / FAIL),
+  a full review with consensus findings, and an actionable security requirements
+  file that is automatically attached to the Jira ticket. The system also
+  cross-references findings against a 47-item NFR checklist derived from 422
+  prior STRAT reviews, and adds idempotency labels to Jira for pipeline
+  integration.
+architecture_notes: |
+  The plugin follows a two-skill architecture with a clear separation of concerns:
+
+  1. **strat-security-review** (orchestrator): Manages the full review lifecycle.
+     It fetches the STRAT from Jira via Atlassian MCP, performs mechanical threat
+     surface extraction (endpoints, services, data flows, credentials, CRDs,
+     trust boundaries, RBAC, dependencies, agent/MCP surfaces), determines the
+     review tier (Light / Standard / Deep), and spawns three isolated reviewer
+     instances. After synthesis, it writes two output files (full review +
+     requirements), attaches the requirements file to Jira, and adds verdict
+     labels for downstream pipeline idempotency.
+
+  2. **security-reviewer** (worker): Runs in `context: fork` isolation on the
+     `claude-opus-4-6` model. Each instance performs a two-phase analysis:
+     Phase A discovers all potential concerns by checking every catalog pattern
+     and performing creative exploration. Phase B applies a relevance gate
+     (requiring specific STRAT citations and checking existing controls) and a
+     severity decision tree. Architecture context from `.context/` is consulted
+     for Standard/Deep tiers to avoid flagging already-mitigated controls.
+
+  The Light tier includes a short-circuit: if the threat surface inventory is
+  entirely empty, the orchestrator skips reviewer spawning and issues a direct
+  PASS verdict. Intermediate files (threat surface, individual reviewer outputs)
+  are preserved for auditability and calibration.
 skills:
   strat-security-review:
     description: |
-      Security review orchestrator for STRAT documents. Extracts threat surface,
-      determines review tier, spawns 3 independent reviewers, synthesizes
-      consensus findings, and produces a final verdict with confidence tagging.
+      Multi-reviewer consensus orchestrator for security review of RHOAI strategy
+      documents. Operates in four phases: (1) fetch the STRAT from Jira and extract
+      a mechanical threat surface inventory covering endpoints, services, data flows,
+      credentials, CRDs, trust boundaries, RBAC, external dependencies, and agent/MCP
+      surfaces; (2) determine review tier (Light/Standard/Deep) based on security
+      surface hints and effort size, then spawn three independent security-reviewer
+      instances in isolated forked contexts; (3) synthesize findings using confidence
+      tagging (HIGH=3/3, MEDIUM=2/3, LOW=1/3 reviewer agreement) with majority-vote
+      severity resolution; (4) write a full review and a requirements file, attach
+      requirements to Jira, and add idempotency labels (strat-security-pass,
+      strat-security-concerns, strat-security-fail).
+
+      Includes a Light tier short-circuit that skips reviewer spawning when the
+      threat surface inventory is entirely empty. Cross-references synthesized
+      findings against a 47-item NFR checklist derived from 422 prior reviews.
+      Five or more NFR gaps at Standard/Deep tier upgrade the verdict to CONCERNS.
+    argument_hint: "<RHAISTRAT_KEY> [--force]"
     arguments:
       - name: "RHAISTRAT_KEY"
         required: true
-        description: "RHAISTRAT Jira key (e.g., RHAISTRAT-400)"
+        description: "RHAISTRAT Jira key identifying the strategy document to review (e.g., RHAISTRAT-400)"
       - name: "--force"
         required: false
-        description: "Regenerate review even if one already exists"
+        default: "false"
+        description: "Regenerate the security review even if one already exists for this STRAT"
     usage_examples:
       - "/strat-security-review RHAISTRAT-400"
       - "/strat-security-review RHAISTRAT-400 --force"
   security-reviewer:
     description: |
-      Independent security reviewer that assesses RHOAI strategy documents
-      against 39 catalog patterns. Runs in isolated forked context as part
-      of the multi-reviewer consensus process.
+      Independent security reviewer that assesses RHOAI strategy documents against
+      a 39-pattern risk catalog plus creative exploration. Runs in isolated forked
+      context (context: fork) on the claude-opus-4-6 model as part of the
+      multi-reviewer consensus process -- not intended for direct user invocation.
+
+      Operates in two phases: Phase A (Discovery) checks every catalog pattern
+      against the threat surface inventory, recording each as APPLICABLE or
+      NOT-APPLICABLE, then performs creative exploration for cross-component
+      attack chains, novel attack surfaces, emergent risks, and unvalidated
+      assumptions. Phase B (Filter and Classify) applies a relevance gate
+      requiring specific STRAT text citations and checking existing controls
+      from architecture context, then assigns severity via a decision tree
+      (Critical > High > Medium > NFR Gap).
+
+      The catalog covers 39 patterns across 10 categories: Authentication &
+      Authorization (AUTH-01 through AUTH-06), Data Protection (DATA-01 through
+      DATA-04), Cryptographic Compliance (CRYPTO-01 through CRYPTO-04), Network
+      & API Security (NET-01 through NET-03), Supply Chain (SUPPLY-01 through
+      SUPPLY-04), Infrastructure (INFRA-01 through INFRA-03), Multi-Tenant
+      Isolation (TENANT-01 through TENANT-03), Agentic AI Security (AGENT-01
+      through AGENT-05), MCP Security (MCP-01 through MCP-04), and Upstream
+      Component Risk (UPSTREAM-01 through UPSTREAM-04). Also checks RHOAI
+      organizational constraints (FIPS 140-3, TLS profile compliance, auth
+      patterns, secret management, namespace-scoped RBAC).
+    argument_hint: "<STRAT_KEY> --reviewer <N> --threat-surface <path> --tier <tier>"
     arguments:
       - name: "STRAT_KEY"
         required: true
-        description: "STRAT key (e.g., RHAISTRAT-400)"
+        description: "RHAISTRAT Jira key (e.g., RHAISTRAT-400)"
       - name: "--reviewer"
-        type: "N"
+        type: "integer"
         required: true
-        description: "Reviewer number (1, 2, or 3)"
+        description: "Reviewer number (1, 2, or 3) identifying this instance in the consensus set"
       - name: "--threat-surface"
-        type: "<path>"
+        type: "path"
         required: true
-        description: "Path to threat surface inventory file"
+        description: "Path to the threat surface inventory file extracted by the orchestrator"
       - name: "--tier"
-        type: "light | standard | deep"
+        type: "enum"
         required: true
-        description: "Review depth tier"
+        description: "Review depth tier: light (minimal surface), standard (1-2 hints), or deep (3+ hints, auth+crypto, agentic/MCP)"
+    usage_examples:
+      - "/security-reviewer RHAISTRAT-400 --reviewer 1 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier standard"
+      - "/security-reviewer RHAISTRAT-400 --reviewer 2 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier deep"

--- a/site/docs/plugins/rhoai-security-reviewer/index.md
+++ b/site/docs/plugins/rhoai-security-reviewer/index.md
@@ -36,6 +36,19 @@ integration.
     - **Repository**: [jctanner/ai-first-pipeline](https://github.com/jctanner/ai-first-pipeline)
     - **Tags**: <span class="tag-pill">security</span> <span class="tag-pill">review</span> <span class="tag-pill">strat</span> <span class="tag-pill">threat-modeling</span> <span class="tag-pill">fips</span> <span class="tag-pill">compliance</span> <span class="tag-pill">consensus</span>
 
+## Pipeline
+
+<div class="diagram-container" markdown>
+![rhoai-security-reviewer pipeline](pipeline.svg)
+</div>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/strat-security-review`](strat-security-review.md) | Multi-reviewer consensus orchestrator for security review of STRAT documents. Extracts threat surfaces, spawns three independent security-reviewer instances, synthesizes findings with confidence levels, and produces a final verdict (PASS/CONCERNS/FAIL). | :material-check: |
+| [`/security-reviewer`](security-reviewer.md) | Individual security reviewer that assesses RHOAI strategy documents against 39 catalog patterns covering authentication, data protection, cryptographic compliance, network security, supply chain, and infrastructure. Uses a two-phase discovery-then-filter approach with severity classification. | :material-check: |
+
 ## Architecture
 
 The plugin follows a two-skill architecture with a clear separation of concerns:
@@ -61,19 +74,6 @@ The Light tier includes a short-circuit: if the threat surface inventory is
 entirely empty, the orchestrator skips reviewer spawning and issues a direct
 PASS verdict. Intermediate files (threat surface, individual reviewer outputs)
 are preserved for auditability and calibration.
-
-## Pipeline
-
-<div class="diagram-container" markdown>
-![rhoai-security-reviewer pipeline](pipeline.svg)
-</div>
-
-## Skills
-
-| Skill | Description | Invocable |
-|-------|-------------|-----------|
-| [`/strat-security-review`](strat-security-review.md) | Multi-reviewer consensus orchestrator for security review of STRAT documents. Extracts threat surfaces, spawns three independent security-reviewer instances, synthesizes findings with confidence levels, and produces a final verdict (PASS/CONCERNS/FAIL). | :material-check: |
-| [`/security-reviewer`](security-reviewer.md) | Individual security reviewer that assesses RHOAI strategy documents against 39 catalog patterns covering authentication, data protection, cryptographic compliance, network security, supply chain, and infrastructure. Uses a two-phase discovery-then-filter approach with severity classification. | :material-check: |
 
 ## Installation
 

--- a/site/docs/plugins/rhoai-security-reviewer/index.md
+++ b/site/docs/plugins/rhoai-security-reviewer/index.md
@@ -7,10 +7,25 @@ title: rhoai-security-reviewer
 
 # rhoai-security-reviewer
 
-Consensus-based security review for RHOAI strategy documents. An orchestrator
-extracts threat surfaces, spawns three independent reviewers in parallel,
-synthesizes findings with confidence tagging, and produces a PASS/CONCERNS/FAIL
-verdict covering 39 catalog patterns.
+Consensus-based security review system for RHOAI strategy documents (STRATs).
+Rather than relying on a single reviewer pass, this plugin uses an orchestrator
+that extracts a mechanical threat surface inventory from the STRAT, then spawns
+three independent security reviewers running in isolated forked contexts. Each
+reviewer checks the STRAT against all 39 catalog risk patterns covering
+authentication, data protection, cryptographic compliance (FIPS 140-3),
+network security, supply chain, infrastructure, multi-tenant isolation,
+agentic AI security, MCP security, and upstream component risk. Reviewers
+also perform creative exploration for risks not covered by the catalog.
+
+The orchestrator synthesizes reviewer findings using confidence tagging based
+on cross-reviewer agreement: risks found by all three reviewers are HIGH
+confidence, by two are MEDIUM, and by one are LOW. Severity is resolved by
+majority vote. The final output includes a verdict (PASS / CONCERNS / FAIL),
+a full review with consensus findings, and an actionable security requirements
+file that is automatically attached to the Jira ticket. The system also
+cross-references findings against a 47-item NFR checklist derived from 422
+prior STRAT reviews, and adds idempotency labels to Jira for pipeline
+integration.
 
 
 !!! info "Plugin Details"
@@ -20,6 +35,32 @@ verdict covering 39 catalog patterns.
     - **Category**: [Security Review](../../categories/security.md)
     - **Repository**: [jctanner/ai-first-pipeline](https://github.com/jctanner/ai-first-pipeline)
     - **Tags**: <span class="tag-pill">security</span> <span class="tag-pill">review</span> <span class="tag-pill">strat</span> <span class="tag-pill">threat-modeling</span> <span class="tag-pill">fips</span> <span class="tag-pill">compliance</span> <span class="tag-pill">consensus</span>
+
+## Architecture
+
+The plugin follows a two-skill architecture with a clear separation of concerns:
+
+1. **strat-security-review** (orchestrator): Manages the full review lifecycle.
+   It fetches the STRAT from Jira via Atlassian MCP, performs mechanical threat
+   surface extraction (endpoints, services, data flows, credentials, CRDs,
+   trust boundaries, RBAC, dependencies, agent/MCP surfaces), determines the
+   review tier (Light / Standard / Deep), and spawns three isolated reviewer
+   instances. After synthesis, it writes two output files (full review +
+   requirements), attaches the requirements file to Jira, and adds verdict
+   labels for downstream pipeline idempotency.
+
+2. **security-reviewer** (worker): Runs in `context: fork` isolation on the
+   `claude-opus-4-6` model. Each instance performs a two-phase analysis:
+   Phase A discovers all potential concerns by checking every catalog pattern
+   and performing creative exploration. Phase B applies a relevance gate
+   (requiring specific STRAT citations and checking existing controls) and a
+   severity decision tree. Architecture context from `.context/` is consulted
+   for Standard/Deep tiers to avoid flagging already-mitigated controls.
+
+The Light tier includes a short-circuit: if the threat surface inventory is
+entirely empty, the orchestrator skips reviewer spawning and issues a direct
+PASS verdict. Intermediate files (threat surface, individual reviewer outputs)
+are preserved for auditability and calibration.
 
 ## Pipeline
 

--- a/site/docs/plugins/rhoai-security-reviewer/index.md
+++ b/site/docs/plugins/rhoai-security-reviewer/index.md
@@ -49,6 +49,12 @@ integration.
 | [`/strat-security-review`](strat-security-review.md) | Multi-reviewer consensus orchestrator for security review of STRAT documents. Extracts threat surfaces, spawns three independent security-reviewer instances, synthesizes findings with confidence levels, and produces a final verdict (PASS/CONCERNS/FAIL). | :material-check: |
 | [`/security-reviewer`](security-reviewer.md) | Individual security reviewer that assesses RHOAI strategy documents against 39 catalog patterns covering authentication, data protection, cryptographic compliance, network security, supply chain, and infrastructure. Uses a two-phase discovery-then-filter approach with severity classification. | :material-check: |
 
+## Installation
+
+```bash
+/plugin install rhoai-security-reviewer@opendatahub-skills
+```
+
 ## Architecture
 
 The plugin follows a two-skill architecture with a clear separation of concerns:
@@ -74,9 +80,3 @@ The Light tier includes a short-circuit: if the threat surface inventory is
 entirely empty, the orchestrator skips reviewer spawning and issues a direct
 PASS verdict. Intermediate files (threat surface, individual reviewer outputs)
 are preserved for auditability and calibration.
-
-## Installation
-
-```bash
-/plugin install rhoai-security-reviewer@opendatahub-skills
-```

--- a/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
+++ b/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
@@ -7,9 +7,30 @@ title: security-reviewer
 
 # security-reviewer
 
-Independent security reviewer that assesses RHOAI strategy documents
-against 39 catalog patterns. Runs in isolated forked context as part
-of the multi-reviewer consensus process.
+Independent security reviewer that assesses RHOAI strategy documents against
+a 39-pattern risk catalog plus creative exploration. Runs in isolated forked
+context (context: fork) on the claude-opus-4-6 model as part of the
+multi-reviewer consensus process -- not intended for direct user invocation.
+
+Operates in two phases: Phase A (Discovery) checks every catalog pattern
+against the threat surface inventory, recording each as APPLICABLE or
+NOT-APPLICABLE, then performs creative exploration for cross-component
+attack chains, novel attack surfaces, emergent risks, and unvalidated
+assumptions. Phase B (Filter and Classify) applies a relevance gate
+requiring specific STRAT text citations and checking existing controls
+from architecture context, then assigns severity via a decision tree
+(Critical > High > Medium > NFR Gap).
+
+The catalog covers 39 patterns across 10 categories: Authentication &
+Authorization (AUTH-01 through AUTH-06), Data Protection (DATA-01 through
+DATA-04), Cryptographic Compliance (CRYPTO-01 through CRYPTO-04), Network
+& API Security (NET-01 through NET-03), Supply Chain (SUPPLY-01 through
+SUPPLY-04), Infrastructure (INFRA-01 through INFRA-03), Multi-Tenant
+Isolation (TENANT-01 through TENANT-03), Agentic AI Security (AGENT-01
+through AGENT-05), MCP Security (MCP-01 through MCP-04), and Upstream
+Component Risk (UPSTREAM-01 through UPSTREAM-04). Also checks RHOAI
+organizational constraints (FIPS 140-3, TLS profile compliance, auth
+patterns, secret management, namespace-scoped RBAC).
 
 **Plugin**: [rhoai-security-reviewer](index.md) | **:material-check: User-invocable**
 
@@ -21,9 +42,20 @@ of the multi-reviewer consensus process.
 
 ## Arguments
 
+```
+/security-reviewer <STRAT_KEY> --reviewer <N> --threat-surface <path> --tier <tier>
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `STRAT_KEY` | :material-check: | — | STRAT key (e.g., RHAISTRAT-400) |
-| `--reviewer` | :material-check: | — | Reviewer number (1, 2, or 3) |
-| `--threat-surface` | :material-check: | — | Path to threat surface inventory file |
-| `--tier` | :material-check: | — | Review depth tier |
+| `STRAT_KEY` | :material-check: | — | RHAISTRAT Jira key (e.g., RHAISTRAT-400) |
+| `--reviewer` | :material-check: | — | Reviewer number (1, 2, or 3) identifying this instance in the consensus set |
+| `--threat-surface` | :material-check: | — | Path to the threat surface inventory file extracted by the orchestrator |
+| `--tier` | :material-check: | — | Review depth tier: light (minimal surface), standard (1-2 hints), or deep (3+ hints, auth+crypto, agentic/MCP) |
+
+## Usage
+
+```
+/security-reviewer RHAISTRAT-400 --reviewer 1 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier standard
+/security-reviewer RHAISTRAT-400 --reviewer 2 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier deep
+```

--- a/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
+++ b/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
@@ -7,9 +7,22 @@ title: strat-security-review
 
 # strat-security-review
 
-Security review orchestrator for STRAT documents. Extracts threat surface,
-determines review tier, spawns 3 independent reviewers, synthesizes
-consensus findings, and produces a final verdict with confidence tagging.
+Multi-reviewer consensus orchestrator for security review of RHOAI strategy
+documents. Operates in four phases: (1) fetch the STRAT from Jira and extract
+a mechanical threat surface inventory covering endpoints, services, data flows,
+credentials, CRDs, trust boundaries, RBAC, external dependencies, and agent/MCP
+surfaces; (2) determine review tier (Light/Standard/Deep) based on security
+surface hints and effort size, then spawn three independent security-reviewer
+instances in isolated forked contexts; (3) synthesize findings using confidence
+tagging (HIGH=3/3, MEDIUM=2/3, LOW=1/3 reviewer agreement) with majority-vote
+severity resolution; (4) write a full review and a requirements file, attach
+requirements to Jira, and add idempotency labels (strat-security-pass,
+strat-security-concerns, strat-security-fail).
+
+Includes a Light tier short-circuit that skips reviewer spawning when the
+threat surface inventory is entirely empty. Cross-references synthesized
+findings against a 47-item NFR checklist derived from 422 prior reviews.
+Five or more NFR gaps at Standard/Deep tier upgrade the verdict to CONCERNS.
 
 **Plugin**: [rhoai-security-reviewer](index.md) | **:material-check: User-invocable**
 
@@ -21,10 +34,14 @@ consensus findings, and produces a final verdict with confidence tagging.
 
 ## Arguments
 
+```
+/strat-security-review <RHAISTRAT_KEY> [--force]
+```
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `RHAISTRAT_KEY` | :material-check: | — | RHAISTRAT Jira key (e.g., RHAISTRAT-400) |
-| `--force` |  | — | Regenerate review even if one already exists |
+| `RHAISTRAT_KEY` | :material-check: | — | RHAISTRAT Jira key identifying the strategy document to review (e.g., RHAISTRAT-400) |
+| `--force` |  | `false` | Regenerate the security review even if one already exists for this STRAT |
 
 ## Usage
 

--- a/site/docs/plugins/test-plan/_enriched.yaml
+++ b/site/docs/plugins/test-plan/_enriched.yaml
@@ -1,63 +1,268 @@
 description: |
-  Generate test plans and test cases from RHOAI strategies using parallel
-  sub-agent analysis and automated review with a 5-criteria quality rubric.
+  End-to-end test planning and automation workflow for RHOAI (Red Hat OpenShift AI).
+  Takes a Jira strategy document as input and produces a complete test plan, individual
+  test case specifications, executable test automation code, and visual UI verification
+  reports. The pipeline uses parallel sub-agent analysis (endpoints, risks, infrastructure)
+  to extract testable interfaces, then scores quality with a 5-criteria rubric and
+  auto-revises up to 2 cycles. Supports the full lifecycle: create, review, publish to
+  GitHub, resolve PR feedback, update with new documentation, and verify UI test cases
+  against live clusters via Playwright. Test code generation uses odh-test-context for
+  repo-specific conventions, Tiger Team pattern guides, and intelligent placement analysis
+  to decide whether tests belong in the component repo or downstream E2E repo.
+
+architecture_notes: |
+  The plugin is organized as an orchestrated pipeline of 19 skills, split into
+  user-invocable commands and internal forked sub-agents:
+
+  **User-invocable pipeline stages:**
+  1. test-plan-create -- generates a test plan from a Jira strategy with 3 parallel analyzers
+  2. test-plan-create-cases -- generates TC-*.md files from the test plan
+  3. test-plan-update -- re-analyzes with new documents, merges findings, bumps version
+  4. test-plan-case-implement -- generates executable test code with placement analysis
+  5. test-plan-ui-verify -- browser-based UI test execution via Playwright CDP
+  6. test-plan-publish -- creates/updates GitHub PRs with test plan artifacts
+  7. test-plan-resolve-feedback -- triages and applies PR review comments
+  8. test-plan-score -- standalone quality rubric assessment (read-only)
+
+  **Internal sub-agents (context: fork):**
+  - test-plan-analyze-endpoints, test-plan-analyze-risks, test-plan-analyze-infra -- parallel analyzers
+  - test-plan-merge -- intelligent merge of new findings into existing plans
+  - test-plan-resolve-gaps -- cross-references gaps with new documentation
+  - test-plan-analyze-placement -- recommends component vs downstream repo placement
+  - test-plan-review -- quality scoring + auto-revision loop (max 2 cycles)
+  - test-plan-generate-test-file -- parallel test file generation sub-agent
+  - test-plan-score-test-function -- quality scoring for generated test functions
+
+  Key architectural patterns:
+  - Parallel forked sub-agents for analysis and code generation (isolated context, clean return)
+  - Python scripts for deterministic operations (frontmatter, validation, file mapping, repo utilities)
+  - MCP integration (Atlassian) for fetching Jira strategies
+  - Persistent Playwright CDP browser for UI verification with screenshot capture
+  - odh-test-context integration for repository-specific test conventions
+
 skills:
-  test-plan.create:
+  test-plan-create:
     description: |
-      Generate a complete test plan for a RHOAI feature from a strategy document.
-      Spawns 3 parallel sub-analyzers (endpoints, risks, infra), merges findings,
-      and runs an automated review with scoring and auto-revision.
+      Generate a complete test plan for a RHOAI feature from a Jira strategy
+      (RHAISTRAT or RHOAIENG issue), with optional ADR for additional technical depth.
+      Spawns 3 parallel sub-analyzers (endpoints, risks, infra), merges their findings
+      into a structured template, collects gaps into TestPlanGaps.md, then runs an
+      automated quality review with scoring and up to 2 auto-revision cycles. Produces
+      TestPlan.md, TestPlanGaps.md, TestPlanReview.md, and README.md in a feature directory.
+    argument_hint: "<JIRA_KEY> [ADR_FILE_PATH]"
     arguments:
       - name: "JIRA_KEY"
         required: true
-        description: "Strategy key (RHAISTRAT-*) or issue key (RHOAIENG-*)"
+        description: "Jira strategy key (RHAISTRAT-*) or issue key (RHOAIENG-*) to generate the test plan from"
       - name: "ADR_FILE_PATH"
         required: false
-        description: "Local path to ADR document (markdown, text, or PDF)"
+        description: "Local path to an ADR document (markdown, text, or PDF) for additional technical depth"
       - name: "--output-dir"
-        type: "<path>"
         required: false
-        description: "Override output directory for test plan artifacts"
+        description: "Override output directory for test plan artifacts (skips validation)"
     usage_examples:
-      - "/test-plan.create RHAISTRAT-400"
-      - "/test-plan.create RHOAIENG-48676"
-      - "/test-plan.create RHAISTRAT-400 /path/to/adr.pdf"
-  test-plan.create-cases:
+      - "/test-plan-create RHAISTRAT-400"
+      - "/test-plan-create RHOAIENG-48676"
+      - "/test-plan-create RHAISTRAT-400 /path/to/adr.pdf"
+
+  test-plan-create-cases:
     description: |
-      Generate individual test case files (TC-*.md) from an existing test plan.
-      Supports upgrade-aware cases and validates endpoint coverage.
+      Generate individual test case specification files (TC-*.md) from an existing test plan.
+      Processes categories one at a time, generates E2E and optional upgrade test cases,
+      validates endpoint coverage, and updates the test plan with traceability data.
+      Supports regeneration mode for updating existing test cases.
+    argument_hint: "[FEATURE_SOURCE] [--output-dir PATH]"
     arguments:
-      - name: "FEATURE_DIR"
+      - name: "FEATURE_SOURCE"
         required: false
-        default: "auto-detected from prior /test-plan.create"
-        description: "Feature directory, GitHub branch URL, or PR URL"
+        default: "auto-detected from prior /test-plan-create run"
+        description: "Feature directory path, GitHub branch URL, or GitHub PR URL"
       - name: "--output-dir"
-        type: "<path>"
         required: false
-        description: "Force creation in specified directory"
+        description: "Force creation in specified directory (contributor override)"
     usage_examples:
-      - "/test-plan.create-cases"
-      - "/test-plan.create-cases mcp_catalog"
-      - "/test-plan.create-cases /path/to/feature_dir"
-  test-plan.analyze.endpoints:
+      - "/test-plan-create-cases"
+      - "/test-plan-create-cases mcp_catalog"
+      - "/test-plan-create-cases /path/to/feature_dir"
+
+  test-plan-update:
     description: |
-      Internal forked sub-analyzer. Extracts feature scope, test objectives,
-      and API endpoints/methods under test from strategy and ADR documents.
-  test-plan.analyze.risks:
-    description: |
-      Internal forked sub-analyzer. Determines test levels, test types,
-      priority definitions, NFR assessments, and risks with mitigations.
-  test-plan.analyze.infra:
-    description: |
-      Internal forked sub-analyzer. Identifies test environment configuration,
-      test data, test users, infrastructure, and tooling requirements.
-  test-plan.review:
-    description: |
-      Internal quality reviewer. Scores test plans against a 5-criteria rubric
-      (specificity, grounding, scope fidelity, actionability, consistency) and
-      auto-revises failing plans up to 2 cycles.
+      Update an existing test plan with new documentation (ADR, API specs, design docs).
+      Re-runs the 3 parallel analyzers with original + new material, uses the merge
+      sub-agent to intelligently integrate findings while preserving user edits, resolves
+      gaps, re-runs quality review, and optionally regenerates test cases. Bumps the
+      version number automatically.
+    argument_hint: "<SOURCE> <NEW_DOC_PATH> [<NEW_DOC_PATH>...]"
     arguments:
-      - name: "FEATURE_DIR"
+      - name: "SOURCE"
+        required: true
+        description: "Test plan location: local directory path, GitHub branch URL, or GitHub PR URL"
+      - name: "NEW_DOC_PATH"
+        required: true
+        description: "One or more paths to new documentation files (ADR, API spec, design doc)"
+    usage_examples:
+      - "/test-plan-update ~/Code/collection-tests/mcp_catalog adr.pdf"
+      - "/test-plan-update https://github.com/org/repo/pull/42 api-spec.md design.md"
+
+  test-plan-case-implement:
+    description: |
+      Generate executable test automation code (pytest, Go, Jest, etc.) from TC-*.md
+      test case specifications. Runs placement analysis to determine component repo vs
+      downstream E2E repo placement, loads repository conventions from odh-test-context,
+      generates test files in parallel via sub-agents, scores quality with a 5-criteria
+      rubric, and auto-revises low-scoring functions. Supports selective implementation
+      via --test-cases flag.
+    argument_hint: "<FEATURE_SOURCE> [--test-cases TC-ID,TC-ID] [--target-repo PATH]"
+    arguments:
+      - name: "FEATURE_SOURCE"
+        required: true
+        description: "Feature directory, GitHub PR URL, or GitHub branch containing test case artifacts"
+      - name: "--test-cases"
         required: false
-        default: "auto-detected"
-        description: "Feature directory containing TestPlan.md"
+        description: "Comma-separated list of specific test case IDs to implement (e.g., TC-API-001,TC-E2E-001)"
+      - name: "--target-repo"
+        required: false
+        description: "Override auto-detected target repository path or URL"
+    usage_examples:
+      - "/test-plan-case-implement features/notebooks/RHAISTRAT-400-notebook-spawning"
+      - "/test-plan-case-implement https://github.com/org/repo/pull/7"
+      - "/test-plan-case-implement features/notebooks/RHAISTRAT-400 --test-cases TC-API-001,TC-API-002"
+      - "/test-plan-case-implement features/notebooks/RHAISTRAT-400 --target-repo ~/Code/opendatahub-tests"
+
+  test-plan-ui-verify:
+    description: |
+      Browser-based UI test execution against live ODH/RHOAI clusters. Uses a two-step
+      flow: ui_prepare.py (deterministic setup in terminal) followed by Claude Code
+      execution. Loads TC-*.md files from a GitHub PR or repo folder, executes each via
+      a persistent Playwright CDP browser, and produces a visual HTML report with
+      PASS/FAIL/BLOCKED/INCOMPLETE verdicts and highlighted screenshots. Supports upgrade
+      testing workflow with pre/post phase comparison and regression detection.
+    arguments: []
+    usage_examples:
+      - "python3 scripts/ui_prepare.py --test-plan-pr https://github.com/org/repo/pull/5"
+      - "python3 scripts/ui_prepare.py --test-plan-pr <url> --tc TC-UI --priority P0"
+      - "python3 scripts/ui_prepare.py --test-plan-pr <url> --upgrade-phase pre"
+      - "/test-plan-ui-verify"
+
+  test-plan-publish:
+    description: |
+      Publish test plan artifacts to GitHub by creating a branch, committing all files,
+      and opening a pull request. Validates frontmatter and artifacts before publishing.
+      Supports updating existing PRs (pushes new commits to the same branch). Uses
+      version-free branch names (test-plan/<source_key>) for iterative updates.
+    argument_hint: "[FEATURE_SOURCE] [--repo owner/repo] [--reviewers user1,user2]"
+    arguments:
+      - name: "FEATURE_SOURCE"
+        required: false
+        default: "auto-detected from prior /test-plan-create run"
+        description: "Feature directory path, GitHub branch URL, or GitHub PR URL"
+      - name: "--repo"
+        required: false
+        description: "Target GitHub repository in owner/repo format"
+      - name: "--reviewers"
+        required: false
+        description: "Comma-separated list of GitHub usernames to assign as PR reviewers"
+    usage_examples:
+      - "/test-plan-publish tool_calling_metadata"
+      - "/test-plan-publish tool_calling_metadata --reviewers alice,bob"
+      - "/test-plan-publish tool_calling_metadata --repo org/test-plans-repo"
+
+  test-plan-resolve-feedback:
+    description: |
+      Read PR review comments from a published test plan, assess each against the
+      existing test plan content, and let the user decide which to apply. Processes
+      comments one at a time with assessment (aligns, conflicts, needs clarification,
+      already covered) and concrete change proposals. Commits and pushes approved
+      changes to the same branch with a descriptive commit message.
+    argument_hint: "<PR_URL>"
+    arguments:
+      - name: "PR_URL"
+        required: true
+        description: "Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/42)"
+    usage_examples:
+      - "/test-plan-resolve-feedback https://github.com/org/test-plans-repo/pull/42"
+
+  test-plan-score:
+    description: |
+      Score an existing test plan using the 5-criteria quality rubric (Specificity,
+      Grounding, Scope Fidelity, Actionability, Consistency) without triggering
+      auto-revision. Read-only assessment for standalone quality evaluation or
+      evaluating test plans created outside the automated pipeline.
+    argument_hint: "<feature_dir>"
+    arguments:
+      - name: "feature_dir"
+        required: true
+        description: "Path to directory containing TestPlan.md"
+    usage_examples:
+      - "/test-plan-score kagenti_agent_templates"
+      - "/test-plan-score mcp_catalog"
+
+  test-plan-analyze-endpoints:
+    description: |
+      Internal forked sub-analyzer. Extracts feature scope (in-scope, out-of-scope,
+      test objectives) and identifies API endpoints, gRPC services, Python/Go methods,
+      UI components, CLI commands, and configuration interfaces under test. Assigns
+      priorities and reports gaps. Produces findings for Sections 1 and 4 of the test plan.
+
+  test-plan-analyze-risks:
+    description: |
+      Internal forked sub-analyzer. Determines test levels (API integration, UI, security,
+      performance), test types (positive, negative, boundary, regression), feature-specific
+      priority definitions, non-functional requirement assessments (disconnected, upgrade,
+      performance, RBAC), and risks with impact/probability/mitigation. Produces findings
+      for Sections 2, 7, and 8.
+
+  test-plan-analyze-infra:
+    description: |
+      Internal forked sub-analyzer. Identifies cluster configuration requirements
+      (OpenShift/RHOAI versions, databases, runtimes), test data requirements, test
+      users (service accounts, RBAC roles), infrastructure dependencies, configuration
+      (env vars, ConfigMaps, feature gates), and test tooling. Produces findings for
+      Sections 3 and 9.
+
+  test-plan-merge:
+    description: |
+      Internal forked sub-agent for intelligent merge of new analyzer findings into
+      an existing test plan. Applies section-by-section merge logic (additive for scope
+      and endpoints, replacement for boilerplate priorities, preserving user edits).
+      Returns updated section content, change summary, and merge statistics.
+
+  test-plan-resolve-gaps:
+    description: |
+      Internal forked sub-agent that cross-references existing test plan gaps with
+      new analyzer findings and documentation. Uses semantic matching to determine
+      which gaps are resolved, which remain open, and identifies new gaps. Returns
+      structured output with resolved/unresolved/new gaps and statistics.
+
+  test-plan-analyze-placement:
+    description: |
+      Internal forked sub-agent for test case placement analysis. Classifies each TC
+      by test level (unit, integration, k8s-integration, api, e2e) and scores placement
+      options (same_repo, downstream, both) using factors: test level preferences,
+      infrastructure requirements, TC priority (P0 prefers upstream for fast feedback),
+      and code repo agent readiness. Returns recommendations with user confirmation.
+
+  test-plan-review:
+    description: |
+      Internal quality reviewer and auto-revision orchestrator. Scores test plans
+      against a 5-criteria rubric (specificity, grounding, scope fidelity, actionability,
+      consistency), each scored 0-2 for a 10-point scale. Uses forked score and review
+      agents, then enters a revision loop (max 2 cycles) where a revise agent edits
+      failing sections and re-scores. Writes TestPlanReview.md with scores, feedback,
+      and verdict (Ready/Revise/Rework).
+
+  test-plan-generate-test-file:
+    description: |
+      Internal forked sub-agent for parallel test file generation. Receives test case
+      data, repository conventions, and pattern guides. Generates complete test files
+      with framework-appropriate structure (imports, fixtures, AAA pattern functions),
+      validates syntax, scores quality via test-plan-score-test-function, and auto-revises
+      low-scoring functions. Returns result via temp file for parent to write.
+
+  test-plan-score-test-function:
+    description: |
+      Internal forked scorer sub-agent. Evaluates generated test function code using a
+      5-criteria rubric: Coverage (all TC requirements implemented), Assertions (specific
+      and meaningful), Convention Adherence (follows repo patterns), Test Data (realistic
+      values from TC), Code Quality (clean, no excessive TODOs). Returns verdict
+      (Ready/Good/Revise/Rework) with per-criterion scores and revision recommendations.

--- a/site/docs/plugins/test-plan/index.md
+++ b/site/docs/plugins/test-plan/index.md
@@ -27,6 +27,34 @@ to decide whether tests belong in the component repo or downstream E2E repo.
     - **Repository**: [opendatahub-io/odh-test-gen](https://github.com/opendatahub-io/odh-test-gen)
     - **Tags**: <span class="tag-pill">test-plan</span> <span class="tag-pill">test-cases</span> <span class="tag-pill">quality</span> <span class="tag-pill">strategy</span> <span class="tag-pill">review</span> <span class="tag-pill">scoring</span> <span class="tag-pill">automation</span> <span class="tag-pill">playwright</span> <span class="tag-pill">ui-testing</span>
 
+## Pipeline
+
+<div class="diagram-container" markdown>
+![test-plan pipeline](pipeline.svg)
+</div>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/test-plan-create`](test-plan-create.md) | Generate a test plan from a strategy | :material-check: |
+| [`/test-plan-create-cases`](test-plan-create-cases.md) | Generate test case files from a test plan | :material-check: |
+| [`/test-plan-update`](test-plan-update.md) | Update test plan with new docs (ADR, API specs), re-analyze, bump version | :material-check: |
+| [`/test-plan-case-implement`](test-plan-case-implement.md) | Generate executable test automation code from TC specifications with intelligent placement | :material-check: |
+| [`/test-plan-ui-verify`](test-plan-ui-verify.md) | Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright; supports upgrade testing workflow | :material-check: |
+| [`/test-plan-publish`](test-plan-publish.md) | Publish test plan artifacts to GitHub with PR creation | :material-check: |
+| [`/test-plan-resolve-feedback`](test-plan-resolve-feedback.md) | Assess and resolve PR review comments on test plans | :material-check: |
+| [`/test-plan-score`](test-plan-score.md) | Score test plan quality using rubric without auto-revision | :material-check: |
+| [`/test-plan-analyze-endpoints`](test-plan-analyze-endpoints.md) | Extract scope and API endpoints | :material-close: internal |
+| [`/test-plan-analyze-risks`](test-plan-analyze-risks.md) | Determine test levels, priorities, NFRs, and risks | :material-close: internal |
+| [`/test-plan-analyze-infra`](test-plan-analyze-infra.md) | Identify environment and infrastructure needs | :material-close: internal |
+| [`/test-plan-merge`](test-plan-merge.md) | Intelligently merge new analyzer findings into existing test plan | :material-close: internal |
+| [`/test-plan-resolve-gaps`](test-plan-resolve-gaps.md) | Cross-reference gaps with new findings to determine what's resolved | :material-close: internal |
+| [`/test-plan-analyze-placement`](test-plan-analyze-placement.md) | Analyze test cases and recommend placement (component repo vs downstream) | :material-close: internal |
+| [`/test-plan-review`](test-plan-review.md) | Review test plan with 5-criteria rubric and auto-revision | :material-close: internal |
+| [`/test-plan-generate-test-file`](test-plan-generate-test-file.md) | Generate complete test file with all functions, quality scoring and auto-revision | :material-close: internal |
+| [`/test-plan-score-test-function`](test-plan-score-test-function.md) | Score generated test function code using 5-criteria quality rubric | :material-close: internal |
+
 ## Architecture
 
 The plugin is organized as an orchestrated pipeline of 19 skills, split into
@@ -57,34 +85,6 @@ Key architectural patterns:
 - MCP integration (Atlassian) for fetching Jira strategies
 - Persistent Playwright CDP browser for UI verification with screenshot capture
 - odh-test-context integration for repository-specific test conventions
-
-## Pipeline
-
-<div class="diagram-container" markdown>
-![test-plan pipeline](pipeline.svg)
-</div>
-
-## Skills
-
-| Skill | Description | Invocable |
-|-------|-------------|-----------|
-| [`/test-plan-create`](test-plan-create.md) | Generate a test plan from a strategy | :material-check: |
-| [`/test-plan-create-cases`](test-plan-create-cases.md) | Generate test case files from a test plan | :material-check: |
-| [`/test-plan-update`](test-plan-update.md) | Update test plan with new docs (ADR, API specs), re-analyze, bump version | :material-check: |
-| [`/test-plan-case-implement`](test-plan-case-implement.md) | Generate executable test automation code from TC specifications with intelligent placement | :material-check: |
-| [`/test-plan-ui-verify`](test-plan-ui-verify.md) | Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright; supports upgrade testing workflow | :material-check: |
-| [`/test-plan-publish`](test-plan-publish.md) | Publish test plan artifacts to GitHub with PR creation | :material-check: |
-| [`/test-plan-resolve-feedback`](test-plan-resolve-feedback.md) | Assess and resolve PR review comments on test plans | :material-check: |
-| [`/test-plan-score`](test-plan-score.md) | Score test plan quality using rubric without auto-revision | :material-check: |
-| [`/test-plan-analyze-endpoints`](test-plan-analyze-endpoints.md) | Extract scope and API endpoints | :material-close: internal |
-| [`/test-plan-analyze-risks`](test-plan-analyze-risks.md) | Determine test levels, priorities, NFRs, and risks | :material-close: internal |
-| [`/test-plan-analyze-infra`](test-plan-analyze-infra.md) | Identify environment and infrastructure needs | :material-close: internal |
-| [`/test-plan-merge`](test-plan-merge.md) | Intelligently merge new analyzer findings into existing test plan | :material-close: internal |
-| [`/test-plan-resolve-gaps`](test-plan-resolve-gaps.md) | Cross-reference gaps with new findings to determine what's resolved | :material-close: internal |
-| [`/test-plan-analyze-placement`](test-plan-analyze-placement.md) | Analyze test cases and recommend placement (component repo vs downstream) | :material-close: internal |
-| [`/test-plan-review`](test-plan-review.md) | Review test plan with 5-criteria rubric and auto-revision | :material-close: internal |
-| [`/test-plan-generate-test-file`](test-plan-generate-test-file.md) | Generate complete test file with all functions, quality scoring and auto-revision | :material-close: internal |
-| [`/test-plan-score-test-function`](test-plan-score-test-function.md) | Score generated test function code using 5-criteria quality rubric | :material-close: internal |
 
 ## Installation
 

--- a/site/docs/plugins/test-plan/index.md
+++ b/site/docs/plugins/test-plan/index.md
@@ -55,6 +55,12 @@ to decide whether tests belong in the component repo or downstream E2E repo.
 | [`/test-plan-generate-test-file`](test-plan-generate-test-file.md) | Generate complete test file with all functions, quality scoring and auto-revision | :material-close: internal |
 | [`/test-plan-score-test-function`](test-plan-score-test-function.md) | Score generated test function code using 5-criteria quality rubric | :material-close: internal |
 
+## Installation
+
+```bash
+/plugin install test-plan@opendatahub-skills
+```
+
 ## Architecture
 
 The plugin is organized as an orchestrated pipeline of 19 skills, split into
@@ -85,9 +91,3 @@ Key architectural patterns:
 - MCP integration (Atlassian) for fetching Jira strategies
 - Persistent Playwright CDP browser for UI verification with screenshot capture
 - odh-test-context integration for repository-specific test conventions
-
-## Installation
-
-```bash
-/plugin install test-plan@opendatahub-skills
-```

--- a/site/docs/plugins/test-plan/index.md
+++ b/site/docs/plugins/test-plan/index.md
@@ -7,8 +7,16 @@ title: test-plan
 
 # test-plan
 
-Generate test plans and test cases from RHOAI strategies using parallel
-sub-agent analysis and automated review with a 5-criteria quality rubric.
+End-to-end test planning and automation workflow for RHOAI (Red Hat OpenShift AI).
+Takes a Jira strategy document as input and produces a complete test plan, individual
+test case specifications, executable test automation code, and visual UI verification
+reports. The pipeline uses parallel sub-agent analysis (endpoints, risks, infrastructure)
+to extract testable interfaces, then scores quality with a 5-criteria rubric and
+auto-revises up to 2 cycles. Supports the full lifecycle: create, review, publish to
+GitHub, resolve PR feedback, update with new documentation, and verify UI test cases
+against live clusters via Playwright. Test code generation uses odh-test-context for
+repo-specific conventions, Tiger Team pattern guides, and intelligent placement analysis
+to decide whether tests belong in the component repo or downstream E2E repo.
 
 
 !!! info "Plugin Details"
@@ -18,6 +26,37 @@ sub-agent analysis and automated review with a 5-criteria quality rubric.
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
     - **Repository**: [opendatahub-io/odh-test-gen](https://github.com/opendatahub-io/odh-test-gen)
     - **Tags**: <span class="tag-pill">test-plan</span> <span class="tag-pill">test-cases</span> <span class="tag-pill">quality</span> <span class="tag-pill">strategy</span> <span class="tag-pill">review</span> <span class="tag-pill">scoring</span> <span class="tag-pill">automation</span> <span class="tag-pill">playwright</span> <span class="tag-pill">ui-testing</span>
+
+## Architecture
+
+The plugin is organized as an orchestrated pipeline of 19 skills, split into
+user-invocable commands and internal forked sub-agents:
+
+**User-invocable pipeline stages:**
+1. test-plan-create -- generates a test plan from a Jira strategy with 3 parallel analyzers
+2. test-plan-create-cases -- generates TC-*.md files from the test plan
+3. test-plan-update -- re-analyzes with new documents, merges findings, bumps version
+4. test-plan-case-implement -- generates executable test code with placement analysis
+5. test-plan-ui-verify -- browser-based UI test execution via Playwright CDP
+6. test-plan-publish -- creates/updates GitHub PRs with test plan artifacts
+7. test-plan-resolve-feedback -- triages and applies PR review comments
+8. test-plan-score -- standalone quality rubric assessment (read-only)
+
+**Internal sub-agents (context: fork):**
+- test-plan-analyze-endpoints, test-plan-analyze-risks, test-plan-analyze-infra -- parallel analyzers
+- test-plan-merge -- intelligent merge of new findings into existing plans
+- test-plan-resolve-gaps -- cross-references gaps with new documentation
+- test-plan-analyze-placement -- recommends component vs downstream repo placement
+- test-plan-review -- quality scoring + auto-revision loop (max 2 cycles)
+- test-plan-generate-test-file -- parallel test file generation sub-agent
+- test-plan-score-test-function -- quality scoring for generated test functions
+
+Key architectural patterns:
+- Parallel forked sub-agents for analysis and code generation (isolated context, clean return)
+- Python scripts for deterministic operations (frontmatter, validation, file mapping, repo utilities)
+- MCP integration (Atlassian) for fetching Jira strategies
+- Persistent Playwright CDP browser for UI verification with screenshot capture
+- odh-test-context integration for repository-specific test conventions
 
 ## Pipeline
 

--- a/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
@@ -19,3 +19,9 @@ priorities and reports gaps. Produces findings for Sections 1 and 4 of the test 
 <div class="diagram-container" markdown>
 ![test-plan-analyze-endpoints diagram](test-plan-analyze-endpoints.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-analyze-endpoints
+```

--- a/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
@@ -7,7 +7,10 @@ title: test-plan-analyze-endpoints
 
 # test-plan-analyze-endpoints
 
-Extract scope and API endpoints
+Internal forked sub-analyzer. Extracts feature scope (in-scope, out-of-scope,
+test objectives) and identifies API endpoints, gRPC services, Python/Go methods,
+UI components, CLI commands, and configuration interfaces under test. Assigns
+priorities and reports gaps. Produces findings for Sections 1 and 4 of the test plan.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-analyze-infra.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-infra.md
@@ -7,7 +7,11 @@ title: test-plan-analyze-infra
 
 # test-plan-analyze-infra
 
-Identify environment and infrastructure needs
+Internal forked sub-analyzer. Identifies cluster configuration requirements
+(OpenShift/RHOAI versions, databases, runtimes), test data requirements, test
+users (service accounts, RBAC roles), infrastructure dependencies, configuration
+(env vars, ConfigMaps, feature gates), and test tooling. Produces findings for
+Sections 3 and 9.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-analyze-infra.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-infra.md
@@ -20,3 +20,9 @@ Sections 3 and 9.
 <div class="diagram-container" markdown>
 ![test-plan-analyze-infra diagram](test-plan-analyze-infra.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-analyze-infra
+```

--- a/site/docs/plugins/test-plan/test-plan-analyze-placement.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-placement.md
@@ -20,3 +20,9 @@ and code repo agent readiness. Returns recommendations with user confirmation.
 <div class="diagram-container" markdown>
 ![test-plan-analyze-placement diagram](test-plan-analyze-placement.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-analyze-placement
+```

--- a/site/docs/plugins/test-plan/test-plan-analyze-placement.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-placement.md
@@ -7,7 +7,11 @@ title: test-plan-analyze-placement
 
 # test-plan-analyze-placement
 
-Analyze test cases and recommend placement (component repo vs downstream)
+Internal forked sub-agent for test case placement analysis. Classifies each TC
+by test level (unit, integration, k8s-integration, api, e2e) and scores placement
+options (same_repo, downstream, both) using factors: test level preferences,
+infrastructure requirements, TC priority (P0 prefers upstream for fast feedback),
+and code repo agent readiness. Returns recommendations with user confirmation.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-analyze-risks.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-risks.md
@@ -20,3 +20,9 @@ for Sections 2, 7, and 8.
 <div class="diagram-container" markdown>
 ![test-plan-analyze-risks diagram](test-plan-analyze-risks.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-analyze-risks
+```

--- a/site/docs/plugins/test-plan/test-plan-analyze-risks.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-risks.md
@@ -7,7 +7,11 @@ title: test-plan-analyze-risks
 
 # test-plan-analyze-risks
 
-Determine test levels, priorities, NFRs, and risks
+Internal forked sub-analyzer. Determines test levels (API integration, UI, security,
+performance), test types (positive, negative, boundary, regression), feature-specific
+priority definitions, non-functional requirement assessments (disconnected, upgrade,
+performance, RBAC), and risks with impact/probability/mitigation. Produces findings
+for Sections 2, 7, and 8.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-case-implement.md
+++ b/site/docs/plugins/test-plan/test-plan-case-implement.md
@@ -7,7 +7,12 @@ title: test-plan-case-implement
 
 # test-plan-case-implement
 
-Generate executable test automation code from TC specifications with intelligent placement
+Generate executable test automation code (pytest, Go, Jest, etc.) from TC-*.md
+test case specifications. Runs placement analysis to determine component repo vs
+downstream E2E repo placement, loads repository conventions from odh-test-context,
+generates test files in parallel via sub-agents, scores quality with a 5-criteria
+rubric, and auto-revises low-scoring functions. Supports selective implementation
+via --test-cases flag.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +21,24 @@ Generate executable test automation code from TC specifications with intelligent
 <div class="diagram-container" markdown>
 ![test-plan-case-implement diagram](test-plan-case-implement.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-case-implement <FEATURE_SOURCE> [--test-cases TC-ID,TC-ID] [--target-repo PATH]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `FEATURE_SOURCE` | :material-check: | — | Feature directory, GitHub PR URL, or GitHub branch containing test case artifacts |
+| `--test-cases` |  | — | Comma-separated list of specific test case IDs to implement (e.g., TC-API-001,TC-E2E-001) |
+| `--target-repo` |  | — | Override auto-detected target repository path or URL |
+
+## Usage
+
+```
+/test-plan-case-implement features/notebooks/RHAISTRAT-400-notebook-spawning
+/test-plan-case-implement https://github.com/org/repo/pull/7
+/test-plan-case-implement features/notebooks/RHAISTRAT-400 --test-cases TC-API-001,TC-API-002
+/test-plan-case-implement features/notebooks/RHAISTRAT-400 --target-repo ~/Code/opendatahub-tests
+```

--- a/site/docs/plugins/test-plan/test-plan-create-cases.md
+++ b/site/docs/plugins/test-plan/test-plan-create-cases.md
@@ -7,7 +7,10 @@ title: test-plan-create-cases
 
 # test-plan-create-cases
 
-Generate test case files from a test plan
+Generate individual test case specification files (TC-*.md) from an existing test plan.
+Processes categories one at a time, generates E2E and optional upgrade test cases,
+validates endpoint coverage, and updates the test plan with traceability data.
+Supports regeneration mode for updating existing test cases.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +19,22 @@ Generate test case files from a test plan
 <div class="diagram-container" markdown>
 ![test-plan-create-cases diagram](test-plan-create-cases.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-create-cases [FEATURE_SOURCE] [--output-dir PATH]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `FEATURE_SOURCE` |  | `auto-detected from prior /test-plan-create run` | Feature directory path, GitHub branch URL, or GitHub PR URL |
+| `--output-dir` |  | — | Force creation in specified directory (contributor override) |
+
+## Usage
+
+```
+/test-plan-create-cases
+/test-plan-create-cases mcp_catalog
+/test-plan-create-cases /path/to/feature_dir
+```

--- a/site/docs/plugins/test-plan/test-plan-create.md
+++ b/site/docs/plugins/test-plan/test-plan-create.md
@@ -7,7 +7,12 @@ title: test-plan-create
 
 # test-plan-create
 
-Generate a test plan from a strategy
+Generate a complete test plan for a RHOAI feature from a Jira strategy
+(RHAISTRAT or RHOAIENG issue), with optional ADR for additional technical depth.
+Spawns 3 parallel sub-analyzers (endpoints, risks, infra), merges their findings
+into a structured template, collects gaps into TestPlanGaps.md, then runs an
+automated quality review with scoring and up to 2 auto-revision cycles. Produces
+TestPlan.md, TestPlanGaps.md, TestPlanReview.md, and README.md in a feature directory.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +21,23 @@ Generate a test plan from a strategy
 <div class="diagram-container" markdown>
 ![test-plan-create diagram](test-plan-create.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-create <JIRA_KEY> [ADR_FILE_PATH]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `JIRA_KEY` | :material-check: | — | Jira strategy key (RHAISTRAT-*) or issue key (RHOAIENG-*) to generate the test plan from |
+| `ADR_FILE_PATH` |  | — | Local path to an ADR document (markdown, text, or PDF) for additional technical depth |
+| `--output-dir` |  | — | Override output directory for test plan artifacts (skips validation) |
+
+## Usage
+
+```
+/test-plan-create RHAISTRAT-400
+/test-plan-create RHOAIENG-48676
+/test-plan-create RHAISTRAT-400 /path/to/adr.pdf
+```

--- a/site/docs/plugins/test-plan/test-plan-generate-test-file.md
+++ b/site/docs/plugins/test-plan/test-plan-generate-test-file.md
@@ -20,3 +20,9 @@ low-scoring functions. Returns result via temp file for parent to write.
 <div class="diagram-container" markdown>
 ![test-plan-generate-test-file diagram](test-plan-generate-test-file.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-generate-test-file
+```

--- a/site/docs/plugins/test-plan/test-plan-generate-test-file.md
+++ b/site/docs/plugins/test-plan/test-plan-generate-test-file.md
@@ -7,7 +7,11 @@ title: test-plan-generate-test-file
 
 # test-plan-generate-test-file
 
-Generate complete test file with all functions, quality scoring and auto-revision
+Internal forked sub-agent for parallel test file generation. Receives test case
+data, repository conventions, and pattern guides. Generates complete test files
+with framework-appropriate structure (imports, fixtures, AAA pattern functions),
+validates syntax, scores quality via test-plan-score-test-function, and auto-revises
+low-scoring functions. Returns result via temp file for parent to write.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-merge.md
+++ b/site/docs/plugins/test-plan/test-plan-merge.md
@@ -19,3 +19,9 @@ Returns updated section content, change summary, and merge statistics.
 <div class="diagram-container" markdown>
 ![test-plan-merge diagram](test-plan-merge.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-merge
+```

--- a/site/docs/plugins/test-plan/test-plan-merge.md
+++ b/site/docs/plugins/test-plan/test-plan-merge.md
@@ -7,7 +7,10 @@ title: test-plan-merge
 
 # test-plan-merge
 
-Intelligently merge new analyzer findings into existing test plan
+Internal forked sub-agent for intelligent merge of new analyzer findings into
+an existing test plan. Applies section-by-section merge logic (additive for scope
+and endpoints, replacement for boilerplate priorities, preserving user edits).
+Returns updated section content, change summary, and merge statistics.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-publish.md
+++ b/site/docs/plugins/test-plan/test-plan-publish.md
@@ -7,7 +7,10 @@ title: test-plan-publish
 
 # test-plan-publish
 
-Publish test plan artifacts to GitHub with PR creation
+Publish test plan artifacts to GitHub by creating a branch, committing all files,
+and opening a pull request. Validates frontmatter and artifacts before publishing.
+Supports updating existing PRs (pushes new commits to the same branch). Uses
+version-free branch names (test-plan/<source_key>) for iterative updates.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +19,23 @@ Publish test plan artifacts to GitHub with PR creation
 <div class="diagram-container" markdown>
 ![test-plan-publish diagram](test-plan-publish.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-publish [FEATURE_SOURCE] [--repo owner/repo] [--reviewers user1,user2]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `FEATURE_SOURCE` |  | `auto-detected from prior /test-plan-create run` | Feature directory path, GitHub branch URL, or GitHub PR URL |
+| `--repo` |  | — | Target GitHub repository in owner/repo format |
+| `--reviewers` |  | — | Comma-separated list of GitHub usernames to assign as PR reviewers |
+
+## Usage
+
+```
+/test-plan-publish tool_calling_metadata
+/test-plan-publish tool_calling_metadata --reviewers alice,bob
+/test-plan-publish tool_calling_metadata --repo org/test-plans-repo
+```

--- a/site/docs/plugins/test-plan/test-plan-resolve-feedback.md
+++ b/site/docs/plugins/test-plan/test-plan-resolve-feedback.md
@@ -7,7 +7,11 @@ title: test-plan-resolve-feedback
 
 # test-plan-resolve-feedback
 
-Assess and resolve PR review comments on test plans
+Read PR review comments from a published test plan, assess each against the
+existing test plan content, and let the user decide which to apply. Processes
+comments one at a time with assessment (aligns, conflicts, needs clarification,
+already covered) and concrete change proposals. Commits and pushes approved
+changes to the same branch with a descriptive commit message.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,19 @@ Assess and resolve PR review comments on test plans
 <div class="diagram-container" markdown>
 ![test-plan-resolve-feedback diagram](test-plan-resolve-feedback.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-resolve-feedback <PR_URL>
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PR_URL` | :material-check: | — | Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/42) |
+
+## Usage
+
+```
+/test-plan-resolve-feedback https://github.com/org/test-plans-repo/pull/42
+```

--- a/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
+++ b/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
@@ -19,3 +19,9 @@ structured output with resolved/unresolved/new gaps and statistics.
 <div class="diagram-container" markdown>
 ![test-plan-resolve-gaps diagram](test-plan-resolve-gaps.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-resolve-gaps
+```

--- a/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
+++ b/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
@@ -7,7 +7,10 @@ title: test-plan-resolve-gaps
 
 # test-plan-resolve-gaps
 
-Cross-reference gaps with new findings to determine what's resolved
+Internal forked sub-agent that cross-references existing test plan gaps with
+new analyzer findings and documentation. Uses semantic matching to determine
+which gaps are resolved, which remain open, and identifies new gaps. Returns
+structured output with resolved/unresolved/new gaps and statistics.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-review.md
+++ b/site/docs/plugins/test-plan/test-plan-review.md
@@ -7,7 +7,12 @@ title: test-plan-review
 
 # test-plan-review
 
-Review test plan with 5-criteria rubric and auto-revision
+Internal quality reviewer and auto-revision orchestrator. Scores test plans
+against a 5-criteria rubric (specificity, grounding, scope fidelity, actionability,
+consistency), each scored 0-2 for a 10-point scale. Uses forked score and review
+agents, then enters a revision loop (max 2 cycles) where a revise agent edits
+failing sections and re-scores. Writes TestPlanReview.md with scores, feedback,
+and verdict (Ready/Revise/Rework).
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-review.md
+++ b/site/docs/plugins/test-plan/test-plan-review.md
@@ -21,3 +21,9 @@ and verdict (Ready/Revise/Rework).
 <div class="diagram-container" markdown>
 ![test-plan-review diagram](test-plan-review.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-review
+```

--- a/site/docs/plugins/test-plan/test-plan-score-test-function.md
+++ b/site/docs/plugins/test-plan/test-plan-score-test-function.md
@@ -20,3 +20,9 @@ values from TC), Code Quality (clean, no excessive TODOs). Returns verdict
 <div class="diagram-container" markdown>
 ![test-plan-score-test-function diagram](test-plan-score-test-function.svg)
 </div>
+
+## Usage
+
+```
+/test-plan-score-test-function
+```

--- a/site/docs/plugins/test-plan/test-plan-score-test-function.md
+++ b/site/docs/plugins/test-plan/test-plan-score-test-function.md
@@ -7,7 +7,11 @@ title: test-plan-score-test-function
 
 # test-plan-score-test-function
 
-Score generated test function code using 5-criteria quality rubric
+Internal forked scorer sub-agent. Evaluates generated test function code using a
+5-criteria rubric: Coverage (all TC requirements implemented), Assertions (specific
+and meaningful), Convention Adherence (follows repo patterns), Test Data (realistic
+values from TC), Code Quality (clean, no excessive TODOs). Returns verdict
+(Ready/Good/Revise/Rework) with per-criterion scores and revision recommendations.
 
 **Plugin**: [test-plan](index.md) | **:material-close: Internal**
 

--- a/site/docs/plugins/test-plan/test-plan-score.md
+++ b/site/docs/plugins/test-plan/test-plan-score.md
@@ -7,7 +7,10 @@ title: test-plan-score
 
 # test-plan-score
 
-Score test plan quality using rubric without auto-revision
+Score an existing test plan using the 5-criteria quality rubric (Specificity,
+Grounding, Scope Fidelity, Actionability, Consistency) without triggering
+auto-revision. Read-only assessment for standalone quality evaluation or
+evaluating test plans created outside the automated pipeline.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +19,20 @@ Score test plan quality using rubric without auto-revision
 <div class="diagram-container" markdown>
 ![test-plan-score diagram](test-plan-score.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-score <feature_dir>
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `feature_dir` | :material-check: | — | Path to directory containing TestPlan.md |
+
+## Usage
+
+```
+/test-plan-score kagenti_agent_templates
+/test-plan-score mcp_catalog
+```

--- a/site/docs/plugins/test-plan/test-plan-ui-verify.md
+++ b/site/docs/plugins/test-plan/test-plan-ui-verify.md
@@ -7,7 +7,12 @@ title: test-plan-ui-verify
 
 # test-plan-ui-verify
 
-Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright; supports upgrade testing workflow
+Browser-based UI test execution against live ODH/RHOAI clusters. Uses a two-step
+flow: ui_prepare.py (deterministic setup in terminal) followed by Claude Code
+execution. Loads TC-*.md files from a GitHub PR or repo folder, executes each via
+a persistent Playwright CDP browser, and produces a visual HTML report with
+PASS/FAIL/BLOCKED/INCOMPLETE verdicts and highlighted screenshots. Supports upgrade
+testing workflow with pre/post phase comparison and regression detection.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +21,12 @@ Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright; 
 <div class="diagram-container" markdown>
 ![test-plan-ui-verify diagram](test-plan-ui-verify.svg)
 </div>
+
+## Usage
+
+```
+python3 scripts/ui_prepare.py --test-plan-pr https://github.com/org/repo/pull/5
+python3 scripts/ui_prepare.py --test-plan-pr <url> --tc TC-UI --priority P0
+python3 scripts/ui_prepare.py --test-plan-pr <url> --upgrade-phase pre
+/test-plan-ui-verify
+```

--- a/site/docs/plugins/test-plan/test-plan-update.md
+++ b/site/docs/plugins/test-plan/test-plan-update.md
@@ -7,7 +7,11 @@ title: test-plan-update
 
 # test-plan-update
 
-Update test plan with new docs (ADR, API specs), re-analyze, bump version
+Update an existing test plan with new documentation (ADR, API specs, design docs).
+Re-runs the 3 parallel analyzers with original + new material, uses the merge
+sub-agent to intelligently integrate findings while preserving user edits, resolves
+gaps, re-runs quality review, and optionally regenerates test cases. Bumps the
+version number automatically.
 
 **Plugin**: [test-plan](index.md) | **:material-check: User-invocable**
 
@@ -16,3 +20,21 @@ Update test plan with new docs (ADR, API specs), re-analyze, bump version
 <div class="diagram-container" markdown>
 ![test-plan-update diagram](test-plan-update.svg)
 </div>
+
+## Arguments
+
+```
+/test-plan-update <SOURCE> <NEW_DOC_PATH> [<NEW_DOC_PATH>...]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SOURCE` | :material-check: | — | Test plan location: local directory path, GitHub branch URL, or GitHub PR URL |
+| `NEW_DOC_PATH` | :material-check: | — | One or more paths to new documentation files (ADR, API spec, design doc) |
+
+## Usage
+
+```
+/test-plan-update ~/Code/collection-tests/mcp_catalog adr.pdf
+/test-plan-update https://github.com/org/repo/pull/42 api-spec.md design.md
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: OpenDataHub Skills Registry
 site_url: https://opendatahub-io.github.io/skills-registry
+repo_url: https://github.com/opendatahub-io/skills-registry
+repo_name: opendatahub-io/skills-registry
 
 theme:
   name: material

--- a/skills/analyze-plugin/SKILL.md
+++ b/skills/analyze-plugin/SKILL.md
@@ -27,6 +27,9 @@ and generate enriched documentation pages with SVG diagrams for the skills-regis
 
 - `<plugin-name>` — Name of the plugin as it appears in `registry.yaml` (e.g., `rfe-creator`).
   If omitted, list available plugins and ask the user to choose.
+- `--no-diagrams` — Skip diagram generation (Steps 5-6). Only clone, read SKILL.md files,
+  and generate the enrichment YAML. Useful for refreshing descriptions, arguments, and
+  argument hints without the slow diagram pipeline.
 
 ## Instructions
 
@@ -117,11 +120,17 @@ remaining skills.
 Extract from each SKILL.md:
 - **Frontmatter** fields (description, allowed-tools, user-invocable, argument-hint, etc.)
 - **Detailed description** — the full markdown content beyond the frontmatter
-- **Arguments** — look for "Parse Arguments", "Arguments", "Usage" sections. Extract from
-  markdown tables, bullet lists, or usage code blocks. Capture: name, type/format,
-  required/optional, default value, description. For positional arguments, use descriptive
-  names (e.g., "input", "plugin-name"). Also extract usage examples (invocation patterns
-  like `/skill-name arg1 arg2`). If the frontmatter has `argument-hint`, use it as a guide.
+- **argument-hint** — if present in frontmatter, store it as `argument_hint` in the
+  enrichment. Then use it as the starting point for building the arguments list:
+  parse each token (`<NAME>` = required, `[NAME]` = optional, `--flag` = flag),
+  then search the SKILL.md body for descriptions of each argument name. Look for
+  the argument name in headings, table rows, bullet lists, or prose near "Parse
+  Arguments", "Inputs", "Arguments", or "Usage" sections.
+- **Arguments** — look for "Parse Arguments", "Arguments", "Usage", "Inputs" sections.
+  Extract from markdown tables, bullet lists, or usage code blocks. Capture: name,
+  type/format, required/optional, default value, description. If `argument-hint`
+  was already parsed, merge — the hint provides names and required/optional status,
+  the body provides descriptions and types.
 - **Usage examples** — any example invocations or usage patterns
 - **Input/output** — what the skill takes and produces
 - **Architecture notes** — how the skill works internally (sub-agents, scripts, prompts)
@@ -143,15 +152,22 @@ skills:
   skill-name:
     description: |
       Detailed description from the SKILL.md content.
+    argument_hint: "<REQUIRED_ARG> [OPTIONAL_ARG] --flag"
     arguments:
+      - name: "REQUIRED_ARG"
+        required: true
+        description: "Description inferred from SKILL.md body"
+      - name: "OPTIONAL_ARG"
+        required: false
+        description: "Description inferred from SKILL.md body"
       - name: "--flag"
         type: "(value type)"
         required: false
         default: "default-value"
         description: "What this argument does"
     usage_examples:
+      - "/skill-name <REQUIRED_ARG> [OPTIONAL_ARG]"
       - "/skill-name --flag value"
-      - "/skill-name positional-arg"
   # ... repeat for each skill
 ```
 
@@ -159,6 +175,8 @@ The description should be richer than the one-line registry description — it s
 explain what the plugin does, why, and how. Keep it concise but informative (2-4 paragraphs).
 
 ### 5. Generate pipeline diagram
+
+**Skip this step if `--no-diagrams` is set.**
 
 Invoke `/skill-diagram` to create a pipeline diagram showing all skills in the plugin.
 The `--layout` flag chains to `/diagram-layout` automatically — do not invoke diagram-layout
@@ -176,6 +194,8 @@ mv site/docs/plugins/<plugin-name>/pipeline.drawio.svg site/docs/plugins/<plugin
 ```
 
 ### 6. Generate individual skill diagrams
+
+**Skip this step if `--no-diagrams` is set.**
 
 For each skill, invoke `/skill-diagram` to create a detailed architecture diagram.
 Use sub-agents with `run_in_background: true` to generate diagrams **in parallel** —

--- a/skills/generate-site/SKILL.md
+++ b/skills/generate-site/SKILL.md
@@ -20,48 +20,31 @@ allowed-tools:
 
 # generate-site
 
-Generate the complete documentation site for the skills-registry. Produces structural
-pages from `registry.yaml` and optionally enriches each plugin with detailed content
-and SVG diagrams via `/analyze-plugin`.
+Generate the complete documentation site for the skills-registry. Enriches each plugin
+with detailed content extracted from SKILL.md files, generates presentation-quality SVG
+diagrams, and produces structural pages from `registry.yaml`.
 
 ## Arguments
 
-- `--structure-only` — Only generate structural pages (no enrichment or diagrams).
-  Equivalent to running `python3 scripts/generate_site.py` directly.
-- `--enrich` — Also run `/analyze-plugin` for each plugin to generate enrichment
-  and diagrams. This is slower but produces richer content.
-- `--plugin <name>` — Only enrich a specific plugin. Implies `--enrich` — you don't
-  need to pass both.
-
-If no arguments are provided, defaults to `--structure-only`.
+- `--plugin <name>` — Only process a specific plugin. Without this, all plugins are processed.
+- `--no-diagrams` — Skip diagram generation (enrichment only). Useful for refreshing
+  descriptions, arguments, and argument hints without the slow diagram pipeline.
 
 ## Instructions
 
-### 1. Generate structural pages
+### 1. Enrich plugins
 
-```bash
-python3 scripts/generate_site.py
-```
+Invoke `/analyze-plugin` for each plugin in the registry (or just the `--plugin` if specified).
 
-This reads `registry.yaml` and generates all markdown pages and the `mkdocs.yml`
-navigation under `site/`. It preserves non-markdown files (SVGs, drawio, enrichment
-YAMLs) — only `.md` files are regenerated.
-
-Report the counts: plugins, skills, categories.
-
-### 2. Enrich plugins (if --enrich or --plugin)
-
-If `--enrich` or `--plugin` is specified, invoke `/analyze-plugin` for each plugin
-in the registry (or just the specified `--plugin`).
+If `--no-diagrams` is set, pass it through to `/analyze-plugin` so it skips Steps 5-6
+(pipeline and individual skill diagrams) and only generates the enrichment YAML.
 
 For efficiency, use sub-agents to analyze plugins **in parallel** (up to 6-8 at a time).
-Each agent clones the plugin repo, reads SKILL.md files, generates enrichment YAML,
-and produces pipeline + individual skill diagrams via `/skill-diagram --layout`.
 
 ```
 Agent({
   description: "Analyze <plugin-name>",
-  prompt: "/analyze-plugin <plugin-name>",
+  prompt: "/analyze-plugin <plugin-name> [--no-diagrams]",
   run_in_background: true
 })
 ```
@@ -72,7 +55,7 @@ Wait for all to complete before proceeding.
 #### Permissions
 
 Sub-agents need these permissions to work in the background without interactive approval.
-Verify these are in `.claude/settings.local.json` before launching:
+Verify these are in `.claude/settings.json` before launching:
 
 ```json
 {
@@ -81,9 +64,18 @@ Verify these are in `.claude/settings.local.json` before launching:
       "Read(.tmp/skill-repos/**)",
       "Write(site/docs/plugins/**)",
       "Edit(site/docs/plugins/**)",
-      "Bash(python3:*)",
-      "Bash(d2:*)",
-      "Bash(open:*)"
+      "Bash(python3 *)",
+      "Bash(d2 *)",
+      "Bash(mkdir *)",
+      "Bash(mv *)",
+      "Bash(find *)",
+      "Bash(rm *)",
+      "Bash(git clone *)",
+      "Bash(git pull *)",
+      "Bash(open *)",
+      "Bash(ls *)",
+      "Skill(diagram-skills:skill-diagram:*)",
+      "Skill(diagram-skills:diagram-layout:*)"
     ]
   }
 }
@@ -92,7 +84,7 @@ Verify these are in `.claude/settings.local.json` before launching:
 If permissions are missing, warn the user and suggest adding them before proceeding —
 otherwise every sub-agent will be denied and the enrichment pass will fail silently.
 
-### 3. Clean up after enrichment
+### 2. Clean up after enrichment
 
 After all enrichment agents complete, clean up stray files produced by the
 diagram-layout pipeline:
@@ -106,7 +98,7 @@ find site/docs/plugins -name "*.drawio.png" -delete
 find site/docs/plugins -name "layout-plan.json" -delete
 ```
 
-### 4. Regenerate with enrichments
+### 3. Generate pages
 
 After cleanup, run the generation script again to merge enrichment data into pages:
 
@@ -114,10 +106,10 @@ After cleanup, run the generation script again to merge enrichment data into pag
 python3 scripts/generate_site.py
 ```
 
-This picks up `_enriched.yaml` files and conditionally includes SVG diagram references
-in pages where the SVG exists.
+This picks up `_enriched.yaml` files (including `argument_hint` and `arguments`) and
+conditionally includes SVG diagram references in pages where the SVG exists.
 
-### 5. Build and verify
+### 4. Build and verify
 
 Stop any running dev server first (it holds a file lock):
 
@@ -134,12 +126,12 @@ mkdocs build --config-file site/mkdocs.yml --site-dir /tmp/skills-site-verify-$$
 Check the build output for warnings or errors. Zero warnings is the target — any
 "unrecognized relative link" or "target not found" warnings indicate broken references.
 
-### 6. Report
+### 5. Report
 
 Report:
 - Total pages generated
-- Plugins enriched (if --enrich)
-- Diagrams generated (if --enrich) — pipeline + individual count
+- Plugins enriched
+- Diagrams generated (if not `--no-diagrams`) — pipeline + individual count
 - Build status (success/warnings/errors)
 - Any skipped skills or failed diagram exports
 


### PR DESCRIPTION
## Summary

Enrichment improvements, site generation updates, and UI fixes across all 8 plugins.

### Skill improvements
- **analyze-plugin**: --no-diagrams flag to skip diagram generation, argument_hint extraction from SKILL.md frontmatter with description inference from skill body
- **generate-site**: simplified flow (always enrich, --plugin filters, --no-diagrams passes through)

### Site generation (generate_site.py)
- Show argument invocation example on all skill pages — from argument_hint or auto-generated from arguments list
- Show basic usage section on skills without arguments
- Move Architecture section after Installation (deep-dive content at bottom)
- Add GitHub repo link to site header
- Fix GitHub link color in light mode

### Enrichment refresh
- All 8 plugins re-enriched with argument_hint fields and expanded descriptions
- 71 skills enriched (no diagram changes)

### Housekeeping
- Add diagram artifacts to .gitignore