### PR TITLE
Restyle site: Google Sans Flex, reduced margins, polished tables

### DIFF
--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -26,7 +26,7 @@ repo_name: opendatahub-io/skills-registry
 theme:
   name: material
   font:
-    text: JetBrains Mono
+    text: Google Sans Flex
     code: JetBrains Mono
   palette:
     - media: "(prefers-color-scheme: light)"

--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -73,8 +73,8 @@
   max-width: 75rem;
 }
 
-.md-content {
-  padding-top: 1.5rem;
+.md-main__inner {
+  margin-top: 0;
 }
 
 /* ── Header ── */
@@ -290,7 +290,7 @@
   background: var(--sr-surface);
   color: var(--sr-heading-h2);
   text-align: left;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -298,6 +298,23 @@
 .md-typeset table:not([class]) td {
   padding: 0.7em 1em;
   border-bottom: 1px solid var(--sr-border);
+  font-size: 0.72rem;
+}
+
+.md-typeset table:not([class]) code {
+  font-size: 0.85em;
+  display: inline-block;
+  padding: 0.1em 0.35em;
+  line-height: 1.4;
+}
+
+.md-typeset table:not([class]) td:first-child code {
+  white-space: nowrap;
+}
+
+.md-typeset table:not([class]) td:nth-child(3) code {
+  overflow-wrap: break-word;
+  word-break: keep-all;
 }
 
 .md-typeset table:not([class]) tr:last-child td {

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -6,7 +6,7 @@ repo_name: opendatahub-io/skills-registry
 theme:
   name: material
   font:
-    text: JetBrains Mono
+    text: Google Sans Flex
     code: JetBrains Mono
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
## Summary

- Switch body font from JetBrains Mono to Google Sans Flex (code stays JetBrains Mono)
- Remove top margin gap between tabs bar and content/sidebar
- Normalize table font sizes to match body text (0.72rem)

## Test plan
- [ ] Verify Google Sans Flex loads for body text
- [ ] Code blocks still use JetBrains Mono
- [ ] No gap between tabs and content
- [ ] Argument tables have consistent font size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation site typography: primary font changed to Google Sans Flex for improved text rendering
  * Refined page layout spacing and table cell styling for enhanced overall readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->