### PR TITLE
Add skills for autofix and knowledge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -200,6 +200,57 @@
     },
     {
       "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "documentation",
+      "description": "Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.\n",
+      "homepage": "https://github.com/opendatahub-io/knowledge-skills",
+      "keywords": [
+        "knowledge",
+        "context",
+        "claude-md",
+        "agents-md",
+        "pr-analysis",
+        "automation"
+      ],
+      "license": "Apache-2.0",
+      "name": "knowledge-skills",
+      "repository": "https://github.com/opendatahub-io/knowledge-skills",
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/knowledge-skills",
+        "source": "github"
+      },
+      "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "development-tools",
+      "description": "Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.\n",
+      "homepage": "https://github.com/opendatahub-io/autofix-skills",
+      "keywords": [
+        "autofix",
+        "jira",
+        "cve",
+        "bug-fixing",
+        "triage",
+        "pipeline",
+        "ci-cd"
+      ],
+      "license": "Apache-2.0",
+      "name": "autofix-skills",
+      "repository": "https://github.com/opendatahub-io/autofix-skills",
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/autofix-skills",
+        "source": "github"
+      },
+      "version": "0.1.0"
+    },
+    {
+      "author": {
         "name": "Arjay Hinek"
       },
       "category": "planning",

--- a/catalog.md
+++ b/catalog.md
@@ -99,6 +99,26 @@ Tags: evaluation, testing, skills, agents, mlflow, optimization, scoring
 /plugin install agent-eval-harness@opendatahub-skills
 ```
 
+## Documentation
+
+Skills for generating and maintaining documentation
+
+### knowledge-skills
+
+Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.
+
+v0.1.0 | Apache-2.0 | [opendatahub-io/knowledge-skills](https://github.com/opendatahub-io/knowledge-skills)
+
+Tags: knowledge, context, claude-md, agents-md, pr-analysis, automation
+
+| Skill | Description |
+|-------|-------------|
+| `/knowledge.repo` | Scan merged PRs and propose updates to AI context files (CLAUDE.md, AGENTS.md) as a git-apply-able patch |
+
+```bash
+/plugin install knowledge-skills@opendatahub-skills
+```
+
 ## Security Review
 
 Security analysis, threat modeling, and compliance review
@@ -162,6 +182,25 @@ Tags: python-packaging, licensing, dependencies, gitlab, jira, adr, git, automat
 
 ```bash
 /plugin install odh-ai-helpers@opendatahub-skills
+```
+
+### autofix-skills
+
+Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
+
+v0.1.0 | Apache-2.0 | [opendatahub-io/autofix-skills](https://github.com/opendatahub-io/autofix-skills)
+
+Tags: autofix, jira, cve, bug-fixing, triage, pipeline, ci-cd
+
+| Skill | Description |
+|-------|-------------|
+| `/autofix-resolve` | Orchestrate end-to-end bug fixing via implement and review agent loop (max 3 iterations) |
+| `/autofix-cve-resolve` | CVE remediation across multiple repos with state-machine dispatch |
+| `/autofix-triage` | Assess bug tickets for AI autofix readiness (ready/needs_info/not_fixable) |
+| `/autofix-research` | Investigate spike tickets with no associated repository |
+
+```bash
+/plugin install autofix-skills@opendatahub-skills
 ```
 
 ## Product Planning

--- a/registry.yaml
+++ b/registry.yaml
@@ -425,6 +425,69 @@ plugins:
       requires_python: ">=3.11"
     depends_on: []
 
+  - name: knowledge-skills
+    description: >
+      Autonomous knowledge management skills for keeping AI context files
+      (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant
+      knowledge using parallel agents, and proposes updates as a git-apply-able
+      patch for human review. Supports GitHub and GitLab.
+    version: "0.1.0"
+    category: documentation
+    tags: [knowledge, context, claude-md, agents-md, pr-analysis, automation]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/knowledge-skills
+      ref: main
+    homepage: https://github.com/opendatahub-io/knowledge-skills
+    repository: https://github.com/opendatahub-io/knowledge-skills
+    skills:
+      - name: knowledge.repo
+        description: Scan merged PRs and propose updates to AI context files (CLAUDE.md, AGENTS.md) as a git-apply-able patch
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install knowledge-skills@opendatahub-skills"
+    depends_on: []
+
+  - name: autofix-skills
+    description: >
+      Claude Code plugin for the Jira autofix pipeline. Provides orchestrator
+      skills, agent prompt files, and deterministic Python scripts for automated
+      bug fixing, CVE remediation, and ticket triage. Designed to run inside
+      a Claude Code container as part of a CI pipeline.
+    version: "0.1.0"
+    category: development-tools
+    tags: [autofix, jira, cve, bug-fixing, triage, pipeline, ci-cd]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/autofix-skills
+      ref: main
+    homepage: https://github.com/opendatahub-io/autofix-skills
+    repository: https://github.com/opendatahub-io/autofix-skills
+    skills:
+      - name: autofix-resolve
+        description: Orchestrate end-to-end bug fixing via implement and review agent loop (max 3 iterations)
+        user-invocable: true
+      - name: autofix-cve-resolve
+        description: CVE remediation across multiple repos with state-machine dispatch
+        user-invocable: true
+      - name: autofix-triage
+        description: Assess bug tickets for AI autofix readiness (ready/needs_info/not_fixable)
+        user-invocable: true
+      - name: autofix-research
+        description: Investigate spike tickets with no associated repository
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install autofix-skills@opendatahub-skills"
+    depends_on: []
+
   - name: meeting-quality-skills
     description: >
       Pre-meeting skills for improving meeting quality by checking shared update docs,

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -451,9 +451,7 @@ def generate_category_page(cat_key: str, cat_meta: dict,
         lines.append("")
         for plugin in plugins:
             name = plugin["name"]
-            desc = plugin["description"].strip().split("\n")[0]
-            if len(desc) > 120:
-                desc = desc[:117] + "..."
+            desc = plugin["description"].strip()
             skill_count = len(plugin.get("skills", []))
             version = plugin.get("version", "")
             lines.append(f"### [{name}](../plugins/{name}/index.md)")

--- a/site/docs/categories/development-tools.md
+++ b/site/docs/categories/development-tools.md
@@ -16,3 +16,9 @@ Developer productivity tools for packaging, CI/CD debugging, and workflow automa
 Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for anal...
 
 **19 skills** · v0.1.0
+
+### [autofix-skills](../plugins/autofix-skills/index.md)
+
+Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic...
+
+**4 skills** · v0.1.0

--- a/site/docs/categories/development-tools.md
+++ b/site/docs/categories/development-tools.md
@@ -13,12 +13,12 @@ Developer productivity tools for packaging, CI/CD debugging, and workflow automa
 
 ### [odh-ai-helpers](../plugins/odh-ai-helpers/index.md)
 
-Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for anal...
+Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
 
 **19 skills** · v0.1.0
 
 ### [autofix-skills](../plugins/autofix-skills/index.md)
 
-Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic...
+Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 
 **4 skills** · v0.1.0

--- a/site/docs/categories/documentation.md
+++ b/site/docs/categories/documentation.md
@@ -13,6 +13,6 @@ Skills for generating and maintaining documentation
 
 ### [knowledge-skills](../plugins/knowledge-skills/index.md)
 
-Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged P...
+Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.
 
 **1 skills** · v0.1.0

--- a/site/docs/categories/documentation.md
+++ b/site/docs/categories/documentation.md
@@ -1,0 +1,18 @@
+---
+title: Documentation
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# Documentation
+
+Skills for generating and maintaining documentation
+
+## Plugins
+
+### [knowledge-skills](../plugins/knowledge-skills/index.md)
+
+Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged P...
+
+**1 skills** · v0.1.0

--- a/site/docs/categories/evaluation.md
+++ b/site/docs/categories/evaluation.md
@@ -19,18 +19,18 @@ Assess RFEs against quality criteria using a structured rubric.
 
 ### [test-plan](../plugins/test-plan/index.md)
 
-End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement execut...
+End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement executable automation code, verify UI tests against live clusters via Playwright, publish to GitHub with PR creation, resolve review feedback, and score quality with automated rubrics using parallel sub-agent analysis.
 
 **17 skills** · v1.0.0
 
 ### [quality-tooling](../plugins/quality-tooling/index.md)
 
-Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validat...
+Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.
 
 **5 skills** · v1.0.0
 
 ### [agent-eval-harness](../plugins/agent-eval-harness/index.md)
 
-Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and ite...
+Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and iteratively improve agent skills with MLflow support for experiment tracking, tracing, and reporting. Schema-driven evaluation via eval.yaml with support for inline, LLM-based, and external judges.
 
 **7 skills** · v0.1.0

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -12,6 +12,7 @@ title: Categories
 | Category | Plugins | Description |
 |----------|---------|-------------|
 | [Evaluation & Testing](evaluation.md) | 4 | Skills for evaluating and testing AI agent skills |
+| [Documentation](documentation.md) | 1 | Skills for generating and maintaining documentation |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
-| [Development Tools](development-tools.md) | 1 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
+| [Development Tools](development-tools.md) | 2 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 2 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/categories/planning.md
+++ b/site/docs/categories/planning.md
@@ -13,12 +13,12 @@ Skills for requirements, RFEs, and product strategy
 
 ### [rfe-creator](../plugins/rfe-creator/index.md)
 
-Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pi...
+Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.
 
 **16 skills** · v0.1.0
 
 ### [meeting-quality-skills](../plugins/meeting-quality-skills/index.md)
 
-Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, a...
+Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.
 
 **2 skills** · v0.1.0

--- a/site/docs/categories/security.md
+++ b/site/docs/categories/security.md
@@ -13,6 +13,6 @@ Security analysis, threat modeling, and compliance review
 
 ### [rhoai-security-reviewer](../plugins/rhoai-security-reviewer/index.md)
 
-Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent revie...
+Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent reviewers to identify security risks, then synthesizes findings with confidence tagging based on cross-reviewer agreement. Covers 39 catalog patterns across auth, data protection, cryptographic compliance, network security, supply chain, and infrastructure.
 
 **2 skills** · v0.1.0

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-8 plugins | 70 skills | 4 categories
+10 plugins | 75 skills | 5 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -76,6 +76,22 @@ hide:
 
     **7 skills** · Evaluation & Testing · v0.1.0
 
+-   **[knowledge-skills](plugins/knowledge-skills/index.md)**
+
+    ---
+
+    Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged P...
+
+    **1 skills** · Documentation · v0.1.0
+
+-   **[autofix-skills](plugins/autofix-skills/index.md)**
+
+    ---
+
+    Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic...
+
+    **4 skills** · Development Tools · v0.1.0
+
 -   **[meeting-quality-skills](plugins/meeting-quality-skills/index.md)**
 
     ---
@@ -89,6 +105,7 @@ hide:
 ## Categories
 
 - [Evaluation & Testing](categories/evaluation.md) — Skills for evaluating and testing AI agent skills (4 plugins)
+- [Documentation](categories/documentation.md) — Skills for generating and maintaining documentation (1 plugin)
 - [Security Review](categories/security.md) — Security analysis, threat modeling, and compliance review (1 plugin)
-- [Development Tools](categories/development-tools.md) — Developer productivity tools for packaging, CI/CD debugging, and workflow automation (1 plugin)
+- [Development Tools](categories/development-tools.md) — Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
 - [Product Planning](categories/planning.md) — Skills for requirements, RFEs, and product strategy (2 plugins)

--- a/site/docs/plugins/autofix-skills/autofix-cve-resolve.md
+++ b/site/docs/plugins/autofix-skills/autofix-cve-resolve.md
@@ -1,0 +1,18 @@
+---
+title: autofix-cve-resolve
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# autofix-cve-resolve
+
+CVE remediation across multiple repos with state-machine dispatch
+
+**Plugin**: [autofix-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/autofix-cve-resolve
+```

--- a/site/docs/plugins/autofix-skills/autofix-research.md
+++ b/site/docs/plugins/autofix-skills/autofix-research.md
@@ -1,0 +1,18 @@
+---
+title: autofix-research
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# autofix-research
+
+Investigate spike tickets with no associated repository
+
+**Plugin**: [autofix-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/autofix-research
+```

--- a/site/docs/plugins/autofix-skills/autofix-resolve.md
+++ b/site/docs/plugins/autofix-skills/autofix-resolve.md
@@ -1,0 +1,18 @@
+---
+title: autofix-resolve
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# autofix-resolve
+
+Orchestrate end-to-end bug fixing via implement and review agent loop (max 3 iterations)
+
+**Plugin**: [autofix-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/autofix-resolve
+```

--- a/site/docs/plugins/autofix-skills/autofix-triage.md
+++ b/site/docs/plugins/autofix-skills/autofix-triage.md
@@ -1,0 +1,18 @@
+---
+title: autofix-triage
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# autofix-triage
+
+Assess bug tickets for AI autofix readiness (ready/needs_info/not_fixable)
+
+**Plugin**: [autofix-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/autofix-triage
+```

--- a/site/docs/plugins/autofix-skills/index.md
+++ b/site/docs/plugins/autofix-skills/index.md
@@ -1,0 +1,34 @@
+---
+title: autofix-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# autofix-skills
+
+Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: opendatahub-io
+    - **License**: Apache-2.0
+    - **Category**: [Development Tools](../../categories/development-tools.md)
+    - **Repository**: [opendatahub-io/autofix-skills](https://github.com/opendatahub-io/autofix-skills)
+    - **Tags**: <span class="tag-pill">autofix</span> <span class="tag-pill">jira</span> <span class="tag-pill">cve</span> <span class="tag-pill">bug-fixing</span> <span class="tag-pill">triage</span> <span class="tag-pill">pipeline</span> <span class="tag-pill">ci-cd</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/autofix-resolve`](autofix-resolve.md) | Orchestrate end-to-end bug fixing via implement and review agent loop (max 3 iterations) | :material-check: |
+| [`/autofix-cve-resolve`](autofix-cve-resolve.md) | CVE remediation across multiple repos with state-machine dispatch | :material-check: |
+| [`/autofix-triage`](autofix-triage.md) | Assess bug tickets for AI autofix readiness (ready/needs_info/not_fixable) | :material-check: |
+| [`/autofix-research`](autofix-research.md) | Investigate spike tickets with no associated repository | :material-check: |
+
+## Installation
+
+```bash
+/plugin install autofix-skills@opendatahub-skills
+```

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-8 plugins registered in the marketplace.
+10 plugins registered in the marketplace.
 
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
@@ -18,4 +18,6 @@ title: Plugins
 | [quality-tooling](quality-tooling/index.md) | Evaluation & Testing | 5 | v1.0.0 |
 | [odh-ai-helpers](odh-ai-helpers/index.md) | Development Tools | 19 | v0.1.0 |
 | [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 7 | v0.1.0 |
+| [knowledge-skills](knowledge-skills/index.md) | Documentation | 1 | v0.1.0 |
+| [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [meeting-quality-skills](meeting-quality-skills/index.md) | Product Planning | 2 | v0.1.0 |

--- a/site/docs/plugins/knowledge-skills/index.md
+++ b/site/docs/plugins/knowledge-skills/index.md
@@ -1,0 +1,31 @@
+---
+title: knowledge-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# knowledge-skills
+
+Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: opendatahub-io
+    - **License**: Apache-2.0
+    - **Category**: [Documentation](../../categories/documentation.md)
+    - **Repository**: [opendatahub-io/knowledge-skills](https://github.com/opendatahub-io/knowledge-skills)
+    - **Tags**: <span class="tag-pill">knowledge</span> <span class="tag-pill">context</span> <span class="tag-pill">claude-md</span> <span class="tag-pill">agents-md</span> <span class="tag-pill">pr-analysis</span> <span class="tag-pill">automation</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/knowledge.repo`](knowledge.repo.md) | Scan merged PRs and propose updates to AI context files (CLAUDE.md, AGENTS.md) as a git-apply-able patch | :material-check: |
+
+## Installation
+
+```bash
+/plugin install knowledge-skills@opendatahub-skills
+```

--- a/site/docs/plugins/knowledge-skills/knowledge.repo.md
+++ b/site/docs/plugins/knowledge-skills/knowledge.repo.md
@@ -1,0 +1,18 @@
+---
+title: knowledge.repo
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# knowledge.repo
+
+Scan merged PRs and propose updates to AI context files (CLAUDE.md, AGENTS.md) as a git-apply-able patch
+
+**Plugin**: [knowledge-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/knowledge.repo
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -135,6 +135,15 @@ nav:
       - eval-review: plugins/agent-eval-harness/eval-review.md
       - eval-mlflow: plugins/agent-eval-harness/eval-mlflow.md
       - eval-optimize: plugins/agent-eval-harness/eval-optimize.md
+    - knowledge-skills:
+      - plugins/knowledge-skills/index.md
+      - knowledge.repo: plugins/knowledge-skills/knowledge.repo.md
+    - autofix-skills:
+      - plugins/autofix-skills/index.md
+      - autofix-resolve: plugins/autofix-skills/autofix-resolve.md
+      - autofix-cve-resolve: plugins/autofix-skills/autofix-cve-resolve.md
+      - autofix-triage: plugins/autofix-skills/autofix-triage.md
+      - autofix-research: plugins/autofix-skills/autofix-research.md
     - meeting-quality-skills:
       - plugins/meeting-quality-skills/index.md
       - meeting-async-update-check: plugins/meeting-quality-skills/meeting-async-update-check.md
@@ -142,6 +151,7 @@ nav:
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md
+    - Documentation: categories/documentation.md
     - Security Review: categories/security.md
     - Development Tools: categories/development-tools.md
     - Product Planning: categories/planning.md


### PR DESCRIPTION
## Description

Adds two new skills that will be used in automated pipeline repos in GitLab.

Also fixes the truncation of plugin description that is resulting in an interesting description in https://github.com/opendatahub-io/skills-registry/blob/83ff2965bcc64ceaa866bcaedd2aed07026b1865/site/docs/categories/development-tools.md.

## How Has This Been Tested?

Skills were tested in their own respective repos.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `knowledge-skills` plugin for autonomous documentation management capabilities
  * Introduced `autofix-skills` plugin with four capabilities: end-to-end bug resolution, CVE remediation, ticket triaging, and issue research

* **Documentation**
  * Added comprehensive documentation for new plugins and their individual features
  * Updated marketplace catalog and site to reflect new plugin registry entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->