### PR TITLE
Add disconnected-readiness-scorer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -279,7 +279,7 @@
       },
       "category": "devops",
       "description": "Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.\n",
-      "homepage": "https://github.com/asanzgom/disconnected-readiness-scorer",
+      "homepage": "https://github.com/opendatahub-io/disconnected-readiness-scorer",
       "keywords": [
         "disconnected",
         "air-gap",
@@ -290,13 +290,13 @@
       ],
       "license": "Apache-2.0",
       "name": "disconnected-readiness-scorer",
-      "repository": "https://github.com/asanzgom/disconnected-readiness-scorer",
+      "repository": "https://github.com/opendatahub-io/disconnected-readiness-scorer",
       "skills": [
         "./skills"
       ],
       "source": {
         "ref": "f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d",
-        "repo": "asanzgom/disconnected-readiness-scorer",
+        "repo": "opendatahub-io/disconnected-readiness-scorer",
         "source": "github"
       },
       "strict": false,

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -272,6 +272,35 @@
         "source": "github"
       },
       "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "asanzgom"
+      },
+      "category": "devops",
+      "description": "Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.\n",
+      "homepage": "https://github.com/asanzgom/disconnected-readiness-scorer",
+      "keywords": [
+        "disconnected",
+        "air-gap",
+        "openshift",
+        "image-mirroring",
+        "readiness",
+        "scoring"
+      ],
+      "license": "Apache-2.0",
+      "name": "disconnected-readiness-scorer",
+      "repository": "https://github.com/asanzgom/disconnected-readiness-scorer",
+      "skills": [
+        "./skills"
+      ],
+      "source": {
+        "ref": "f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d",
+        "repo": "asanzgom/disconnected-readiness-scorer",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ python3 scripts/check_versions.py --dry-run
 python3 scripts/validate_registry.py --diff origin/main --validate-remote-plugins
 ```
 
-**Before committing any change to `registry.yaml`**, run all four generators (validate, sync marketplace, generate catalog, generate site). CI checks that every generated file matches — it does not auto-commit.
+**Before committing any change to `registry.yaml`**, run all four generators (validate, sync marketplace, generate catalog, generate site). CI checks that every generated file matches -- it does not auto-commit.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,17 @@
-# Skills Registry
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
 
 Skills and Claude Code plugins marketplace for the opendatahub-io organization. `registry.yaml` is the single source of truth — all other files are generated from it.
 
 ## Common Commands
 
 ```bash
+# Install Python dependencies (needed for all scripts)
+pip install pyyaml jsonschema
+
 # Validate registry.yaml against schema
 python3 scripts/validate_registry.py
 
@@ -19,9 +26,12 @@ python3 scripts/generate_site.py
 
 # Check plugin repo versions against registry
 python3 scripts/check_versions.py --dry-run
+
+# Validate and also clone/check new plugin repos
+python3 scripts/validate_registry.py --diff origin/main --validate-remote-plugins
 ```
 
-Always run all four (validate, sync, generate catalog, generate site) before committing changes to registry.yaml. CI will fail if generated files are out of sync.
+**Before committing any change to `registry.yaml`**, run all four generators (validate, sync marketplace, generate catalog, generate site). CI checks that every generated file matches — it does not auto-commit.
 
 ## Architecture
 
@@ -61,7 +71,8 @@ See @CONTRIBUTING.md for the full process. Quick checklist:
 2. Run `python3 scripts/validate_registry.py`
 3. Run `python3 scripts/sync_marketplace.py`
 4. Run `python3 scripts/generate_catalog.py`
-5. Commit all changed files and open a PR
+5. Run `python3 scripts/generate_site.py`
+6. Commit all changed files and open a PR
 
 ## Testing a Marketplace Branch
 

--- a/catalog.md
+++ b/catalog.md
@@ -127,7 +127,7 @@ Skills for deployment, CI/CD, and infrastructure
 
 Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 
-v0.1.0 | Apache-2.0 | [asanzgom/disconnected-readiness-scorer](https://github.com/asanzgom/disconnected-readiness-scorer)
+v0.1.0 | Apache-2.0 | [opendatahub-io/disconnected-readiness-scorer](https://github.com/opendatahub-io/disconnected-readiness-scorer)
 
 Tags: disconnected, air-gap, openshift, image-mirroring, readiness, scoring
 

--- a/catalog.md
+++ b/catalog.md
@@ -119,6 +119,26 @@ Tags: knowledge, context, claude-md, agents-md, pr-analysis, automation
 /plugin install knowledge-skills@opendatahub-skills
 ```
 
+## DevOps & CI/CD
+
+Skills for deployment, CI/CD, and infrastructure
+
+### disconnected-readiness-scorer
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
+
+v0.1.0 | Apache-2.0 | [asanzgom/disconnected-readiness-scorer](https://github.com/asanzgom/disconnected-readiness-scorer)
+
+Tags: disconnected, air-gap, openshift, image-mirroring, readiness, scoring
+
+| Skill | Description |
+|-------|-------------|
+| `/disconnected-score` | Score a repository's readiness for disconnected / air-gapped OpenShift deployments |
+
+```bash
+/plugin install disconnected-readiness-scorer@opendatahub-skills
+```
+
 ## Security Review
 
 Security analysis, threat modeling, and compliance review

--- a/registry.yaml
+++ b/registry.yaml
@@ -536,12 +536,12 @@ plugins:
     license: Apache-2.0
     source:
       type: github
-      repo: asanzgom/disconnected-readiness-scorer
+      repo: opendatahub-io/disconnected-readiness-scorer
       ref: f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d
     strict: false
     skills_dir: skills
-    homepage: https://github.com/asanzgom/disconnected-readiness-scorer
-    repository: https://github.com/asanzgom/disconnected-readiness-scorer
+    homepage: https://github.com/opendatahub-io/disconnected-readiness-scorer
+    repository: https://github.com/opendatahub-io/disconnected-readiness-scorer
     skills:
       - name: disconnected-score
         description: Score a repository's readiness for disconnected / air-gapped OpenShift deployments

--- a/registry.yaml
+++ b/registry.yaml
@@ -520,3 +520,32 @@ plugins:
         skill_dir: skills/
         entry_point: "skills/{skill_name}/SKILL.md"
     depends_on: []
+
+  - name: disconnected-readiness-scorer
+    description: >
+      Score a repository's readiness for disconnected / air-gapped OpenShift
+      deployments. Scans for image manifest completeness, digest enforcement,
+      runtime egress, and Python dependency validation. Supports automatic
+      detection of image management patterns (env var vs static CSV) and
+      cross-references against the opendatahub-operator manifest.
+    version: "0.1.0"
+    category: devops
+    tags: [disconnected, air-gap, openshift, image-mirroring, readiness, scoring]
+    author:
+      name: asanzgom
+    license: Apache-2.0
+    source:
+      type: github
+      repo: asanzgom/disconnected-readiness-scorer
+      ref: main
+    skills_dir: skills
+    homepage: https://github.com/asanzgom/disconnected-readiness-scorer
+    repository: https://github.com/asanzgom/disconnected-readiness-scorer
+    skills:
+      - name: disconnected-score
+        description: Score a repository's readiness for disconnected / air-gapped OpenShift deployments
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install disconnected-readiness-scorer@opendatahub-skills"
+    depends_on: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -537,7 +537,7 @@ plugins:
     source:
       type: github
       repo: asanzgom/disconnected-readiness-scorer
-      ref: main
+      ref: f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d
     strict: false
     skills_dir: skills
     homepage: https://github.com/asanzgom/disconnected-readiness-scorer

--- a/registry.yaml
+++ b/registry.yaml
@@ -538,6 +538,7 @@ plugins:
       type: github
       repo: asanzgom/disconnected-readiness-scorer
       ref: main
+    strict: false
     skills_dir: skills
     homepage: https://github.com/asanzgom/disconnected-readiness-scorer
     repository: https://github.com/asanzgom/disconnected-readiness-scorer

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -353,9 +353,9 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
                 else:
                     parts.append(f"[{name}]")
             hint = " ".join(parts)
-        lines.append(f"```bash")
+        lines.append("```bash")
         lines.append(f"/{sname} {hint}")
-        lines.append(f"```")
+        lines.append("```")
         lines.append("")
         lines.append("| Argument | Required | Default | Description |")
         lines.append("|----------|----------|---------|-------------|")
@@ -363,16 +363,16 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
             aname = f'`{arg["name"]}`'
             req = ":material-check:" if arg.get("required") else ""
             default = f'`{arg["default"]}`' if arg.get("default") else "-"
-            adesc = arg.get("description", "")
+            adesc = " ".join(arg.get("description", "").split())
             lines.append(f"| {aname} | {req} | {default} | {adesc} |")
         lines.append("")
     elif argument_hint:
         # No enriched arguments but argument-hint exists — parse it as fallback
         lines.append("## Arguments")
         lines.append("")
-        lines.append(f"```bash")
+        lines.append("```bash")
         lines.append(f"/{sname} {argument_hint}")
-        lines.append(f"```")
+        lines.append("```")
         lines.append("")
         lines.append("| Argument | Required | Description |")
         lines.append("|----------|----------|-------------|")
@@ -602,7 +602,7 @@ def generate_llms_full_txt(registry: dict, docs_dir: Path) -> str:
                 for arg in args:
                     aname = arg.get("name", "")
                     req = "yes" if arg.get("required") else ""
-                    adesc = arg.get("description", "")
+                    adesc = " ".join(arg.get("description", "").split())
                     lines.append(f"| `{aname}` | {req} | {adesc} |")
                 lines.append("")
             if examples:

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -148,7 +148,7 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
         lines.append("")
         lines.append(f"    {desc}")
         lines.append("")
-        lines.append(f"    **{skill_count} skills** · {cat_name} · v{version}")
+        lines.append(f"    **{skill_count} skills** - {cat_name} - v{version}")
         lines.append("")
 
     lines.append("</div>")
@@ -162,7 +162,7 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
             continue
         count = len(cat_list)
         lines.append(f"- [{cat_meta['name']}](categories/{cat_key}.md) "
-                     f"— {cat_meta.get('description', '')} ({count} plugin{'s' if count != 1 else ''})")
+                     f"-- {cat_meta.get('description', '')} ({count} plugin{'s' if count != 1 else ''})")
     lines.append("")
 
     return "\n".join(lines)
@@ -353,7 +353,7 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
                 else:
                     parts.append(f"[{name}]")
             hint = " ".join(parts)
-        lines.append(f"```")
+        lines.append(f"```bash")
         lines.append(f"/{sname} {hint}")
         lines.append(f"```")
         lines.append("")
@@ -362,7 +362,7 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
         for arg in enriched_skill["arguments"]:
             aname = f'`{arg["name"]}`'
             req = ":material-check:" if arg.get("required") else ""
-            default = f'`{arg["default"]}`' if arg.get("default") else "—"
+            default = f'`{arg["default"]}`' if arg.get("default") else "-"
             adesc = arg.get("description", "")
             lines.append(f"| {aname} | {req} | {default} | {adesc} |")
         lines.append("")
@@ -370,7 +370,7 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
         # No enriched arguments but argument-hint exists — parse it as fallback
         lines.append("## Arguments")
         lines.append("")
-        lines.append(f"```")
+        lines.append(f"```bash")
         lines.append(f"/{sname} {argument_hint}")
         lines.append(f"```")
         lines.append("")
@@ -393,7 +393,7 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
     if enriched_skill and enriched_skill.get("usage_examples"):
         lines.append("## Usage")
         lines.append("")
-        lines.append("```")
+        lines.append("```bash")
         for ex in enriched_skill["usage_examples"]:
             lines.append(ex)
         lines.append("```")
@@ -407,7 +407,7 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
         # No arguments, no usage examples — show basic invocation
         lines.append("## Usage")
         lines.append("")
-        lines.append("```")
+        lines.append("```bash")
         lines.append(f"/{sname}")
         lines.append("```")
         lines.append("")
@@ -458,7 +458,7 @@ def generate_category_page(cat_key: str, cat_meta: dict,
             lines.append("")
             lines.append(desc)
             lines.append("")
-            lines.append(f"**{skill_count} skills** · v{version}")
+            lines.append(f"**{skill_count} skills** - v{version}")
             lines.append("")
 
     return "\n".join(lines)

--- a/site/docs/categories/development-tools.md
+++ b/site/docs/categories/development-tools.md
@@ -15,10 +15,10 @@ Developer productivity tools for packaging, CI/CD debugging, and workflow automa
 
 Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
 
-**19 skills** · v0.1.0
+**19 skills** - v0.1.0
 
 ### [autofix-skills](../plugins/autofix-skills/index.md)
 
 Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 
-**4 skills** · v0.1.0
+**4 skills** - v0.1.0

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -1,0 +1,18 @@
+---
+title: DevOps & CI/CD
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# DevOps & CI/CD
+
+Skills for deployment, CI/CD, and infrastructure
+
+## Plugins
+
+### [disconnected-readiness-scorer](../plugins/disconnected-readiness-scorer/index.md)
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
+
+**1 skills** · v0.1.0

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -15,4 +15,4 @@ Skills for deployment, CI/CD, and infrastructure
 
 Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 
-**1 skills** · v0.1.0
+**1 skills** - v0.1.0

--- a/site/docs/categories/documentation.md
+++ b/site/docs/categories/documentation.md
@@ -15,4 +15,4 @@ Skills for generating and maintaining documentation
 
 Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.
 
-**1 skills** · v0.1.0
+**1 skills** - v0.1.0

--- a/site/docs/categories/evaluation.md
+++ b/site/docs/categories/evaluation.md
@@ -15,22 +15,22 @@ Skills for evaluating and testing AI agent skills
 
 Assess RFEs against quality criteria using a structured rubric.
 
-**2 skills** · v1.0.0
+**2 skills** - v1.0.0
 
 ### [test-plan](../plugins/test-plan/index.md)
 
 End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement executable automation code, verify UI tests against live clusters via Playwright, publish to GitHub with PR creation, resolve review feedback, and score quality with automated rubrics using parallel sub-agent analysis.
 
-**17 skills** · v1.0.0
+**17 skills** - v1.0.0
 
 ### [quality-tooling](../plugins/quality-tooling/index.md)
 
 Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.
 
-**5 skills** · v1.0.0
+**5 skills** - v1.0.0
 
 ### [agent-eval-harness](../plugins/agent-eval-harness/index.md)
 
 Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and iteratively improve agent skills with MLflow support for experiment tracking, tracing, and reporting. Schema-driven evaluation via eval.yaml with support for inline, LLM-based, and external judges.
 
-**7 skills** · v0.1.0
+**7 skills** - v0.1.0

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -13,6 +13,7 @@ title: Categories
 |----------|---------|-------------|
 | [Evaluation & Testing](evaluation.md) | 4 | Skills for evaluating and testing AI agent skills |
 | [Documentation](documentation.md) | 1 | Skills for generating and maintaining documentation |
+| [DevOps & CI/CD](devops.md) | 1 | Skills for deployment, CI/CD, and infrastructure |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
 | [Development Tools](development-tools.md) | 2 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 2 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/categories/planning.md
+++ b/site/docs/categories/planning.md
@@ -15,10 +15,10 @@ Skills for requirements, RFEs, and product strategy
 
 Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.
 
-**16 skills** · v0.1.0
+**16 skills** - v0.1.0
 
 ### [meeting-quality-skills](../plugins/meeting-quality-skills/index.md)
 
 Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.
 
-**2 skills** · v0.1.0
+**2 skills** - v0.1.0

--- a/site/docs/categories/security.md
+++ b/site/docs/categories/security.md
@@ -15,4 +15,4 @@ Security analysis, threat modeling, and compliance review
 
 Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent reviewers to identify security risks, then synthesizes findings with confidence tagging based on cross-reviewer agreement. Covers 39 catalog patterns across auth, data protection, cryptographic compliance, network security, supply chain, and infrastructure.
 
-**2 skills** · v0.1.0
+**2 skills** - v0.1.0

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -26,7 +26,7 @@ hide:
 
     Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pi...
 
-    **16 skills** · Product Planning · v0.1.0
+    **16 skills** - Product Planning - v0.1.0
 
 -   **[assess-rfe](plugins/assess-rfe/index.md)**
 
@@ -34,7 +34,7 @@ hide:
 
     Assess RFEs against quality criteria using a structured rubric.
 
-    **2 skills** · Evaluation & Testing · v1.0.0
+    **2 skills** - Evaluation & Testing - v1.0.0
 
 -   **[rhoai-security-reviewer](plugins/rhoai-security-reviewer/index.md)**
 
@@ -42,7 +42,7 @@ hide:
 
     Consensus-based security review for RHOAI strategy documents (STRATs). An orchestrator spawns three independent revie...
 
-    **2 skills** · Security Review · v0.1.0
+    **2 skills** - Security Review - v0.1.0
 
 -   **[test-plan](plugins/test-plan/index.md)**
 
@@ -50,7 +50,7 @@ hide:
 
     End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement execut...
 
-    **17 skills** · Evaluation & Testing · v1.0.0
+    **17 skills** - Evaluation & Testing - v1.0.0
 
 -   **[quality-tooling](plugins/quality-tooling/index.md)**
 
@@ -58,7 +58,7 @@ hide:
 
     Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validat...
 
-    **5 skills** · Evaluation & Testing · v1.0.0
+    **5 skills** - Evaluation & Testing - v1.0.0
 
 -   **[odh-ai-helpers](plugins/odh-ai-helpers/index.md)**
 
@@ -66,7 +66,7 @@ hide:
 
     Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for anal...
 
-    **19 skills** · Development Tools · v0.1.0
+    **19 skills** - Development Tools - v0.1.0
 
 -   **[agent-eval-harness](plugins/agent-eval-harness/index.md)**
 
@@ -74,7 +74,7 @@ hide:
 
     Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and ite...
 
-    **7 skills** · Evaluation & Testing · v0.1.0
+    **7 skills** - Evaluation & Testing - v0.1.0
 
 -   **[knowledge-skills](plugins/knowledge-skills/index.md)**
 
@@ -82,7 +82,7 @@ hide:
 
     Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged P...
 
-    **1 skills** · Documentation · v0.1.0
+    **1 skills** - Documentation - v0.1.0
 
 -   **[autofix-skills](plugins/autofix-skills/index.md)**
 
@@ -90,7 +90,7 @@ hide:
 
     Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic...
 
-    **4 skills** · Development Tools · v0.1.0
+    **4 skills** - Development Tools - v0.1.0
 
 -   **[meeting-quality-skills](plugins/meeting-quality-skills/index.md)**
 
@@ -98,7 +98,7 @@ hide:
 
     Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, a...
 
-    **2 skills** · Product Planning · v0.1.0
+    **2 skills** - Product Planning - v0.1.0
 
 -   **[disconnected-readiness-scorer](plugins/disconnected-readiness-scorer/index.md)**
 
@@ -106,15 +106,15 @@ hide:
 
     Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest complete...
 
-    **1 skills** · DevOps & CI/CD · v0.1.0
+    **1 skills** - DevOps & CI/CD - v0.1.0
 
 </div>
 
 ## Categories
 
-- [Evaluation & Testing](categories/evaluation.md) — Skills for evaluating and testing AI agent skills (4 plugins)
-- [Documentation](categories/documentation.md) — Skills for generating and maintaining documentation (1 plugin)
-- [DevOps & CI/CD](categories/devops.md) — Skills for deployment, CI/CD, and infrastructure (1 plugin)
-- [Security Review](categories/security.md) — Security analysis, threat modeling, and compliance review (1 plugin)
-- [Development Tools](categories/development-tools.md) — Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
-- [Product Planning](categories/planning.md) — Skills for requirements, RFEs, and product strategy (2 plugins)
+- [Evaluation & Testing](categories/evaluation.md) -- Skills for evaluating and testing AI agent skills (4 plugins)
+- [Documentation](categories/documentation.md) -- Skills for generating and maintaining documentation (1 plugin)
+- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (1 plugin)
+- [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)
+- [Development Tools](categories/development-tools.md) -- Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
+- [Product Planning](categories/planning.md) -- Skills for requirements, RFEs, and product strategy (2 plugins)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-10 plugins | 75 skills | 5 categories
+11 plugins | 76 skills | 6 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -100,12 +100,21 @@ hide:
 
     **2 skills** · Product Planning · v0.1.0
 
+-   **[disconnected-readiness-scorer](plugins/disconnected-readiness-scorer/index.md)**
+
+    ---
+
+    Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest complete...
+
+    **1 skills** · DevOps & CI/CD · v0.1.0
+
 </div>
 
 ## Categories
 
 - [Evaluation & Testing](categories/evaluation.md) — Skills for evaluating and testing AI agent skills (4 plugins)
 - [Documentation](categories/documentation.md) — Skills for generating and maintaining documentation (1 plugin)
+- [DevOps & CI/CD](categories/devops.md) — Skills for deployment, CI/CD, and infrastructure (1 plugin)
 - [Security Review](categories/security.md) — Security analysis, threat modeling, and compliance review (1 plugin)
 - [Development Tools](categories/development-tools.md) — Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
 - [Product Planning](categories/planning.md) — Skills for requirements, RFEs, and product strategy (2 plugins)

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -401,8 +401,7 @@ what-if analysis, and near-miss identification).
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `input` | yes | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project.
- |
+| `input` | yes | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project. |
 
 Examples:
 ```

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -1960,7 +1960,7 @@ Build a focused agenda from our team's weekly updates
 
 Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 
-**Repository**: https://github.com/asanzgom/disconnected-readiness-scorer
+**Repository**: https://github.com/opendatahub-io/disconnected-readiness-scorer
 
 ### Skills
 

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -1956,3 +1956,17 @@ Build a focused agenda from our team's weekly updates
 ```
 
 ---
+
+## disconnected-readiness-scorer
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
+
+**Repository**: https://github.com/asanzgom/disconnected-readiness-scorer
+
+### Skills
+
+#### /disconnected-score
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments
+
+---

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -14,6 +14,7 @@
 - [knowledge-skills](https://opendatahub-io.github.io/skills-registry/plugins/knowledge-skills/): Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, AGENTS.md) up to date. Scans merged PRs, extracts relevant knowledge using parallel agents, and proposes updates as a git-apply-able patch for human review. Supports GitHub and GitLab.
 - [autofix-skills](https://opendatahub-io.github.io/skills-registry/plugins/autofix-skills/): Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 - [meeting-quality-skills](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/): Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.
+- [disconnected-readiness-scorer](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 
 ## Skills
 
@@ -83,6 +84,7 @@
 - [autofix-research](https://opendatahub-io.github.io/skills-registry/plugins/autofix-skills/autofix-research/): Investigate spike tickets with no associated repository
 - [meeting-async-update-check](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/meeting-async-update-check/): Check a shared update doc and identify attendees missing async updates before a status meeting
 - [meeting-risk-agenda](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/meeting-risk-agenda/): Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items
+- [disconnected-score](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/disconnected-score/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments
 
 ## Optional
 

--- a/site/docs/plugins/agent-eval-harness/eval-analyze.md
+++ b/site/docs/plugins/agent-eval-harness/eval-analyze.md
@@ -25,7 +25,7 @@ hash for staleness detection.
 
 ## Arguments
 
-```
+```bash
 /eval-analyze [--skill <name>] [--config <path>] [--update]
 ```
 
@@ -37,7 +37,7 @@ hash for staleness detection.
 
 ## Usage
 
-```
+```bash
 /eval-analyze --skill my-skill
 /eval-analyze --update
 /eval-analyze --skill rfe.create --config eval-rfe.yaml

--- a/site/docs/plugins/agent-eval-harness/eval-dataset.md
+++ b/site/docs/plugins/agent-eval-harness/eval-dataset.md
@@ -25,7 +25,7 @@ AskUserQuestion, and creates annotations.yaml for outcome-aware judges.
 
 ## Arguments
 
-```
+```bash
 /eval-dataset [--config <path>] [--count <N>] [--strategy <type>]
 ```
 
@@ -37,7 +37,7 @@ AskUserQuestion, and creates annotations.yaml for outcome-aware judges.
 
 ## Usage
 
-```
+```bash
 /eval-dataset
 /eval-dataset --count 10 --strategy expand
 /eval-dataset --strategy from-traces

--- a/site/docs/plugins/agent-eval-harness/eval-mlflow.md
+++ b/site/docs/plugins/agent-eval-harness/eval-mlflow.md
@@ -25,19 +25,19 @@ MLFLOW_TRACKING_URI env var, then defaults to localhost:5000.
 
 ## Arguments
 
-```
+```bash
 /eval-mlflow [--action <action>] [--run-id <id>] [--config <path>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `--action` |  | `all` | Which sync action to perform. |
-| `--run-id` |  | — | Which eval run to log or attach feedback to. Required for log-results, push-feedback, and pull-feedback. |
+| `--run-id` |  | - | Which eval run to log or attach feedback to. Required for log-results, push-feedback, and pull-feedback. |
 | `--config` |  | `eval.yaml` | Path to eval config. |
 
 ## Usage
 
-```
+```bash
 /eval-mlflow --run-id 2026-05-01-opus
 /eval-mlflow --action sync-dataset
 /eval-mlflow --run-id 2026-05-01-opus --action push-feedback

--- a/site/docs/plugins/agent-eval-harness/eval-optimize.md
+++ b/site/docs/plugins/agent-eval-harness/eval-optimize.md
@@ -26,7 +26,7 @@ iterations reached.
 
 ## Arguments
 
-```
+```bash
 /eval-optimize [--config <path>] [--model <model>] [--max-iterations <N>] [--run-id <id>] [--target-judge <name>]
 ```
 
@@ -36,11 +36,11 @@ iterations reached.
 | `--model` |  | `models.skill from config` | Model for skill execution across all iterations. |
 | `--max-iterations` |  | `3` | Maximum optimization iterations before stopping. |
 | `--run-id` |  | `auto-generated` | Base run ID. Iterations append -iter-N. |
-| `--target-judge` |  | — | Focus optimization on a specific failing judge instead of all judges. |
+| `--target-judge` |  | - | Focus optimization on a specific failing judge instead of all judges. |
 
 ## Usage
 
-```
+```bash
 /eval-optimize
 /eval-optimize --max-iterations 5 --model claude-opus-4-6
 /eval-optimize --target-judge completeness

--- a/site/docs/plugins/agent-eval-harness/eval-review.md
+++ b/site/docs/plugins/agent-eval-harness/eval-review.md
@@ -25,19 +25,19 @@ that judges cannot measure.
 
 ## Arguments
 
-```
+```bash
 /eval-review --run-id <id> [--config <path>] [--case <filter>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--run-id` | :material-check: | — | Which eval run to review. |
+| `--run-id` | :material-check: | - | Which eval run to review. |
 | `--config` |  | `eval.yaml` | Path to eval config. |
-| `--case` |  | — | Substring match to select specific cases for review. |
+| `--case` |  | - | Substring match to select specific cases for review. |
 
 ## Usage
 
-```
+```bash
 /eval-review --run-id 2026-05-01-opus
 /eval-review --run-id 2026-05-01-opus --case case-003
 ```

--- a/site/docs/plugins/agent-eval-harness/eval-run.md
+++ b/site/docs/plugins/agent-eval-harness/eval-run.md
@@ -27,7 +27,7 @@ reasoning effort levels.
 
 ## Arguments
 
-```
+```bash
 /eval-run [--config <path>] [--model <model>] [--run-id <id>] [--baseline <run-id>] [--case <filter>] [--no-judge] [--gold] [--effort <level>] [--subagent-model <model>] [--skill <name>]
 ```
 
@@ -37,8 +37,8 @@ reasoning effort levels.
 | `--model` |  | `models.skill from config` | Model for skill execution. Required if models.skill is unset in eval.yaml. |
 | `--subagent-model` |  | `models.subagent, falls back to skill model` | Model for subagents (e.g., claude-sonnet-4-6 while main is claude-opus-4-7). |
 | `--run-id` |  | `YYYY-MM-DD-<model>` | Identifier for this run. |
-| `--case` |  | — | Substring match to select specific cases. |
-| `--baseline` |  | — | Previous run to compare against for regression detection via pairwise comparison. |
+| `--case` |  | - | Substring match to select specific cases. |
+| `--baseline` |  | - | Previous run to compare against for regression detection via pairwise comparison. |
 | `--no-judge` |  | `false` | Skip LLM judges, run inline checks only. |
 | `--gold` |  | `false` | Save outputs as gold references after the run. |
 | `--effort` |  | `runner.effort from config` | Claude Code reasoning effort level. |
@@ -46,7 +46,7 @@ reasoning effort levels.
 
 ## Usage
 
-```
+```bash
 /eval-run --model claude-opus-4-6
 /eval-run --model claude-opus-4-6 --baseline 2026-05-01-opus
 /eval-run --case case-001 --no-judge

--- a/site/docs/plugins/agent-eval-harness/eval-setup.md
+++ b/site/docs/plugins/agent-eval-harness/eval-setup.md
@@ -25,19 +25,19 @@ hook and agent_eval is available via symlinks.
 
 ## Arguments
 
-```
+```bash
 /eval-setup [--tracking-uri <uri>] [--skip-mlflow] [--runs-dir <path>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--tracking-uri` |  | — | MLflow tracking URI (skips interactive setup). Accepts local or remote URIs. |
+| `--tracking-uri` |  | - | MLflow tracking URI (skips interactive setup). Accepts local or remote URIs. |
 | `--skip-mlflow` |  | `false` | Skip MLflow setup entirely. The harness works without MLflow. |
 | `--runs-dir` |  | `eval/runs` | Directory where eval runs are stored. Configured via AGENT_EVAL_RUNS_DIR env var. |
 
 ## Usage
 
-```
+```bash
 /eval-setup
 /eval-setup --tracking-uri http://127.0.0.1:5000
 /eval-setup --skip-mlflow

--- a/site/docs/plugins/assess-rfe/assess-rfe.md
+++ b/site/docs/plugins/assess-rfe/assess-rfe.md
@@ -34,8 +34,7 @@ what-if analysis, and near-miss identification).
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `input` | :material-check: | - | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project.
- |
+| `input` | :material-check: | - | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project. |
 
 ## Usage
 

--- a/site/docs/plugins/assess-rfe/assess-rfe.md
+++ b/site/docs/plugins/assess-rfe/assess-rfe.md
@@ -28,18 +28,18 @@ what-if analysis, and near-miss identification).
 
 ## Arguments
 
-```
+```bash
 /assess-rfe <input>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `input` | :material-check: | — | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project.
+| `input` | :material-check: | - | The RFE to assess. Accepts multiple formats: a Jira issue key (e.g., RHAIRFE-1234), a file path to a document, a URL, raw pasted text, or a wildcard pattern (e.g., RHAIRFE-*) for bulk assessment of an entire Jira project.
  |
 
 ## Usage
 
-```
+```bash
 /assess-rfe RHAIRFE-1234
 /assess-rfe PROJ-99
 /assess-rfe /path/to/document.md

--- a/site/docs/plugins/assess-rfe/export-rubric.md
+++ b/site/docs/plugins/assess-rfe/export-rubric.md
@@ -23,6 +23,6 @@ understand how RFEs are evaluated.
 
 ## Usage
 
-```
+```bash
 /export-rubric
 ```

--- a/site/docs/plugins/autofix-skills/autofix-cve-resolve.md
+++ b/site/docs/plugins/autofix-skills/autofix-cve-resolve.md
@@ -23,6 +23,6 @@ and branches per CVE. Never writes fix code directly.
 
 ## Usage
 
-```
+```bash
 /autofix-cve-resolve
 ```

--- a/site/docs/plugins/autofix-skills/autofix-research.md
+++ b/site/docs/plugins/autofix-skills/autofix-research.md
@@ -23,6 +23,6 @@ observations if external access would be needed.
 
 ## Usage
 
-```
+```bash
 /autofix-research
 ```

--- a/site/docs/plugins/autofix-skills/autofix-resolve.md
+++ b/site/docs/plugins/autofix-skills/autofix-resolve.md
@@ -24,7 +24,7 @@ Never writes code directly — all coding happens through prompt agents.
 
 ## Arguments
 
-```
+```bash
 /autofix-resolve [mode]
 ```
 
@@ -34,7 +34,7 @@ Never writes code directly — all coding happens through prompt agents.
 
 ## Usage
 
-```
+```bash
 /autofix-resolve
 /autofix-resolve iterate
 ```

--- a/site/docs/plugins/autofix-skills/autofix-triage.md
+++ b/site/docs/plugins/autofix-skills/autofix-triage.md
@@ -25,6 +25,6 @@ or external deps). Produces a structured JSON verdict
 
 ## Usage
 
-```
+```bash
 /autofix-triage
 ```

--- a/site/docs/plugins/disconnected-readiness-scorer/disconnected-score.md
+++ b/site/docs/plugins/disconnected-readiness-scorer/disconnected-score.md
@@ -13,6 +13,6 @@ Score a repository's readiness for disconnected / air-gapped OpenShift deploymen
 
 ## Usage
 
-```
+```bash
 /disconnected-score
 ```

--- a/site/docs/plugins/disconnected-readiness-scorer/disconnected-score.md
+++ b/site/docs/plugins/disconnected-readiness-scorer/disconnected-score.md
@@ -1,0 +1,18 @@
+---
+title: disconnected-score
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# disconnected-score
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments
+
+**Plugin**: [disconnected-readiness-scorer](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```
+/disconnected-score
+```

--- a/site/docs/plugins/disconnected-readiness-scorer/index.md
+++ b/site/docs/plugins/disconnected-readiness-scorer/index.md
@@ -15,7 +15,7 @@ Score a repository's readiness for disconnected / air-gapped OpenShift deploymen
     - **Author**: asanzgom
     - **License**: Apache-2.0
     - **Category**: [DevOps & CI/CD](../../categories/devops.md)
-    - **Repository**: [asanzgom/disconnected-readiness-scorer](https://github.com/asanzgom/disconnected-readiness-scorer)
+    - **Repository**: [opendatahub-io/disconnected-readiness-scorer](https://github.com/opendatahub-io/disconnected-readiness-scorer)
     - **Tags**: <span class="tag-pill">disconnected</span> <span class="tag-pill">air-gap</span> <span class="tag-pill">openshift</span> <span class="tag-pill">image-mirroring</span> <span class="tag-pill">readiness</span> <span class="tag-pill">scoring</span>
 
 ## Skills

--- a/site/docs/plugins/disconnected-readiness-scorer/index.md
+++ b/site/docs/plugins/disconnected-readiness-scorer/index.md
@@ -1,0 +1,31 @@
+---
+title: disconnected-readiness-scorer
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# disconnected-readiness-scorer
+
+Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: asanzgom
+    - **License**: Apache-2.0
+    - **Category**: [DevOps & CI/CD](../../categories/devops.md)
+    - **Repository**: [asanzgom/disconnected-readiness-scorer](https://github.com/asanzgom/disconnected-readiness-scorer)
+    - **Tags**: <span class="tag-pill">disconnected</span> <span class="tag-pill">air-gap</span> <span class="tag-pill">openshift</span> <span class="tag-pill">image-mirroring</span> <span class="tag-pill">readiness</span> <span class="tag-pill">scoring</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/disconnected-score`](disconnected-score.md) | Score a repository's readiness for disconnected / air-gapped OpenShift deployments | :material-check: |
+
+## Installation
+
+```bash
+/plugin install disconnected-readiness-scorer@opendatahub-skills
+```

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-10 plugins registered in the marketplace.
+11 plugins registered in the marketplace.
 
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
@@ -21,3 +21,4 @@ title: Plugins
 | [knowledge-skills](knowledge-skills/index.md) | Documentation | 1 | v0.1.0 |
 | [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [meeting-quality-skills](meeting-quality-skills/index.md) | Product Planning | 2 | v0.1.0 |
+| [disconnected-readiness-scorer](disconnected-readiness-scorer/index.md) | DevOps & CI/CD | 1 | v0.1.0 |

--- a/site/docs/plugins/knowledge-skills/knowledge.repo.md
+++ b/site/docs/plugins/knowledge-skills/knowledge.repo.md
@@ -25,7 +25,7 @@ and artifacts (patch file, run report). Non-interactive — designed for CI.
 
 ## Arguments
 
-```
+```bash
 /knowledge.repo [--days N]
 ```
 
@@ -35,7 +35,7 @@ and artifacts (patch file, run report). Non-interactive — designed for CI.
 
 ## Usage
 
-```
+```bash
 /knowledge.repo
 /knowledge.repo --days 14
 /knowledge.repo --days 30

--- a/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-async-update-check.md
@@ -29,21 +29,21 @@ reminder message the organizer can send to those who haven't updated yet.
 
 ## Arguments
 
-```
+```bash
 /meeting-async-update-check <meeting_title> <meeting_datetime> <attendee_list> <update_document> [update_format]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `meeting_title` | :material-check: | — | Title of the meeting being checked |
-| `meeting_datetime` | :material-check: | — | Date and time of the upcoming meeting |
-| `attendee_list` | :material-check: | — | List of meeting attendees to check for updates |
-| `update_document` | :material-check: | — | Shared meeting update document content or link (Google Doc or pasted text) |
-| `update_format` |  | — | Optional expected format for updates, if one exists |
+| `meeting_title` | :material-check: | - | Title of the meeting being checked |
+| `meeting_datetime` | :material-check: | - | Date and time of the upcoming meeting |
+| `attendee_list` | :material-check: | - | List of meeting attendees to check for updates |
+| `update_document` | :material-check: | - | Shared meeting update document content or link (Google Doc or pasted text) |
+| `update_format` |  | - | Optional expected format for updates, if one exists |
 
 ## Usage
 
-```
+```bash
 /meeting-async-update-check
 Check who hasn't updated the weekly sync doc yet
 ```

--- a/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
+++ b/site/docs/plugins/meeting-quality-skills/meeting-risk-agenda.md
@@ -27,19 +27,19 @@ or could be shortened. If ownership is unclear, it explicitly calls that out.
 
 ## Arguments
 
-```
+```bash
 /meeting-risk-agenda [meeting_title] <update_document> [attendee_list]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `meeting_title` |  | — | Title of the meeting (optional context) |
-| `update_document` | :material-check: | — | Meeting update document content (Google Doc or pasted text) |
-| `attendee_list` |  | — | List of meeting attendees (optional, helps with owner matching) |
+| `meeting_title` |  | - | Title of the meeting (optional context) |
+| `update_document` | :material-check: | - | Meeting update document content (Google Doc or pasted text) |
+| `attendee_list` |  | - | List of meeting attendees (optional, helps with owner matching) |
 
 ## Usage
 
-```
+```bash
 /meeting-risk-agenda
 Build a focused agenda from our team's weekly updates
 ```

--- a/site/docs/plugins/odh-ai-helpers/adr-review.md
+++ b/site/docs/plugins/odh-ai-helpers/adr-review.md
@@ -26,17 +26,17 @@ Markdown files, .docx documents, and directories of multiple ADRs.
 
 ## Arguments
 
-```
+```bash
 /adr-review <ADR_PATH>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ADR_PATH` | :material-check: | — | Path to an ADR file (.md or .docx) or a directory containing multiple ADRs |
+| `ADR_PATH` | :material-check: | - | Path to an ADR file (.md or .docx) or a directory containing multiple ADRs |
 
 ## Usage
 
-```
+```bash
 /adr-review /path/to/adr.md
 /adr-review /path/to/adr-directory/
 ```

--- a/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
+++ b/site/docs/plugins/odh-ai-helpers/git-shallow-clone.md
@@ -21,18 +21,18 @@ prints the clone path to stdout for downstream consumption.
 
 ## Arguments
 
-```
+```bash
 /git-shallow-clone <REPOSITORY_URL> [TAG_OR_BRANCH]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `REPOSITORY_URL` | :material-check: | — | URL of the Git repository to clone |
+| `REPOSITORY_URL` | :material-check: | - | URL of the Git repository to clone |
 | `TAG_OR_BRANCH` |  | `HEAD` | Git tag or branch to shallow-clone |
 
 ## Usage
 
-```
+```bash
 /git-shallow-clone https://github.com/psf/requests.git
 /git-shallow-clone https://github.com/psf/requests.git v2.28.0
 ```

--- a/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
+++ b/site/docs/plugins/odh-ai-helpers/gitlab-pipeline-debugger.md
@@ -23,20 +23,20 @@ parse full GitLab pipeline and job URLs to extract project paths and IDs.
 
 ## Arguments
 
-```
+```bash
 /gitlab-pipeline-debugger [PIPELINE_URL] [-b] [-p] [-R]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PIPELINE_URL` |  | — | Full GitLab pipeline or job URL to debug |
-| `-b` |  | — | Branch name to check pipeline for |
-| `-p` |  | — | Specific pipeline ID to inspect |
+| `PIPELINE_URL` |  | - | Full GitLab pipeline or job URL to debug |
+| `-b` |  | - | Branch name to check pipeline for |
+| `-p` |  | - | Specific pipeline ID to inspect |
 | `-R` |  | `auto-detected from git remote` | GitLab project path to target |
 
 ## Usage
 
-```
+```bash
 /gitlab-pipeline-debugger
 /gitlab-pipeline-debugger https://gitlab.com/org/project/-/pipelines/123456
 /gitlab-pipeline-debugger -b feature-branch

--- a/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
+++ b/site/docs/plugins/odh-ai-helpers/jira-upload-chat-log.md
@@ -23,7 +23,7 @@ the actual upload to the jira-workitem-attach skill.
 
 ## Arguments
 
-```
+```bash
 /jira-upload-chat-log [TICKET_KEY]
 ```
 
@@ -33,7 +33,7 @@ the actual upload to the jira-workitem-attach skill.
 
 ## Usage
 
-```
+```bash
 /jira-upload-chat-log AIPCC-7354
 /jira-upload-chat-log
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-full-deps.md
+++ b/site/docs/plugins/odh-ai-helpers/python-full-deps.md
@@ -24,19 +24,19 @@ dependencies from metadata.
 
 ## Arguments
 
-```
+```bash
 /python-full-deps <PACKAGE_NAME> [VERSION] [PYTHON_VERSION]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | PyPI project name (e.g., vllm, requests) |
+| `PACKAGE_NAME` | :material-check: | - | PyPI project name (e.g., vllm, requests) |
 | `VERSION` |  | `latest` | Specific package version (e.g., 0.4.0) |
 | `PYTHON_VERSION` |  | `3.12` | Python version for environment marker resolution (e.g., 3.11) |
 
 ## Usage
 
-```
+```bash
 /python-full-deps requests
 /python-full-deps vllm 0.4.0 3.11
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-bug-finder.md
@@ -23,17 +23,17 @@ and available workarounds for each issue found.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-bug-finder <PACKAGE_NAME>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | Python package name to search issues for |
+| `PACKAGE_NAME` | :material-check: | - | Python package name to search issues for |
 
 ## Usage
 
-```
+```bash
 /python-packaging-bug-finder torch
 /python-packaging-bug-finder numpy
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-complexity.md
@@ -23,19 +23,19 @@ actionable recommendations for wheel building strategies.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-complexity <PACKAGE_NAME> [VERSION] [--json]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | Python package name to analyze |
+| `PACKAGE_NAME` | :material-check: | - | Python package name to analyze |
 | `VERSION` |  | `latest` | Specific package version |
-| `--json` |  | — | Output as structured JSON for programmatic processing |
+| `--json` |  | - | Output as structured JSON for programmatic processing |
 
 ## Usage
 
-```
+```bash
 /python-packaging-complexity torch
 /python-packaging-complexity numpy 1.24.3
 /python-packaging-complexity tensorflow --json

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-env-finder.md
@@ -23,7 +23,7 @@ Python-specific build variables.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-env-finder [PROJECT_PATH]
 ```
 
@@ -33,7 +33,7 @@ Python-specific build variables.
 
 ## Usage
 
-```
+```bash
 /python-packaging-env-finder
 /python-packaging-env-finder /path/to/project
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-checker.md
@@ -26,20 +26,20 @@ Verdict, Build compliance, Export compliance, and Notes.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-license-checker <PACKAGE_NAME> [--repo-url] [--source-available] [--upstream-org]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | Python package name to check |
-| `--repo-url` |  | — | Source repository URL (skips source-finder step) |
-| `--source-available` |  | — | Whether buildable source exists |
-| `--upstream-org` |  | — | Name and primary country of the maintaining organization |
+| `PACKAGE_NAME` | :material-check: | - | Python package name to check |
+| `--repo-url` |  | - | Source repository URL (skips source-finder step) |
+| `--source-available` |  | - | Whether buildable source exists |
+| `--upstream-org` |  | - | Name and primary country of the maintaining organization |
 
 ## Usage
 
-```
+```bash
 /python-packaging-license-checker requests
 /python-packaging-license-checker some-package --repo-url https://github.com/org/repo
 ```

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-license-finder.md
@@ -22,19 +22,19 @@ directly. Can also accept a source URL to skip PyPI lookup entirely.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-license-finder <PACKAGE_NAME> [VERSION] [--source-url]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | Python package name |
+| `PACKAGE_NAME` | :material-check: | - | Python package name |
 | `VERSION` |  | `latest` | Specific package version |
-| `--source-url` |  | — | Source repository URL (skips PyPI lookup) |
+| `--source-url` |  | - | Source repository URL (skips PyPI lookup) |
 
 ## Usage
 
-```
+```bash
 /python-packaging-license-finder requests
 /python-packaging-license-finder django 4.2.0
 /python-packaging-license-finder some-pkg --source-url https://github.com/org/repo

--- a/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
+++ b/site/docs/plugins/odh-ai-helpers/python-packaging-source-finder.md
@@ -23,17 +23,17 @@ search when PyPI metadata is insufficient.
 
 ## Arguments
 
-```
+```bash
 /python-packaging-source-finder <PACKAGE_NAME>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PACKAGE_NAME` | :material-check: | — | Python package name to find the repository for |
+| `PACKAGE_NAME` | :material-check: | - | Python package name to find the repository for |
 
 ## Usage
 
-```
+```bash
 /python-packaging-source-finder requests
 /python-packaging-source-finder vllm
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-check-backported.md
@@ -22,19 +22,19 @@ the downstream branch). Adds an already_backported boolean to each PR.
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-check-backported [--input] [--downstream] [--branch] [--output]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--input` | :material-check: | — | Path to filtered.json from classify step |
-| `--downstream` | :material-check: | — | Path to downstream repository |
-| `--branch` | :material-check: | — | Downstream branch name (e.g., rhai/0.13.0) |
-| `--output` | :material-check: | — | Output path for candidates.json |
+| `--input` | :material-check: | - | Path to filtered.json from classify step |
+| `--downstream` | :material-check: | - | Path to downstream repository |
+| `--branch` | :material-check: | - | Downstream branch name (e.g., rhai/0.13.0) |
+| `--output` | :material-check: | - | Output path for candidates.json |
 
 ## Usage
 
-```
+```bash
 /vllm-backport-check-backported --input artifacts/filtered.json --downstream /path/to/downstream --branch rhai/0.13.0 --output artifacts/candidates.json
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-cherry-pick.md
@@ -23,21 +23,21 @@ follow-up for semantic validation of the cherry-picked diff.
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-cherry-pick [--input] [--downstream] [--branch] [--jira-url] [--report-url] [--output]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--input` | :material-check: | — | Path to ranked.json from score-rank step |
-| `--downstream` | :material-check: | — | Path to downstream repository |
-| `--branch` | :material-check: | — | Downstream branch name (e.g., rhai/0.13.0) |
-| `--jira-url` |  | — | Jira ticket URL to link in the PR |
-| `--report-url` |  | — | GitHub report URL to link in the PR |
-| `--output` | :material-check: | — | Output path for cherry-pick-result.json |
+| `--input` | :material-check: | - | Path to ranked.json from score-rank step |
+| `--downstream` | :material-check: | - | Path to downstream repository |
+| `--branch` | :material-check: | - | Downstream branch name (e.g., rhai/0.13.0) |
+| `--jira-url` |  | - | Jira ticket URL to link in the PR |
+| `--report-url` |  | - | GitHub report URL to link in the PR |
+| `--output` | :material-check: | - | Output path for cherry-pick-result.json |
 
 ## Usage
 
-```
+```bash
 /vllm-backport-cherry-pick --input artifacts/ranked.json --downstream /path/to/repo --branch rhai/0.13.0 --output artifacts/cherry-pick-result.json
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-classify.md
@@ -23,19 +23,19 @@ non-runtime code. PRs classified as "unclear" require agent review.
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-classify [--input] [--repo] [--tag] [--output]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--input` | :material-check: | — | Path to raw-prs.json from fetch-prs step |
-| `--repo` | :material-check: | — | Path to local vllm repository clone |
-| `--tag` | :material-check: | — | Release tag to check file existence against (e.g., v0.13.0) |
-| `--output` | :material-check: | — | Output path for filtered.json |
+| `--input` | :material-check: | - | Path to raw-prs.json from fetch-prs step |
+| `--repo` | :material-check: | - | Path to local vllm repository clone |
+| `--tag` | :material-check: | - | Release tag to check file existence against (e.g., v0.13.0) |
+| `--output` | :material-check: | - | Output path for filtered.json |
 
 ## Usage
 
-```
+```bash
 /vllm-backport-classify --input artifacts/raw-prs.json --repo /path/to/vllm --tag v0.13.0 --output artifacts/filtered.json
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-fetch-prs.md
@@ -22,7 +22,7 @@ Also detects reverted PRs. Outputs a JSON array of PR objects to stdout.
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-fetch-prs [DAYS_BACK]
 ```
 
@@ -32,7 +32,7 @@ Also detects reverted PRs. Outputs a JSON array of PR objects to stdout.
 
 ## Usage
 
-```
+```bash
 /vllm-backport-fetch-prs
 /vllm-backport-fetch-prs 14
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-push-report.md
@@ -21,18 +21,18 @@ commits, pushes, and prints the GitHub URL to stdout.
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-push-report [--report] [--candidates] [--version]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--report` | :material-check: | — | Path to report markdown file |
-| `--candidates` | :material-check: | — | Path to ranked.json |
-| `--version` | :material-check: | — | Release version (e.g., v0.13.0) |
+| `--report` | :material-check: | - | Path to report markdown file |
+| `--candidates` | :material-check: | - | Path to ranked.json |
+| `--version` | :material-check: | - | Release version (e.g., v0.13.0) |
 
 ## Usage
 
-```
+```bash
 /vllm-backport-push-report --report artifacts/report.md --candidates artifacts/ranked.json --version v0.13.0
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-backport-score-rank.md
@@ -23,17 +23,17 @@ backport_ease labels (ai-fixable if self-contained and safe/moderate risk).
 
 ## Arguments
 
-```
+```bash
 /vllm-backport-score-rank [--input] [--output]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--input` | :material-check: | — | Path to analyzed.json with agent-added semantic fields |
-| `--output` | :material-check: | — | Output path for ranked.json |
+| `--input` | :material-check: | - | Path to analyzed.json with agent-added semantic fields |
+| `--output` | :material-check: | - | Output path for ranked.json |
 
 ## Usage
 
-```
+```bash
 /vllm-backport-score-rank --input artifacts/analyzed.json --output artifacts/ranked.json
 ```

--- a/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-compare-reqs.md
@@ -24,20 +24,20 @@ package onboarding workflows.
 
 ## Arguments
 
-```
+```bash
 /vllm-compare-reqs <VERSION1> <VERSION2> <VARIANT_OR_FILE> [--pretty]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VERSION1` | :material-check: | — | First version to compare (e.g., v0.13.0) |
-| `VERSION2` | :material-check: | — | Second version to compare (e.g., v0.14.0) |
-| `VARIANT_OR_FILE` | :material-check: | — | Variant name (rocm, cuda, cpu, tpu, xpu) or specific file (common.txt, rocm-build.txt) |
+| `VERSION1` | :material-check: | - | First version to compare (e.g., v0.13.0) |
+| `VERSION2` | :material-check: | - | Second version to compare (e.g., v0.14.0) |
+| `VARIANT_OR_FILE` | :material-check: | - | Variant name (rocm, cuda, cpu, tpu, xpu) or specific file (common.txt, rocm-build.txt) |
 | `--pretty` |  | `true` | Show clean categorized output (use --no-pretty for simple diff) |
 
 ## Usage
 
-```
+```bash
 /vllm-compare-reqs v0.13.0 v0.14.0 rocm
 /vllm-compare-reqs v0.13.0 v0.14.0 cuda
 /vllm-compare-reqs v0.13.0 v0.14.0 common.txt

--- a/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
+++ b/site/docs/plugins/odh-ai-helpers/vllm-slack-summary.md
@@ -23,7 +23,7 @@ performance regressions, and upstream release stability.
 
 ## Arguments
 
-```
+```bash
 /vllm-slack-summary [--days] [--output-dir]
 ```
 
@@ -34,7 +34,7 @@ performance regressions, and upstream release stability.
 
 ## Usage
 
-```
+```bash
 /vllm-slack-summary
 /vllm-slack-summary --days 14
 ```

--- a/site/docs/plugins/quality-tooling/historical-bug-coverage.md
+++ b/site/docs/plugins/quality-tooling/historical-bug-coverage.md
@@ -33,21 +33,21 @@ cross-repo coverage analysis.
 
 ## Arguments
 
-```
+```bash
 /historical-bug-coverage --jql JQL_QUERY --repo REPO_PATH [--external-tests PATH] [--filter FILTER_ID] [--output PATH]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--jql` | :material-check: | — | JQL query string to fetch bugs from Jira (mutually exclusive with --filter) |
-| `--repo` | :material-check: | — | Path to the target repository to analyze for test coverage |
-| `--external-tests` |  | — | Path to an external test repository for cross-repo coverage analysis |
-| `--filter` |  | — | Saved Jira filter ID (alternative to --jql) |
-| `--output` |  | — | Output HTML file path (defaults to {repo-name}-bug-coverage.html) |
+| `--jql` | :material-check: | - | JQL query string to fetch bugs from Jira (mutually exclusive with --filter) |
+| `--repo` | :material-check: | - | Path to the target repository to analyze for test coverage |
+| `--external-tests` |  | - | Path to an external test repository for cross-repo coverage analysis |
+| `--filter` |  | - | Saved Jira filter ID (alternative to --jql) |
+| `--output` |  | - | Output HTML file path (defaults to {repo-name}-bug-coverage.html) |
 
 ## Usage
 
-```
+```bash
 /historical-bug-coverage --jql "project = MYPROJECT AND priority in (Blocker, Critical)" --repo /path/to/repo
 /historical-bug-coverage --jql "project = MYPROJECT AND component = 'Dashboard'" --repo /path/to/repo --external-tests /path/to/e2e-tests
 /historical-bug-coverage --jql "project = MYPROJECT AND created >= -90d" --repo /path/to/repo

--- a/site/docs/plugins/quality-tooling/konflux-build-simulator.md
+++ b/site/docs/plugins/quality-tooling/konflux-build-simulator.md
@@ -31,17 +31,17 @@ FIPS strictfipsruntime enforcement, and fastify v5 regression testing.
 
 ## Arguments
 
-```
+```bash
 /konflux-build-simulator [repository-url]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` |  | — | GitHub repository URL to generate build simulation for (prompted if omitted) |
+| `repository-url` |  | - | GitHub repository URL to generate build simulation for (prompted if omitted) |
 
 ## Usage
 
-```
+```bash
 /konflux-build-simulator https://github.com/opendatahub-io/odh-dashboard
 /konflux-build-simulator https://github.com/opendatahub-io/kserve
 /konflux-build-simulator https://github.com/kubeflow/training-operator

--- a/site/docs/plugins/quality-tooling/quality-repo-analysis.md
+++ b/site/docs/plugins/quality-tooling/quality-repo-analysis.md
@@ -29,17 +29,17 @@ browser upon completion.
 
 ## Arguments
 
-```
+```bash
 /quality-repo-analysis [repository-url]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` |  | — | GitHub repository URL to analyze (prompted if omitted) |
+| `repository-url` |  | - | GitHub repository URL to analyze (prompted if omitted) |
 
 ## Usage
 
-```
+```bash
 /quality-repo-analysis https://github.com/opendatahub-io/kserve
 /quality-repo-analysis https://github.com/kubeflow/training-operator
 ```

--- a/site/docs/plugins/quality-tooling/risk-assessment.md
+++ b/site/docs/plugins/quality-tooling/risk-assessment.md
@@ -32,20 +32,20 @@ on GitHub.
 
 ## Arguments
 
-```
+```bash
 /risk-assessment <PR_NUMBER> <REPO> [--headless] [--dry-run]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PR_NUMBER` | :material-check: | — | GitHub pull request number to analyze |
-| `REPO` | :material-check: | — | Repository identifier (owner/repo format) |
-| `--headless` |  | — | Run in headless mode for CI integration |
-| `--dry-run` |  | — | Run analysis without publishing results to GitHub |
+| `PR_NUMBER` | :material-check: | - | GitHub pull request number to analyze |
+| `REPO` | :material-check: | - | Repository identifier (owner/repo format) |
+| `--headless` |  | - | Run in headless mode for CI integration |
+| `--dry-run` |  | - | Run analysis without publishing results to GitHub |
 
 ## Usage
 
-```
+```bash
 /risk-assessment 123 opendatahub-io/odh-dashboard
 /risk-assessment 456 opendatahub-io/kserve --dry-run
 ```

--- a/site/docs/plugins/quality-tooling/test-rules-generator.md
+++ b/site/docs/plugins/quality-tooling/test-rules-generator.md
@@ -30,17 +30,17 @@ following established repository conventions.
 
 ## Arguments
 
-```
+```bash
 /test-rules-generator [repository-url]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `repository-url` |  | — | GitHub repository URL to extract test patterns from (prompted if omitted) |
+| `repository-url` |  | - | GitHub repository URL to extract test patterns from (prompted if omitted) |
 
 ## Usage
 
-```
+```bash
 /test-rules-generator https://github.com/opendatahub-io/odh-dashboard
 /test-rules-generator https://github.com/opendatahub-io/kserve
 /test-rules-generator https://github.com/kubeflow/training-operator

--- a/site/docs/plugins/rfe-creator/architecture-review.md
+++ b/site/docs/plugins/rfe-creator/architecture-review.md
@@ -25,6 +25,6 @@ skips if unavailable. Runs with model: opus.
 
 ## Usage
 
-```
+```bash
 /architecture-review
 ```

--- a/site/docs/plugins/rfe-creator/feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/feasibility-review.md
@@ -24,6 +24,6 @@ optimistic estimates. Runs with model: opus.
 
 ## Usage
 
-```
+```bash
 /feasibility-review
 ```

--- a/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
+++ b/site/docs/plugins/rfe-creator/rfe-creator.update-deps.md
@@ -23,6 +23,6 @@ explicitly by the user.
 
 ## Usage
 
-```
+```bash
 /rfe-creator.update-deps
 ```

--- a/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
+++ b/site/docs/plugins/rfe-creator/rfe-feasibility-review.md
@@ -26,6 +26,6 @@ with model: opus.
 
 ## Usage
 
-```
+```bash
 /rfe-feasibility-review
 ```

--- a/site/docs/plugins/rfe-creator/rfe.auto-fix.md
+++ b/site/docs/plugins/rfe-creator/rfe.auto-fix.md
@@ -25,25 +25,25 @@ handled RFEs and random sampling.
 
 ## Arguments
 
-```
+```bash
 /rfe.auto-fix <IDs...> | --jql <query> [--limit N] [--batch-size N] [--headless] [--reprocess] [--random N] [--announce-complete] [--data-dir <path>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `IDs` |  | — | Explicit RFE IDs to process (space-separated) |
-| `--jql` |  | — | JQL query to fetch RFE IDs from Jira |
-| `--limit` |  | — | Max number of results from JQL query |
+| `IDs` |  | - | Explicit RFE IDs to process (space-separated) |
+| `--jql` |  | - | JQL query to fetch RFE IDs from Jira |
+| `--limit` |  | - | Max number of results from JQL query |
 | `--batch-size` |  | `50` | Process IDs in batches of this size |
-| `--data-dir` |  | — | Directory for snapshot data |
-| `--headless` |  | — | Non-interactive mode |
-| `--reprocess` |  | — | Reprocess RFEs that had prior runs |
-| `--random` |  | — | Process N random RFEs from the result set |
-| `--announce-complete` |  | — | Print completion marker when done |
+| `--data-dir` |  | - | Directory for snapshot data |
+| `--headless` |  | - | Non-interactive mode |
+| `--reprocess` |  | - | Reprocess RFEs that had prior runs |
+| `--random` |  | - | Process N random RFEs from the result set |
+| `--announce-complete` |  | - | Print completion marker when done |
 
 ## Usage
 
-```
+```bash
 /rfe.auto-fix RFE-001 RFE-002 RFE-003
 /rfe.auto-fix --jql "project=RHAIRFE AND status=New" --limit 20
 /rfe.auto-fix --jql "project=RHAIRFE" --reprocess --random 5

--- a/site/docs/plugins/rfe-creator/rfe.create.md
+++ b/site/docs/plugins/rfe-creator/rfe.create.md
@@ -24,21 +24,21 @@ Supports headless mode for batch/CI use.
 
 ## Arguments
 
-```
+```bash
 /rfe.create <problem-statement> [--headless] [--priority <value>] [--labels <csv>] [--rfe-id <ID>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `problem-statement` | :material-check: | — | The problem statement, idea, or need to turn into RFEs |
-| `--headless` |  | — | Skip clarifying questions (Step 2), generate RFEs directly from the input |
+| `problem-statement` | :material-check: | - | The problem statement, idea, or need to turn into RFEs |
+| `--headless` |  | - | Skip clarifying questions (Step 2), generate RFEs directly from the input |
 | `--priority` |  | `Normal` | Override default priority for created RFEs |
-| `--labels` |  | — | Labels to apply to created RFEs |
-| `--rfe-id` |  | — | Pre-assigned RFE ID; use this instead of allocating a new one. The placeholder file must already exist. |
+| `--labels` |  | - | Labels to apply to created RFEs |
+| `--rfe-id` |  | - | Pre-assigned RFE ID; use this instead of allocating a new one. The placeholder file must already exist. |
 
 ## Usage
 
-```
+```bash
 /rfe.create Users need better error messages when model serving fails
 /rfe.create --headless --priority Critical Fix dashboard latency for large clusters
 /rfe.create --headless --rfe-id RFE-003 --labels candidate-3.5 Support GPU sharing

--- a/site/docs/plugins/rfe-creator/rfe.review.md
+++ b/site/docs/plugins/rfe-creator/rfe.review.md
@@ -26,19 +26,19 @@ revise).
 
 ## Arguments
 
-```
+```bash
 /rfe.review <ID> [ID2 ...] [--headless] [--caller <name>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ID` | :material-check: | — | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) |
-| `--headless` |  | — | Suppress end-of-run summary; used when called from rfe.auto-fix or rfe.split |
+| `ID` | :material-check: | - | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) |
+| `--headless` |  | - | Suppress end-of-run summary; used when called from rfe.auto-fix or rfe.split |
 | `--caller` |  | `none` | Identifies calling skill for headless return routing |
 
 ## Usage
 
-```
+```bash
 /rfe.review RHAIRFE-1234
 /rfe.review RFE-001 RFE-002 RFE-003
 /rfe.review --headless --caller autofix RHAIRFE-1234 RHAIRFE-5678

--- a/site/docs/plugins/rfe-creator/rfe.speedrun.md
+++ b/site/docs/plugins/rfe-creator/rfe.speedrun.md
@@ -24,22 +24,22 @@ rfe.submit as sub-skills.
 
 ## Arguments
 
-```
+```bash
 /rfe.speedrun <idea-or-key> [--input <path>] [--headless] [--dry-run] [--batch-size N] [--announce-complete]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `idea-or-key` |  | — | A free-text idea or Jira key (RHAIRFE-NNNN). Mutually exclusive with --input. |
-| `--input` |  | — | Path to a YAML file with batch entries (prompt, priority, labels per entry) |
-| `--headless` |  | — | Suppress questions and confirmations (for CI/eval) |
-| `--dry-run` |  | — | Skip Jira writes in submit phase |
+| `idea-or-key` |  | - | A free-text idea or Jira key (RHAIRFE-NNNN). Mutually exclusive with --input. |
+| `--input` |  | - | Path to a YAML file with batch entries (prompt, priority, labels per entry) |
+| `--headless` |  | - | Suppress questions and confirmations (for CI/eval) |
+| `--dry-run` |  | - | Skip Jira writes in submit phase |
 | `--batch-size` |  | `5` | Override batch size for auto-fix phase |
-| `--announce-complete` |  | — | Print completion marker when done (for CI/eval harnesses) |
+| `--announce-complete` |  | - | Print completion marker when done (for CI/eval harnesses) |
 
 ## Usage
 
-```
+```bash
 /rfe.speedrun Better dashboard for ML model monitoring
 /rfe.speedrun RHAIRFE-1234
 /rfe.speedrun --input batch.yaml --headless --dry-run

--- a/site/docs/plugins/rfe-creator/rfe.split.md
+++ b/site/docs/plugins/rfe-creator/rfe.split.md
@@ -24,18 +24,18 @@ are represented in the children.
 
 ## Arguments
 
-```
+```bash
 /rfe.split <ID> [ID2 ...] [--headless]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ID` | :material-check: | — | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) to split |
-| `--headless` |  | — | Suppress end-of-run summary; used when called from rfe.auto-fix |
+| `ID` | :material-check: | - | One or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN) to split |
+| `--headless` |  | - | Suppress end-of-run summary; used when called from rfe.auto-fix |
 
 ## Usage
 
-```
+```bash
 /rfe.split RHAIRFE-1234
 /rfe.split RHAIRFE-1234 RHAIRFE-5678
 ```

--- a/site/docs/plugins/rfe-creator/rfe.submit.md
+++ b/site/docs/plugins/rfe-creator/rfe.submit.md
@@ -25,18 +25,18 @@ JIRA_USER, and JIRA_TOKEN environment variables.
 
 ## Arguments
 
-```
+```bash
 /rfe.submit [--dry-run] [--artifacts-dir <path>]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `--dry-run` |  | — | Validate locally without writing to Jira |
+| `--dry-run` |  | - | Validate locally without writing to Jira |
 | `--artifacts-dir` |  | `artifacts` | Path to the artifacts directory |
 
 ## Usage
 
-```
+```bash
 /rfe.submit
 /rfe.submit --dry-run
 ```

--- a/site/docs/plugins/rfe-creator/scope-review.md
+++ b/site/docs/plugins/rfe-creator/scope-review.md
@@ -25,6 +25,6 @@ original RFE scope.
 
 ## Usage
 
-```
+```bash
 /scope-review
 ```

--- a/site/docs/plugins/rfe-creator/strat.create.md
+++ b/site/docs/plugins/rfe-creator/strat.create.md
@@ -24,7 +24,7 @@ source RFE, ready for refinement with strat.refine.
 
 ## Usage
 
-```
+```bash
 /strat.create RHAIRFE-1234
 /strat.create
 ```

--- a/site/docs/plugins/rfe-creator/strat.prioritize.md
+++ b/site/docs/plugins/rfe-creator/strat.prioritize.md
@@ -21,6 +21,6 @@ and open questions (JQL filtering, backlog ordering representation).
 
 ## Usage
 
-```
+```bash
 /strat.prioritize
 ```

--- a/site/docs/plugins/rfe-creator/strat.refine.md
+++ b/site/docs/plugins/rfe-creator/strat.refine.md
@@ -26,6 +26,6 @@ execution.
 
 ## Usage
 
-```
+```bash
 /strat.refine
 ```

--- a/site/docs/plugins/rfe-creator/strat.review.md
+++ b/site/docs/plugins/rfe-creator/strat.review.md
@@ -24,6 +24,6 @@ after revisions.
 
 ## Usage
 
-```
+```bash
 /strat.review
 ```

--- a/site/docs/plugins/rfe-creator/testability-review.md
+++ b/site/docs/plugins/rfe-creator/testability-review.md
@@ -25,6 +25,6 @@ vague criteria.
 
 ## Usage
 
-```
+```bash
 /testability-review
 ```

--- a/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
+++ b/site/docs/plugins/rhoai-security-reviewer/security-reviewer.md
@@ -42,20 +42,20 @@ patterns, secret management, namespace-scoped RBAC).
 
 ## Arguments
 
-```
+```bash
 /security-reviewer <STRAT_KEY> --reviewer <N> --threat-surface <path> --tier <tier>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `STRAT_KEY` | :material-check: | — | RHAISTRAT Jira key (e.g., RHAISTRAT-400) |
-| `--reviewer` | :material-check: | — | Reviewer number (1, 2, or 3) identifying this instance in the consensus set |
-| `--threat-surface` | :material-check: | — | Path to the threat surface inventory file extracted by the orchestrator |
-| `--tier` | :material-check: | — | Review depth tier: light (minimal surface), standard (1-2 hints), or deep (3+ hints, auth+crypto, agentic/MCP) |
+| `STRAT_KEY` | :material-check: | - | RHAISTRAT Jira key (e.g., RHAISTRAT-400) |
+| `--reviewer` | :material-check: | - | Reviewer number (1, 2, or 3) identifying this instance in the consensus set |
+| `--threat-surface` | :material-check: | - | Path to the threat surface inventory file extracted by the orchestrator |
+| `--tier` | :material-check: | - | Review depth tier: light (minimal surface), standard (1-2 hints), or deep (3+ hints, auth+crypto, agentic/MCP) |
 
 ## Usage
 
-```
+```bash
 /security-reviewer RHAISTRAT-400 --reviewer 1 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier standard
 /security-reviewer RHAISTRAT-400 --reviewer 2 --threat-surface artifacts/security-reviews/RHAISTRAT-400-threat-surface.md --tier deep
 ```

--- a/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
+++ b/site/docs/plugins/rhoai-security-reviewer/strat-security-review.md
@@ -34,18 +34,18 @@ Five or more NFR gaps at Standard/Deep tier upgrade the verdict to CONCERNS.
 
 ## Arguments
 
-```
+```bash
 /strat-security-review <RHAISTRAT_KEY> [--force]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `RHAISTRAT_KEY` | :material-check: | — | RHAISTRAT Jira key identifying the strategy document to review (e.g., RHAISTRAT-400) |
+| `RHAISTRAT_KEY` | :material-check: | - | RHAISTRAT Jira key identifying the strategy document to review (e.g., RHAISTRAT-400) |
 | `--force` |  | `false` | Regenerate the security review even if one already exists for this STRAT |
 
 ## Usage
 
-```
+```bash
 /strat-security-review RHAISTRAT-400
 /strat-security-review RHAISTRAT-400 --force
 ```

--- a/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-endpoints.md
@@ -22,6 +22,6 @@ priorities and reports gaps. Produces findings for Sections 1 and 4 of the test 
 
 ## Usage
 
-```
+```bash
 /test-plan-analyze-endpoints
 ```

--- a/site/docs/plugins/test-plan/test-plan-analyze-infra.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-infra.md
@@ -23,6 +23,6 @@ Sections 3 and 9.
 
 ## Usage
 
-```
+```bash
 /test-plan-analyze-infra
 ```

--- a/site/docs/plugins/test-plan/test-plan-analyze-placement.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-placement.md
@@ -23,6 +23,6 @@ and code repo agent readiness. Returns recommendations with user confirmation.
 
 ## Usage
 
-```
+```bash
 /test-plan-analyze-placement
 ```

--- a/site/docs/plugins/test-plan/test-plan-analyze-risks.md
+++ b/site/docs/plugins/test-plan/test-plan-analyze-risks.md
@@ -23,6 +23,6 @@ for Sections 2, 7, and 8.
 
 ## Usage
 
-```
+```bash
 /test-plan-analyze-risks
 ```

--- a/site/docs/plugins/test-plan/test-plan-case-implement.md
+++ b/site/docs/plugins/test-plan/test-plan-case-implement.md
@@ -24,19 +24,19 @@ via --test-cases flag.
 
 ## Arguments
 
-```
+```bash
 /test-plan-case-implement <FEATURE_SOURCE> [--test-cases TC-ID,TC-ID] [--target-repo PATH]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `FEATURE_SOURCE` | :material-check: | — | Feature directory, GitHub PR URL, or GitHub branch containing test case artifacts |
-| `--test-cases` |  | — | Comma-separated list of specific test case IDs to implement (e.g., TC-API-001,TC-E2E-001) |
-| `--target-repo` |  | — | Override auto-detected target repository path or URL |
+| `FEATURE_SOURCE` | :material-check: | - | Feature directory, GitHub PR URL, or GitHub branch containing test case artifacts |
+| `--test-cases` |  | - | Comma-separated list of specific test case IDs to implement (e.g., TC-API-001,TC-E2E-001) |
+| `--target-repo` |  | - | Override auto-detected target repository path or URL |
 
 ## Usage
 
-```
+```bash
 /test-plan-case-implement features/notebooks/RHAISTRAT-400-notebook-spawning
 /test-plan-case-implement https://github.com/org/repo/pull/7
 /test-plan-case-implement features/notebooks/RHAISTRAT-400 --test-cases TC-API-001,TC-API-002

--- a/site/docs/plugins/test-plan/test-plan-create-cases.md
+++ b/site/docs/plugins/test-plan/test-plan-create-cases.md
@@ -22,18 +22,18 @@ Supports regeneration mode for updating existing test cases.
 
 ## Arguments
 
-```
+```bash
 /test-plan-create-cases [FEATURE_SOURCE] [--output-dir PATH]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `FEATURE_SOURCE` |  | `auto-detected from prior /test-plan-create run` | Feature directory path, GitHub branch URL, or GitHub PR URL |
-| `--output-dir` |  | — | Force creation in specified directory (contributor override) |
+| `--output-dir` |  | - | Force creation in specified directory (contributor override) |
 
 ## Usage
 
-```
+```bash
 /test-plan-create-cases
 /test-plan-create-cases mcp_catalog
 /test-plan-create-cases /path/to/feature_dir

--- a/site/docs/plugins/test-plan/test-plan-create.md
+++ b/site/docs/plugins/test-plan/test-plan-create.md
@@ -24,19 +24,19 @@ TestPlan.md, TestPlanGaps.md, TestPlanReview.md, and README.md in a feature dire
 
 ## Arguments
 
-```
+```bash
 /test-plan-create <JIRA_KEY> [ADR_FILE_PATH]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JIRA_KEY` | :material-check: | — | Jira strategy key (RHAISTRAT-*) or issue key (RHOAIENG-*) to generate the test plan from |
-| `ADR_FILE_PATH` |  | — | Local path to an ADR document (markdown, text, or PDF) for additional technical depth |
-| `--output-dir` |  | — | Override output directory for test plan artifacts (skips validation) |
+| `JIRA_KEY` | :material-check: | - | Jira strategy key (RHAISTRAT-*) or issue key (RHOAIENG-*) to generate the test plan from |
+| `ADR_FILE_PATH` |  | - | Local path to an ADR document (markdown, text, or PDF) for additional technical depth |
+| `--output-dir` |  | - | Override output directory for test plan artifacts (skips validation) |
 
 ## Usage
 
-```
+```bash
 /test-plan-create RHAISTRAT-400
 /test-plan-create RHOAIENG-48676
 /test-plan-create RHAISTRAT-400 /path/to/adr.pdf

--- a/site/docs/plugins/test-plan/test-plan-generate-test-file.md
+++ b/site/docs/plugins/test-plan/test-plan-generate-test-file.md
@@ -23,6 +23,6 @@ low-scoring functions. Returns result via temp file for parent to write.
 
 ## Usage
 
-```
+```bash
 /test-plan-generate-test-file
 ```

--- a/site/docs/plugins/test-plan/test-plan-merge.md
+++ b/site/docs/plugins/test-plan/test-plan-merge.md
@@ -22,6 +22,6 @@ Returns updated section content, change summary, and merge statistics.
 
 ## Usage
 
-```
+```bash
 /test-plan-merge
 ```

--- a/site/docs/plugins/test-plan/test-plan-publish.md
+++ b/site/docs/plugins/test-plan/test-plan-publish.md
@@ -22,19 +22,19 @@ version-free branch names (test-plan/<source_key>) for iterative updates.
 
 ## Arguments
 
-```
+```bash
 /test-plan-publish [FEATURE_SOURCE] [--repo owner/repo] [--reviewers user1,user2]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `FEATURE_SOURCE` |  | `auto-detected from prior /test-plan-create run` | Feature directory path, GitHub branch URL, or GitHub PR URL |
-| `--repo` |  | — | Target GitHub repository in owner/repo format |
-| `--reviewers` |  | — | Comma-separated list of GitHub usernames to assign as PR reviewers |
+| `--repo` |  | - | Target GitHub repository in owner/repo format |
+| `--reviewers` |  | - | Comma-separated list of GitHub usernames to assign as PR reviewers |
 
 ## Usage
 
-```
+```bash
 /test-plan-publish tool_calling_metadata
 /test-plan-publish tool_calling_metadata --reviewers alice,bob
 /test-plan-publish tool_calling_metadata --repo org/test-plans-repo

--- a/site/docs/plugins/test-plan/test-plan-resolve-feedback.md
+++ b/site/docs/plugins/test-plan/test-plan-resolve-feedback.md
@@ -23,16 +23,16 @@ changes to the same branch with a descriptive commit message.
 
 ## Arguments
 
-```
+```bash
 /test-plan-resolve-feedback <PR_URL>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PR_URL` | :material-check: | — | Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/42) |
+| `PR_URL` | :material-check: | - | Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/42) |
 
 ## Usage
 
-```
+```bash
 /test-plan-resolve-feedback https://github.com/org/test-plans-repo/pull/42
 ```

--- a/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
+++ b/site/docs/plugins/test-plan/test-plan-resolve-gaps.md
@@ -22,6 +22,6 @@ structured output with resolved/unresolved/new gaps and statistics.
 
 ## Usage
 
-```
+```bash
 /test-plan-resolve-gaps
 ```

--- a/site/docs/plugins/test-plan/test-plan-review.md
+++ b/site/docs/plugins/test-plan/test-plan-review.md
@@ -24,6 +24,6 @@ and verdict (Ready/Revise/Rework).
 
 ## Usage
 
-```
+```bash
 /test-plan-review
 ```

--- a/site/docs/plugins/test-plan/test-plan-score-test-function.md
+++ b/site/docs/plugins/test-plan/test-plan-score-test-function.md
@@ -23,6 +23,6 @@ values from TC), Code Quality (clean, no excessive TODOs). Returns verdict
 
 ## Usage
 
-```
+```bash
 /test-plan-score-test-function
 ```

--- a/site/docs/plugins/test-plan/test-plan-score.md
+++ b/site/docs/plugins/test-plan/test-plan-score.md
@@ -22,17 +22,17 @@ evaluating test plans created outside the automated pipeline.
 
 ## Arguments
 
-```
+```bash
 /test-plan-score <feature_dir>
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `feature_dir` | :material-check: | — | Path to directory containing TestPlan.md |
+| `feature_dir` | :material-check: | - | Path to directory containing TestPlan.md |
 
 ## Usage
 
-```
+```bash
 /test-plan-score kagenti_agent_templates
 /test-plan-score mcp_catalog
 ```

--- a/site/docs/plugins/test-plan/test-plan-ui-verify.md
+++ b/site/docs/plugins/test-plan/test-plan-ui-verify.md
@@ -24,7 +24,7 @@ testing workflow with pre/post phase comparison and regression detection.
 
 ## Usage
 
-```
+```bash
 python3 scripts/ui_prepare.py --test-plan-pr https://github.com/org/repo/pull/5
 python3 scripts/ui_prepare.py --test-plan-pr <url> --tc TC-UI --priority P0
 python3 scripts/ui_prepare.py --test-plan-pr <url> --upgrade-phase pre

--- a/site/docs/plugins/test-plan/test-plan-update.md
+++ b/site/docs/plugins/test-plan/test-plan-update.md
@@ -23,18 +23,18 @@ version number automatically.
 
 ## Arguments
 
-```
+```bash
 /test-plan-update <SOURCE> <NEW_DOC_PATH> [<NEW_DOC_PATH>...]
 ```
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `SOURCE` | :material-check: | — | Test plan location: local directory path, GitHub branch URL, or GitHub PR URL |
-| `NEW_DOC_PATH` | :material-check: | — | One or more paths to new documentation files (ADR, API spec, design doc) |
+| `SOURCE` | :material-check: | - | Test plan location: local directory path, GitHub branch URL, or GitHub PR URL |
+| `NEW_DOC_PATH` | :material-check: | - | One or more paths to new documentation files (ADR, API spec, design doc) |
 
 ## Usage
 
-```
+```bash
 /test-plan-update ~/Code/collection-tests/mcp_catalog adr.pdf
 /test-plan-update https://github.com/org/repo/pull/42 api-spec.md design.md
 ```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -148,10 +148,14 @@ nav:
       - plugins/meeting-quality-skills/index.md
       - meeting-async-update-check: plugins/meeting-quality-skills/meeting-async-update-check.md
       - meeting-risk-agenda: plugins/meeting-quality-skills/meeting-risk-agenda.md
+    - disconnected-readiness-scorer:
+      - plugins/disconnected-readiness-scorer/index.md
+      - disconnected-score: plugins/disconnected-readiness-scorer/disconnected-score.md
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md
     - Documentation: categories/documentation.md
+    - DevOps & CI/CD: categories/devops.md
     - Security Review: categories/security.md
     - Development Tools: categories/development-tools.md
     - Product Planning: categories/planning.md


### PR DESCRIPTION
## Summary

- Registers the `disconnected-readiness-scorer` plugin in the skills registry
- Provides a single user-invocable skill (`disconnected-score`) that scans RHOAI component repos for patterns that break disconnected/air-gapped deployments
- Checks: image manifest completeness, digest enforcement, runtime egress detection, and Python dependency validation

## Plugin details

- **Repo:** https://github.com/opendatahub-io/disconnected-readiness-scorer
- **Category:** devops
- **License:** Apache-2.0
- **Install:** `/plugin install disconnected-readiness-scorer@opendatahub-skills`
- **Invoke:** `/disconnected-score` from any RHOAI component repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Disconnected Readiness Scorer plugin with a user-invocable skill "disconnected-score" and an install command.

* **Documentation**
  * Published marketplace/catalog and DevOps & CI/CD category entries, plugin docs and site navigation.
  * Site-wide docs formatting updates: CLI examples annotated as bash, and consistent separator/default marker formatting across category and plugin pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->