### PR TITLE
Update rfe-creator repo to opendatahub-io org

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       },
       "category": "planning",
       "description": "Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.\n",
-      "homepage": "https://github.com/jwforres/rfe-creator",
+      "homepage": "https://github.com/opendatahub-io/rfe-creator",
       "keywords": [
         "rfe",
         "jira",
@@ -22,13 +22,13 @@
         "pipeline"
       ],
       "name": "rfe-creator",
-      "repository": "https://github.com/jwforres/rfe-creator",
+      "repository": "https://github.com/opendatahub-io/rfe-creator",
       "skills": [
         "./.claude/skills"
       ],
       "source": {
         "ref": "main",
-        "repo": "jwforres/rfe-creator",
+        "repo": "opendatahub-io/rfe-creator",
         "source": "github"
       },
       "strict": false,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@ that contains the actual skills:
  ┌──────────────┐
  │ plugins:     │
  │              │        ┌────────────────────────────────┐
- │  rfe-creator ├───────►│ jwforres/rfe-creator           │
+ │  rfe-creator ├───────►│ opendatahub-io/rfe-creator     │
  │              │        │  └─ .claude/skills/            │
  │              │        │      ├─ rfe.create/SKILL.md    │
  │              │        │      ├─ rfe.review/SKILL.md    │

--- a/catalog.md
+++ b/catalog.md
@@ -233,7 +233,7 @@ Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE J
 
 **Requires:** `assess-rfe`
 
-v0.1.0 | [jwforres/rfe-creator](https://github.com/jwforres/rfe-creator)
+v0.1.0 | [opendatahub-io/rfe-creator](https://github.com/opendatahub-io/rfe-creator)
 
 Tags: rfe, jira, review, strategy, pipeline
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -47,12 +47,12 @@ plugins:
       name: jwforres
     source:
       type: github
-      repo: jwforres/rfe-creator
+      repo: opendatahub-io/rfe-creator
       ref: main
     strict: false
     skills_dir: .claude/skills
-    homepage: https://github.com/jwforres/rfe-creator
-    repository: https://github.com/jwforres/rfe-creator
+    homepage: https://github.com/opendatahub-io/rfe-creator
+    repository: https://github.com/opendatahub-io/rfe-creator
     skills:
       - name: rfe.create
         description: Generate new RFEs from problem statements

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -20,7 +20,7 @@ while read operations support both Atlassian MCP and REST API fallback. A
 dependency on the `assess-rfe` plugin provides the scoring rubric, bootstrapped
 automatically on first use.
 
-**Repository**: https://github.com/jwforres/rfe-creator
+**Repository**: https://github.com/opendatahub-io/rfe-creator
 
 ### Architecture
 

--- a/site/docs/plugins/rfe-creator/index.md
+++ b/site/docs/plugins/rfe-creator/index.md
@@ -27,7 +27,7 @@ automatically on first use.
     - **Version**: 0.1.0
     - **Author**: jwforres
     - **Category**: [Product Planning](../../categories/planning.md)
-    - **Repository**: [jwforres/rfe-creator](https://github.com/jwforres/rfe-creator)
+    - **Repository**: [opendatahub-io/rfe-creator](https://github.com/opendatahub-io/rfe-creator)
     - **Tags**: <span class="tag-pill">rfe</span> <span class="tag-pill">jira</span> <span class="tag-pill">review</span> <span class="tag-pill">strategy</span> <span class="tag-pill">pipeline</span>
 
 ## Pipeline


### PR DESCRIPTION
## Summary
- Update rfe-creator plugin source from `jwforres/rfe-creator` to `opendatahub-io/rfe-creator`
- Regenerate marketplace.json, catalog.md, and site docs

## Test plan
- [ ] Verify CI passes (validate + sync check)
- [ ] Confirm `opendatahub-io/rfe-creator` repo exists and is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated rfe-creator plugin documentation, skill catalog, and registry entries with current repository references.

* **Chores**
  * Updated marketplace configuration and related metadata files for the rfe-creator plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->