### PR TITLE
Update assess-rfe repo to opendatahub-io org

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
       },
       "category": "evaluation",
       "description": "Assess RFEs against quality criteria using a structured rubric.\n",
-      "homepage": "https://github.com/n1hility/assess-rfe",
+      "homepage": "https://github.com/opendatahub-io/assess-rfe",
       "keywords": [
         "rfe",
         "rubric",
@@ -48,10 +48,10 @@
         "assessment"
       ],
       "name": "assess-rfe",
-      "repository": "https://github.com/n1hility/assess-rfe",
+      "repository": "https://github.com/opendatahub-io/assess-rfe",
       "source": {
         "ref": "main",
-        "repo": "n1hility/assess-rfe",
+        "repo": "opendatahub-io/assess-rfe",
         "source": "github"
       },
       "version": "1.0.0"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,7 +86,7 @@ that contains the actual skills:
  │              │        └────────────────────────────────┘
  │              │
  │              │        ┌────────────────────────────────┐
- │  assess-rfe  ├───────►│ n1hility/assess-rfe            │
+ │  assess-rfe  ├───────►│ opendatahub-io/assess-rfe      │
  │  (strict:    │        │  ├─ .claude-plugin/            │
  │   true)      │        │  │   └─ plugin.json            │
  │              │        │  └─ skills/                    │

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Other platforms (Cursor, Gemini CLI, Codex, OpenCode) do not have a marketplace 
 #### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/n1hility/assess-rfe
+gemini extensions install https://github.com/opendatahub-io/assess-rfe
 ```
 
 #### Codex
 
 ```bash
-git clone https://github.com/n1hility/assess-rfe ~/.codex/assess-rfe
+git clone https://github.com/opendatahub-io/assess-rfe ~/.codex/assess-rfe
 mkdir -p ~/.agents/skills
 ln -s ~/.codex/assess-rfe/skills ~/.agents/skills/assess-rfe
 ```
@@ -67,14 +67,14 @@ Add to your `opencode.json`:
 
 ```json
 {
-  "plugin": ["assess-rfe@git+https://github.com/n1hility/assess-rfe.git"]
+  "plugin": ["assess-rfe@git+https://github.com/opendatahub-io/assess-rfe.git"]
 }
 ```
 
 #### Cursor
 
 ```
-/add-plugin https://github.com/n1hility/assess-rfe
+/add-plugin https://github.com/opendatahub-io/assess-rfe
 ```
 
 Replace the repo URL with the plugin you want to install. See [catalog.md](catalog.md) for the full list of plugins and their source repositories.

--- a/catalog.md
+++ b/catalog.md
@@ -21,7 +21,7 @@ Skills for evaluating and testing AI agent skills
 
 Assess RFEs against quality criteria using a structured rubric.
 
-v1.0.0 | [n1hility/assess-rfe](https://github.com/n1hility/assess-rfe)
+v1.0.0 | [opendatahub-io/assess-rfe](https://github.com/opendatahub-io/assess-rfe)
 
 Tags: rfe, rubric, quality, assessment
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -120,10 +120,10 @@ plugins:
       name: Jason Greene
     source:
       type: github
-      repo: n1hility/assess-rfe
+      repo: opendatahub-io/assess-rfe
       ref: main
-    homepage: https://github.com/n1hility/assess-rfe
-    repository: https://github.com/n1hility/assess-rfe
+    homepage: https://github.com/opendatahub-io/assess-rfe
+    repository: https://github.com/opendatahub-io/assess-rfe
     skills:
       - name: assess-rfe
         description: Assess RFEs against quality criteria using a structured rubric

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -361,7 +361,7 @@ detailed calibration examples for each criterion and a comprehensive list of
 established RHOAI platform technologies that are considered vocabulary rather
 than architecture prescription.
 
-**Repository**: https://github.com/n1hility/assess-rfe
+**Repository**: https://github.com/opendatahub-io/assess-rfe
 
 ### Architecture
 

--- a/site/docs/plugins/assess-rfe/index.md
+++ b/site/docs/plugins/assess-rfe/index.md
@@ -35,7 +35,7 @@ than architecture prescription.
     - **Version**: 1.0.0
     - **Author**: Jason Greene
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
-    - **Repository**: [n1hility/assess-rfe](https://github.com/n1hility/assess-rfe)
+    - **Repository**: [opendatahub-io/assess-rfe](https://github.com/opendatahub-io/assess-rfe)
     - **Tags**: <span class="tag-pill">rfe</span> <span class="tag-pill">rubric</span> <span class="tag-pill">quality</span> <span class="tag-pill">assessment</span>
 
 ## Pipeline

--- a/site/docs/plugins/rfe-creator/rfe-creator.update-deps.d2
+++ b/site/docs/plugins/rfe-creator/rfe-creator.update-deps.d2
@@ -92,7 +92,7 @@ report: |md
 # --- External ---
 
 assess-rfe-repo: |md
-  **n1hility/assess-rfe**
+  **opendatahub-io/assess-rfe**
   GitHub
 | {
   shape: rectangle


### PR DESCRIPTION
## Summary
- Update assess-rfe plugin source from `n1hility/assess-rfe` to `opendatahub-io/assess-rfe`
- Update all references in registry.yaml, ARCHITECTURE.md, README.md, and the d2 diagram
- Regenerate marketplace.json, catalog.md, and site docs

## Test plan
- [ ] Verify CI passes (validate + sync check)
- [ ] Confirm `opendatahub-io/assess-rfe` repo exists and is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)