### PR TITLE
adding aiops skills for component-onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -301,6 +301,38 @@
       },
       "strict": false,
       "version": "0.1.0"
+    },
+    {
+      "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "devops",
+      "description": "DevOps and TestOps automation skills for ODH/RHOAI \u2014 component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.\n",
+      "homepage": "https://github.com/opendatahub-io/aiops-infra",
+      "keywords": [
+        "devops",
+        "testops",
+        "odh",
+        "rhoai",
+        "konflux",
+        "onboarding",
+        "ci-cd",
+        "release",
+        "automation"
+      ],
+      "license": "Apache-2.0",
+      "name": "aiops-skills",
+      "repository": "https://github.com/opendatahub-io/aiops-infra",
+      "skills": [
+        "./skills"
+      ],
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/aiops-infra",
+        "source": "github"
+      },
+      "strict": false,
+      "version": "0.1.0"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -139,6 +139,23 @@ Tags: disconnected, air-gap, openshift, image-mirroring, readiness, scoring
 /plugin install disconnected-readiness-scorer@opendatahub-skills
 ```
 
+### aiops-skills
+
+DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+
+v0.1.0 | Apache-2.0 | [opendatahub-io/aiops-infra](https://github.com/opendatahub-io/aiops-infra)
+
+Tags: devops, testops, odh, rhoai, konflux, onboarding, ci-cd, release, automation
+
+| Skill | Description |
+|-------|-------------|
+| `/create-component-onboarding-jira` | Interactively collect component onboarding parameters and create/update a Jira ticket |
+| `/validate-component-onboarding-jira` | Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema |
+
+```bash
+/plugin install aiops-skills@opendatahub-skills
+```
+
 ## Security Review
 
 Security analysis, threat modeling, and compliance review

--- a/registry.yaml
+++ b/registry.yaml
@@ -550,3 +550,32 @@ plugins:
       claude-code:
         install: "/plugin install disconnected-readiness-scorer@opendatahub-skills"
     depends_on: []
+  - name: aiops-skills
+    description: >
+      DevOps and TestOps automation skills for ODH/RHOAI — component onboarding,
+      Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+    version: "0.1.0"
+    category: devops
+    tags: [devops, testops, odh, rhoai, konflux, onboarding, ci-cd, release, automation]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/aiops-infra
+      ref: main
+    strict: false
+    skills_dir: skills
+    homepage: https://github.com/opendatahub-io/aiops-infra
+    repository: https://github.com/opendatahub-io/aiops-infra
+    skills:
+      - name: create-component-onboarding-jira
+        description: Interactively collect component onboarding parameters and create/update a Jira ticket
+        user-invocable: true
+      - name: validate-component-onboarding-jira
+        description: Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install aiops-skills@opendatahub-skills"
+    depends_on: []

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -16,3 +16,9 @@ Skills for deployment, CI/CD, and infrastructure
 Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 
 **1 skills** - v0.1.0
+
+### [aiops-skills](../plugins/aiops-skills/index.md)
+
+DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+
+**2 skills** - v0.1.0

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -13,7 +13,7 @@ title: Categories
 |----------|---------|-------------|
 | [Evaluation & Testing](evaluation.md) | 4 | Skills for evaluating and testing AI agent skills |
 | [Documentation](documentation.md) | 1 | Skills for generating and maintaining documentation |
-| [DevOps & CI/CD](devops.md) | 1 | Skills for deployment, CI/CD, and infrastructure |
+| [DevOps & CI/CD](devops.md) | 2 | Skills for deployment, CI/CD, and infrastructure |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
 | [Development Tools](development-tools.md) | 2 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 2 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-11 plugins | 76 skills | 6 categories
+12 plugins | 78 skills | 6 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -108,13 +108,21 @@ hide:
 
     **1 skills** - DevOps & CI/CD - v0.1.0
 
+-   **[aiops-skills](plugins/aiops-skills/index.md)**
+
+    ---
+
+    DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, deliver...
+
+    **2 skills** - DevOps & CI/CD - v0.1.0
+
 </div>
 
 ## Categories
 
 - [Evaluation & Testing](categories/evaluation.md) -- Skills for evaluating and testing AI agent skills (4 plugins)
 - [Documentation](categories/documentation.md) -- Skills for generating and maintaining documentation (1 plugin)
-- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (1 plugin)
+- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (2 plugins)
 - [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)
 - [Development Tools](categories/development-tools.md) -- Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
 - [Product Planning](categories/planning.md) -- Skills for requirements, RFEs, and product strategy (2 plugins)

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -1969,3 +1969,80 @@ Score a repository's readiness for disconnected / air-gapped OpenShift deploymen
 Score a repository's readiness for disconnected / air-gapped OpenShift deployments
 
 ---
+
+## aiops-skills
+
+DevOps and TestOps automation skills for ODH/RHOAI — component onboarding,
+Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+
+Provides an interactive onboarding pipeline for new ODH/RHOAI components:
+collects component parameters through guided Q&A, generates a validated
+component_onboarding_details.yaml, creates or updates Jira tickets with the
+YAML attached, and validates existing onboarding tickets against a JSON Schema
+with cross-checks for branch naming, Dockerfile digest pinning, and product-specific
+requirements. Supports both ODH (CI and Release builds) and RHOAI (with architecture
+selection, release categories, and operator manifest handling).
+
+**Repository**: https://github.com/opendatahub-io/aiops-infra
+
+### Architecture
+
+Two skills form a create-then-validate pipeline for component onboarding:
+
+create-component-onboarding-jira runs an 8-step interactive flow: parse input,
+check prerequisites (uv, jq, Jira credentials), collect parameters via guided
+Q&A with product-aware conditional logic (ODH vs RHOAI), generate YAML, validate
+against JSON Schema, create or update a Jira ticket (cloning product-specific
+templates if no URL provided), attach the YAML, and report results.
+
+validate-component-onboarding-jira runs a 6-step validation flow: check
+prerequisites, create working directory from Jira URL, fetch issue details,
+download YAML attachment, validate against schema with cross-checks (branch
+naming for RHOAI, Dockerfile digest pinning), and update Jira with
+validation-successful or validation-failed labels.
+
+Both skills use deterministic Python scripts (run via uv) for Jira API
+operations and YAML schema validation. The component_onboarding_details.schema.json
+defines conditional requirements based on product_context (ODH vs RHOAI) and
+is_operator fields.
+
+### Skills
+
+#### /create-component-onboarding-jira
+
+Interactively collects ODH/RHOAI component onboarding parameters from the
+user, generates a validated component_onboarding_details.yaml, and creates
+or updates a Jira ticket with the YAML attached. When no Jira URL is provided,
+automatically creates a new ticket by cloning the product-specific onboarding
+template. Supports both ODH (CI and Release builds) and RHOAI (with
+architecture selection, release categories, and operator manifest handling).
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `JIRA_URL` |  | Existing Jira ticket URL to update. If omitted, creates a new ticket by cloning the onboarding template. |
+
+Examples:
+```
+/create-component-onboarding-jira
+/create-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345
+```
+
+#### /validate-component-onboarding-jira
+
+Pre-flight validation tool for ODH component onboarding. Given a Jira issue
+URL, fetches issue details, downloads the component_onboarding_details.yaml
+attachment, and validates it against the JSON Schema. Cross-validates
+repo_branch for RHOAI (must match target version), checks Dockerfile digest
+pinning for RHOAI components, and updates Jira with validation results
+(labels: validation-successful/validation-failed, status: In Progress).
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `JIRA_URL` | yes | Jira ticket URL containing the component_onboarding_details.yaml attachment to validate. |
+
+Examples:
+```
+/validate-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345
+```
+
+---

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -15,6 +15,7 @@
 - [autofix-skills](https://opendatahub-io.github.io/skills-registry/plugins/autofix-skills/): Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 - [meeting-quality-skills](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/): Pre-meeting skills for improving meeting quality by checking shared update docs, identifying missing async updates, and helping organizers focus meetings on items that actually need discussion.
 - [disconnected-readiness-scorer](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
+- [aiops-skills](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/): DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.
 
 ## Skills
 
@@ -85,6 +86,8 @@
 - [meeting-async-update-check](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/meeting-async-update-check/): Check a shared update doc and identify attendees missing async updates before a status meeting
 - [meeting-risk-agenda](https://opendatahub-io.github.io/skills-registry/plugins/meeting-quality-skills/meeting-risk-agenda/): Analyze pre-meeting updates and generate a risk-focused agenda by identifying blocked and at-risk items
 - [disconnected-score](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/disconnected-score/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments
+- [create-component-onboarding-jira](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/create-component-onboarding-jira/): Interactively collect component onboarding parameters and create/update a Jira ticket
+- [validate-component-onboarding-jira](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/validate-component-onboarding-jira/): Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema
 
 ## Optional
 

--- a/site/docs/plugins/aiops-skills/_enriched.yaml
+++ b/site/docs/plugins/aiops-skills/_enriched.yaml
@@ -1,0 +1,62 @@
+description: |
+  DevOps and TestOps automation skills for ODH/RHOAI — component onboarding,
+  Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+
+  Provides an interactive onboarding pipeline for new ODH/RHOAI components:
+  collects component parameters through guided Q&A, generates a validated
+  component_onboarding_details.yaml, creates or updates Jira tickets with the
+  YAML attached, and validates existing onboarding tickets against a JSON Schema
+  with cross-checks for branch naming, Dockerfile digest pinning, and product-specific
+  requirements. Supports both ODH (CI and Release builds) and RHOAI (with architecture
+  selection, release categories, and operator manifest handling).
+architecture_notes: |
+  Two skills form a create-then-validate pipeline for component onboarding:
+
+  create-component-onboarding-jira runs an 8-step interactive flow: parse input,
+  check prerequisites (uv, jq, Jira credentials), collect parameters via guided
+  Q&A with product-aware conditional logic (ODH vs RHOAI), generate YAML, validate
+  against JSON Schema, create or update a Jira ticket (cloning product-specific
+  templates if no URL provided), attach the YAML, and report results.
+
+  validate-component-onboarding-jira runs a 6-step validation flow: check
+  prerequisites, create working directory from Jira URL, fetch issue details,
+  download YAML attachment, validate against schema with cross-checks (branch
+  naming for RHOAI, Dockerfile digest pinning), and update Jira with
+  validation-successful or validation-failed labels.
+
+  Both skills use deterministic Python scripts (run via uv) for Jira API
+  operations and YAML schema validation. The component_onboarding_details.schema.json
+  defines conditional requirements based on product_context (ODH vs RHOAI) and
+  is_operator fields.
+skills:
+  create-component-onboarding-jira:
+    description: |
+      Interactively collects ODH/RHOAI component onboarding parameters from the
+      user, generates a validated component_onboarding_details.yaml, and creates
+      or updates a Jira ticket with the YAML attached. When no Jira URL is provided,
+      automatically creates a new ticket by cloning the product-specific onboarding
+      template. Supports both ODH (CI and Release builds) and RHOAI (with
+      architecture selection, release categories, and operator manifest handling).
+    arguments:
+      - name: "JIRA_URL"
+        type: "string"
+        required: false
+        description: "Existing Jira ticket URL to update. If omitted, creates a new ticket by cloning the onboarding template."
+    usage_examples:
+      - "/create-component-onboarding-jira"
+      - "/create-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345"
+  validate-component-onboarding-jira:
+    description: |
+      Pre-flight validation tool for ODH component onboarding. Given a Jira issue
+      URL, fetches issue details, downloads the component_onboarding_details.yaml
+      attachment, and validates it against the JSON Schema. Cross-validates
+      repo_branch for RHOAI (must match target version), checks Dockerfile digest
+      pinning for RHOAI components, and updates Jira with validation results
+      (labels: validation-successful/validation-failed, status: In Progress).
+    arguments:
+      - name: "JIRA_URL"
+        type: "string"
+        required: true
+        description: "Jira ticket URL containing the component_onboarding_details.yaml attachment to validate."
+    usage_examples:
+      - "/validate-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345"

--- a/site/docs/plugins/aiops-skills/create-component-onboarding-jira.md
+++ b/site/docs/plugins/aiops-skills/create-component-onboarding-jira.md
@@ -1,0 +1,34 @@
+---
+title: create-component-onboarding-jira
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# create-component-onboarding-jira
+
+Interactively collects ODH/RHOAI component onboarding parameters from the
+user, generates a validated component_onboarding_details.yaml, and creates
+or updates a Jira ticket with the YAML attached. When no Jira URL is provided,
+automatically creates a new ticket by cloning the product-specific onboarding
+template. Supports both ODH (CI and Release builds) and RHOAI (with
+architecture selection, release categories, and operator manifest handling).
+
+**Plugin**: [aiops-skills](index.md) | **:material-check: User-invocable**
+
+## Arguments
+
+```bash
+/create-component-onboarding-jira [JIRA_URL]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `JIRA_URL` |  | - | Existing Jira ticket URL to update. If omitted, creates a new ticket by cloning the onboarding template. |
+
+## Usage
+
+```bash
+/create-component-onboarding-jira
+/create-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345
+```

--- a/site/docs/plugins/aiops-skills/index.md
+++ b/site/docs/plugins/aiops-skills/index.md
@@ -1,0 +1,63 @@
+---
+title: aiops-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# aiops-skills
+
+DevOps and TestOps automation skills for ODH/RHOAI — component onboarding,
+Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+
+Provides an interactive onboarding pipeline for new ODH/RHOAI components:
+collects component parameters through guided Q&A, generates a validated
+component_onboarding_details.yaml, creates or updates Jira tickets with the
+YAML attached, and validates existing onboarding tickets against a JSON Schema
+with cross-checks for branch naming, Dockerfile digest pinning, and product-specific
+requirements. Supports both ODH (CI and Release builds) and RHOAI (with architecture
+selection, release categories, and operator manifest handling).
+
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: opendatahub-io
+    - **License**: Apache-2.0
+    - **Category**: [DevOps & CI/CD](../../categories/devops.md)
+    - **Repository**: [opendatahub-io/aiops-infra](https://github.com/opendatahub-io/aiops-infra)
+    - **Tags**: <span class="tag-pill">devops</span> <span class="tag-pill">testops</span> <span class="tag-pill">odh</span> <span class="tag-pill">rhoai</span> <span class="tag-pill">konflux</span> <span class="tag-pill">onboarding</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">release</span> <span class="tag-pill">automation</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/create-component-onboarding-jira`](create-component-onboarding-jira.md) | Interactively collect component onboarding parameters and create/update a Jira ticket | :material-check: |
+| [`/validate-component-onboarding-jira`](validate-component-onboarding-jira.md) | Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema | :material-check: |
+
+## Installation
+
+```bash
+/plugin install aiops-skills@opendatahub-skills
+```
+
+## Architecture
+
+Two skills form a create-then-validate pipeline for component onboarding:
+
+create-component-onboarding-jira runs an 8-step interactive flow: parse input,
+check prerequisites (uv, jq, Jira credentials), collect parameters via guided
+Q&A with product-aware conditional logic (ODH vs RHOAI), generate YAML, validate
+against JSON Schema, create or update a Jira ticket (cloning product-specific
+templates if no URL provided), attach the YAML, and report results.
+
+validate-component-onboarding-jira runs a 6-step validation flow: check
+prerequisites, create working directory from Jira URL, fetch issue details,
+download YAML attachment, validate against schema with cross-checks (branch
+naming for RHOAI, Dockerfile digest pinning), and update Jira with
+validation-successful or validation-failed labels.
+
+Both skills use deterministic Python scripts (run via uv) for Jira API
+operations and YAML schema validation. The component_onboarding_details.schema.json
+defines conditional requirements based on product_context (ODH vs RHOAI) and
+is_operator fields.

--- a/site/docs/plugins/aiops-skills/validate-component-onboarding-jira.md
+++ b/site/docs/plugins/aiops-skills/validate-component-onboarding-jira.md
@@ -1,0 +1,33 @@
+---
+title: validate-component-onboarding-jira
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# validate-component-onboarding-jira
+
+Pre-flight validation tool for ODH component onboarding. Given a Jira issue
+URL, fetches issue details, downloads the component_onboarding_details.yaml
+attachment, and validates it against the JSON Schema. Cross-validates
+repo_branch for RHOAI (must match target version), checks Dockerfile digest
+pinning for RHOAI components, and updates Jira with validation results
+(labels: validation-successful/validation-failed, status: In Progress).
+
+**Plugin**: [aiops-skills](index.md) | **:material-check: User-invocable**
+
+## Arguments
+
+```bash
+/validate-component-onboarding-jira <JIRA_URL>
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `JIRA_URL` | :material-check: | - | Jira ticket URL containing the component_onboarding_details.yaml attachment to validate. |
+
+## Usage
+
+```bash
+/validate-component-onboarding-jira https://redhat.atlassian.net/browse/RHOAIENG-12345
+```

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-11 plugins registered in the marketplace.
+12 plugins registered in the marketplace.
 
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
@@ -22,3 +22,4 @@ title: Plugins
 | [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [meeting-quality-skills](meeting-quality-skills/index.md) | Product Planning | 2 | v0.1.0 |
 | [disconnected-readiness-scorer](disconnected-readiness-scorer/index.md) | DevOps & CI/CD | 1 | v0.1.0 |
+| [aiops-skills](aiops-skills/index.md) | DevOps & CI/CD | 2 | v0.1.0 |

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -151,6 +151,10 @@ nav:
     - disconnected-readiness-scorer:
       - plugins/disconnected-readiness-scorer/index.md
       - disconnected-score: plugins/disconnected-readiness-scorer/disconnected-score.md
+    - aiops-skills:
+      - plugins/aiops-skills/index.md
+      - create-component-onboarding-jira: plugins/aiops-skills/create-component-onboarding-jira.md
+      - validate-component-onboarding-jira: plugins/aiops-skills/validate-component-onboarding-jira.md
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md


### PR DESCRIPTION
adding aiops skills for component-onboarding

## Description
Adding the skills required for automated onboarding for ODH & RHOAI components
Jira - https://redhat.atlassian.net/browse/RHOAIENG-55491

## How Has This Been Tested?
It's been already being used for long to onboard the components
* https://gitlab.com/redhat/rhel-ai/agentic-ci/rhoai-component-onboarding
* https://team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com/#/ai-impact/build-release

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
