### PR TITLE
Fix plugin refs that use commit SHAs instead of branch names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -335,7 +335,7 @@
         "./.claude/skills"
       ],
       "source": {
-        "ref": "main",
+        "ref": "master",
         "repo": "IKRedHat/SPIKE-executor",
         "source": "github"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,7 +192,7 @@
       "name": "agent-eval-harness",
       "repository": "https://github.com/opendatahub-io/agent-eval-harness",
       "source": {
-        "ref": "7d86a7ec657002a27c299fba67f7af1cd8124a6e",
+        "ref": "main",
         "repo": "opendatahub-io/agent-eval-harness",
         "source": "github"
       },
@@ -271,7 +271,7 @@
         "./skills"
       ],
       "source": {
-        "ref": "f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d",
+        "ref": "main",
         "repo": "opendatahub-io/disconnected-readiness-scorer",
         "source": "github"
       },
@@ -335,7 +335,7 @@
         "./.claude/skills"
       ],
       "source": {
-        "ref": "924ec480198b89d42ceb82275938a7859dbf92ff",
+        "ref": "main",
         "repo": "IKRedHat/SPIKE-executor",
         "source": "github"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,11 +192,11 @@
       "name": "agent-eval-harness",
       "repository": "https://github.com/opendatahub-io/agent-eval-harness",
       "source": {
-        "ref": "main",
+        "ref": "v1.4.0",
         "repo": "opendatahub-io/agent-eval-harness",
         "source": "github"
       },
-      "version": "1.0.0"
+      "version": "1.4.0"
     },
     {
       "author": {

--- a/catalog.md
+++ b/catalog.md
@@ -81,7 +81,7 @@ Tags: quality, testing, ci-cd, build-validation, analysis
 
 Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and iteratively improve agent skills with MLflow support for experiment tracking, tracing, and reporting. Schema-driven evaluation via eval.yaml with support for inline, LLM-based, and external judges.
 
-v1.0.0 | [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
+v1.4.0 | [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
 
 Tags: evaluation, testing, skills, agents, mlflow, optimization, scoring
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -372,7 +372,7 @@ plugins:
       iteratively improve agent skills with MLflow support for experiment tracking,
       tracing, and reporting. Schema-driven evaluation via eval.yaml with
       support for inline, LLM-based, and external judges.
-    version: "1.0.0"
+    version: "1.4.0"
     category: evaluation
     tags: [evaluation, testing, skills, agents, mlflow, optimization, scoring]
     author:
@@ -380,7 +380,7 @@ plugins:
     source:
       type: github
       repo: opendatahub-io/agent-eval-harness
-      ref: 7d86a7ec657002a27c299fba67f7af1cd8124a6e # v1.0.0
+      ref: v1.4.0
     homepage: https://github.com/opendatahub-io/agent-eval-harness
     repository: https://github.com/opendatahub-io/agent-eval-harness
     skills:
@@ -492,7 +492,7 @@ plugins:
     source:
       type: github
       repo: opendatahub-io/disconnected-readiness-scorer
-      ref: f8fbba8c8400caeaa1dd9c7455478aad2bf05b4d
+      ref: main
     strict: false
     skills_dir: skills
     homepage: https://github.com/opendatahub-io/disconnected-readiness-scorer
@@ -551,7 +551,7 @@ plugins:
     source:
       type: github
       repo: IKRedHat/SPIKE-executor
-      ref: 924ec480198b89d42ceb82275938a7859dbf92ff
+      ref: master
     strict: false
     skills_dir: .claude/skills
     homepage: https://github.com/IKRedHat/SPIKE-executor

--- a/site/docs/categories/evaluation.md
+++ b/site/docs/categories/evaluation.md
@@ -33,4 +33,4 @@ Quality tooling and automation for RHOAI component development. Includes automat
 
 Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and iteratively improve agent skills with MLflow support for experiment tracking, tracing, and reporting. Schema-driven evaluation via eval.yaml with support for inline, LLM-based, and external judges.
 
-**7 skills** - v1.0.0
+**7 skills** - v1.4.0

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -74,7 +74,7 @@ hide:
 
     Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and ite...
 
-    **7 skills** - Evaluation & Testing - v1.0.0
+    **7 skills** - Evaluation & Testing - v1.4.0
 
 -   **[knowledge-skills](plugins/knowledge-skills/index.md)**
 

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -27,7 +27,7 @@ containerized execution.
 
 !!! info "Plugin Details"
 
-    - **Version**: 1.0.0
+    - **Version**: 1.4.0
     - **Author**: Antonin Stefanutti
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
     - **Repository**: [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -17,7 +17,7 @@ title: Plugins
 | [test-plan](test-plan/index.md) | Evaluation & Testing | 17 | v1.0.0 |
 | [quality-tooling](quality-tooling/index.md) | Evaluation & Testing | 5 | v1.0.0 |
 | [odh-ai-helpers](odh-ai-helpers/index.md) | Development Tools | 19 | v0.1.0 |
-| [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 7 | v1.0.0 |
+| [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 7 | v1.4.0 |
 | [knowledge-skills](knowledge-skills/index.md) | Documentation | 1 | v0.1.0 |
 | [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [disconnected-readiness-scorer](disconnected-readiness-scorer/index.md) | DevOps & CI/CD | 1 | v0.1.0 |


### PR DESCRIPTION
## Summary
- `claude plugin install` clones with `--branch` which doesn't support raw commit SHAs
- Three plugins use commit SHA refs: `agent-eval-harness`, `disconnected-readiness-scorer`, `spike-executor`
- Changed all three to `"ref": "main"` to match every other plugin in the registry

## Reproducer

```bash
$ claude plugin marketplace add opendatahub-io/skills-registry
Adding marketplace…Cloning via SSH: git@github.com:opendatahub-io/skills-registry.git
✔ Successfully added marketplace: opendatahub-skills (declared in user settings)

$ claude plugin install agent-eval-harness@opendatahub-skills
Installing plugin "agent-eval-harness@opendatahub-skills"...
✘ Failed to install plugin "agent-eval-harness@opendatahub-skills": Failed to clone repository:
Cloning into '/home/stbenjam/.claude/plugins/cache/temp_github_1780338808361_6v0z8c'...
fatal: Remote branch 7d86a7ec657002a27c299fba67f7af1cd8124a6e not found in upstream origin
```

The same failure affects `disconnected-readiness-scorer` and `spike-executor` which also pin commit SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated three marketplace plugins to track their latest upstream refs and ensure users get current releases; bumped agent-eval-harness from v1.0.0 to v1.4.0.
* **Documentation**
  * Updated plugin listings and docs to reflect the agent-eval-harness version change across site pages and registry entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->