### PR TITLE
Add gitlab-code-review skill from code-review plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -312,6 +312,29 @@
     },
     {
       "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "code-quality",
+      "description": "AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.\n",
+      "homepage": "https://github.com/opendatahub-io/code-review-skills",
+      "keywords": [
+        "code-review",
+        "gitlab",
+        "ci",
+        "merge-request"
+      ],
+      "license": "Apache-2.0",
+      "name": "code-review-skills",
+      "repository": "https://github.com/opendatahub-io/code-review-skills",
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/code-review-skills",
+        "source": "github"
+      },
+      "version": "0.1.0"
+    },
+    {
+      "author": {
         "name": "IKRedHat"
       },
       "category": "planning",

--- a/catalog.md
+++ b/catalog.md
@@ -99,6 +99,26 @@ Tags: evaluation, testing, skills, agents, mlflow, optimization, scoring
 /plugin install agent-eval-harness@opendatahub-skills
 ```
 
+## Code Quality
+
+Code review, linting, and quality enforcement
+
+### code-review-skills
+
+AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
+
+v0.1.0 | Apache-2.0 | [opendatahub-io/code-review-skills](https://github.com/opendatahub-io/code-review-skills)
+
+Tags: code-review, gitlab, ci, merge-request
+
+| Skill | Description |
+|-------|-------------|
+| `/gitlab-code-review` | Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments |
+
+```bash
+/plugin install code-review-skills@opendatahub-skills
+```
+
 ## Documentation
 
 Skills for generating and maintaining documentation

--- a/registry.yaml
+++ b/registry.yaml
@@ -535,6 +535,34 @@ plugins:
         install: "/plugin install aiops-skills@opendatahub-skills"
     depends_on: []
 
+  - name: code-review-skills
+    description: >
+      AI-powered code review for GitLab merge requests. Reviews all commits
+      since the base branch, produces structured JSON feedback with inline
+      comments, and posts results to the GitLab MR (in CI) or displays them
+      locally for preview. Supports chill mode filtering and comment
+      deduplication.
+    version: "0.1.0"
+    category: code-quality
+    tags: [code-review, gitlab, ci, merge-request]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/code-review-skills
+      ref: main
+    homepage: https://github.com/opendatahub-io/code-review-skills
+    repository: https://github.com/opendatahub-io/code-review-skills
+    skills:
+      - name: gitlab-code-review
+        description: Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install code-review-skills@opendatahub-skills"
+    depends_on: []
+
   - name: spike-executor
     description: >
       Execute RHOAI SPIKE investigations with human-in-the-loop approval gates.

--- a/site/docs/categories/code-quality.md
+++ b/site/docs/categories/code-quality.md
@@ -1,0 +1,18 @@
+---
+title: Code Quality
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# Code Quality
+
+Code review, linting, and quality enforcement
+
+## Plugins
+
+### [code-review-skills](../plugins/code-review-skills/index.md)
+
+AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
+
+**1 skills** - v0.1.0

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -12,6 +12,7 @@ title: Categories
 | Category | Plugins | Description |
 |----------|---------|-------------|
 | [Evaluation & Testing](evaluation.md) | 4 | Skills for evaluating and testing AI agent skills |
+| [Code Quality](code-quality.md) | 1 | Code review, linting, and quality enforcement |
 | [Documentation](documentation.md) | 1 | Skills for generating and maintaining documentation |
 | [DevOps & CI/CD](devops.md) | 2 | Skills for deployment, CI/CD, and infrastructure |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-12 plugins | 73 skills | 6 categories
+13 plugins | 74 skills | 7 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -108,6 +108,14 @@ hide:
 
     **2 skills** - DevOps & CI/CD - v0.1.0
 
+-   **[code-review-skills](plugins/code-review-skills/index.md)**
+
+    ---
+
+    AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON...
+
+    **1 skills** - Code Quality - v0.1.0
+
 -   **[spike-executor](plugins/spike-executor/index.md)**
 
     ---
@@ -121,6 +129,7 @@ hide:
 ## Categories
 
 - [Evaluation & Testing](categories/evaluation.md) -- Skills for evaluating and testing AI agent skills (4 plugins)
+- [Code Quality](categories/code-quality.md) -- Code review, linting, and quality enforcement (1 plugin)
 - [Documentation](categories/documentation.md) -- Skills for generating and maintaining documentation (1 plugin)
 - [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (2 plugins)
 - [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -2018,6 +2018,20 @@ Examples:
 
 ---
 
+## code-review-skills
+
+AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
+
+**Repository**: https://github.com/opendatahub-io/code-review-skills
+
+### Skills
+
+#### /gitlab-code-review
+
+Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
+
+---
+
 ## spike-executor
 
 Execute RHOAI SPIKE investigations with human-in-the-loop approval gates on

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -15,6 +15,7 @@
 - [autofix-skills](https://opendatahub-io.github.io/skills-registry/plugins/autofix-skills/): Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 - [disconnected-readiness-scorer](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments. Scans for image manifest completeness, digest enforcement, runtime egress, and Python dependency validation. Supports automatic detection of image management patterns (env var vs static CSV) and cross-references against the opendatahub-operator manifest.
 - [aiops-skills](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/): DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.
+- [code-review-skills](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/): AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
 - [spike-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates. 9-step lifecycle: intake, plan, Jira sync, AI research enrichment with hallucination detection, pytest test suites on OpenShift, rubric-based scoring with security gates, and RFE input generation. Supports both runtime and protocol library assessment.
 
 ## Skills
@@ -82,6 +83,7 @@
 - [disconnected-score](https://opendatahub-io.github.io/skills-registry/plugins/disconnected-readiness-scorer/disconnected-score/): Score a repository's readiness for disconnected / air-gapped OpenShift deployments
 - [create-component-onboarding-jira](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/create-component-onboarding-jira/): Interactively collect component onboarding parameters and create/update a Jira ticket
 - [validate-component-onboarding-jira](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/validate-component-onboarding-jira/): Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema
+- [gitlab-code-review](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/gitlab-code-review/): Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
 - [SPIKE-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/SPIKE-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates
 
 ## Optional

--- a/site/docs/plugins/code-review-skills/gitlab-code-review.md
+++ b/site/docs/plugins/code-review-skills/gitlab-code-review.md
@@ -1,0 +1,18 @@
+---
+title: gitlab-code-review
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gitlab-code-review
+
+Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
+
+**Plugin**: [code-review-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```bash
+/gitlab-code-review
+```

--- a/site/docs/plugins/code-review-skills/index.md
+++ b/site/docs/plugins/code-review-skills/index.md
@@ -1,0 +1,31 @@
+---
+title: code-review-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# code-review-skills
+
+AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: opendatahub-io
+    - **License**: Apache-2.0
+    - **Category**: [Code Quality](../../categories/code-quality.md)
+    - **Repository**: [opendatahub-io/code-review-skills](https://github.com/opendatahub-io/code-review-skills)
+    - **Tags**: <span class="tag-pill">code-review</span> <span class="tag-pill">gitlab</span> <span class="tag-pill">ci</span> <span class="tag-pill">merge-request</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/gitlab-code-review`](gitlab-code-review.md) | Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments | :material-check: |
+
+## Installation
+
+```bash
+/plugin install code-review-skills@opendatahub-skills
+```

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-12 plugins registered in the marketplace.
+13 plugins registered in the marketplace.
 
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
@@ -22,4 +22,5 @@ title: Plugins
 | [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [disconnected-readiness-scorer](disconnected-readiness-scorer/index.md) | DevOps & CI/CD | 1 | v0.1.0 |
 | [aiops-skills](aiops-skills/index.md) | DevOps & CI/CD | 2 | v0.1.0 |
+| [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -147,12 +147,16 @@ nav:
       - plugins/aiops-skills/index.md
       - create-component-onboarding-jira: plugins/aiops-skills/create-component-onboarding-jira.md
       - validate-component-onboarding-jira: plugins/aiops-skills/validate-component-onboarding-jira.md
+    - code-review-skills:
+      - plugins/code-review-skills/index.md
+      - gitlab-code-review: plugins/code-review-skills/gitlab-code-review.md
     - spike-executor:
       - plugins/spike-executor/index.md
       - SPIKE-executor: plugins/spike-executor/SPIKE-executor.md
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md
+    - Code Quality: categories/code-quality.md
     - Documentation: categories/documentation.md
     - DevOps & CI/CD: categories/devops.md
     - Security Review: categories/security.md


### PR DESCRIPTION
## Description

Adds a skill for GitLab MR code reviews that now lives in https://github.com/opendatahub-io/code-review-skills. The previous version of this skill lived in https://github.com/opendatahub-io/ai-helpers/tree/main/helpers/skills/code-review.

## How Has This Been Tested?

Same skill as already existing one except renamed. This will be used in a code-review pipeline in gitlab.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
