### PR TITLE
Add model-serving-skills plugin with jira-hygiene skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -364,6 +364,31 @@
       },
       "strict": false,
       "version": "0.2.0"
+    },
+    {
+      "author": {
+        "name": "VedantMahabaleshwarkar"
+      },
+      "category": "model-serving",
+      "description": "Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.\n",
+      "homepage": "https://github.com/VedantMahabaleshwarkar/model-serving-skills",
+      "keywords": [
+        "jira",
+        "hygiene",
+        "model-serving",
+        "kserve",
+        "rhoai",
+        "workflow"
+      ],
+      "license": "Apache-2.0",
+      "name": "model-serving-skills",
+      "repository": "https://github.com/VedantMahabaleshwarkar/model-serving-skills",
+      "source": {
+        "ref": "main",
+        "repo": "VedantMahabaleshwarkar/model-serving-skills",
+        "source": "github"
+      },
+      "version": "0.1.0"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -308,3 +308,23 @@ Tags: spike, assessment, jira, research, scoring, rfe, openshift, rhoai, feasibi
 ```bash
 /plugin install spike-executor@opendatahub-skills
 ```
+
+## Model Serving
+
+Skills for the RHOAI Model Serving team — JIRA hygiene, workflow automation, and team-specific tooling
+
+### model-serving-skills
+
+Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.
+
+v0.1.0 | Apache-2.0 | [VedantMahabaleshwarkar/model-serving-skills](https://github.com/VedantMahabaleshwarkar/model-serving-skills)
+
+Tags: jira, hygiene, model-serving, kserve, rhoai, workflow
+
+| Skill | Description |
+|-------|-------------|
+| `/jira-hygiene` | Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels |
+
+```bash
+/plugin install model-serving-skills@opendatahub-skills
+```

--- a/registry.yaml
+++ b/registry.yaml
@@ -31,6 +31,9 @@ categories:
   planning:
     name: Product Planning
     description: Skills for requirements, RFEs, and product strategy
+  model-serving:
+    name: Model Serving
+    description: Skills for the RHOAI Model Serving team — JIRA hygiene, workflow automation, and team-specific tooling
 
 plugins:
 
@@ -594,4 +597,30 @@ plugins:
     python:
       package: spike-executor
       requires_python: ">=3.10"
+    depends_on: []
+
+  - name: model-serving-skills
+    description: >
+      Claude Code skills for the RHOAI Model Serving team. Includes JIRA
+      hygiene enforcement (story points, team, components, activity type,
+      fix version, labels), workflow automation, and team-specific tooling.
+    version: "0.1.0"
+    category: model-serving
+    tags: [jira, hygiene, model-serving, kserve, rhoai, workflow]
+    author:
+      name: VedantMahabaleshwarkar
+    license: Apache-2.0
+    source:
+      type: github
+      repo: VedantMahabaleshwarkar/model-serving-skills
+      ref: main
+    homepage: https://github.com/VedantMahabaleshwarkar/model-serving-skills
+    repository: https://github.com/VedantMahabaleshwarkar/model-serving-skills
+    skills:
+      - name: jira-hygiene
+        description: Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install model-serving-skills@opendatahub-skills"
     depends_on: []

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -7,7 +7,7 @@ title: Categories
 
 # Categories
 
-7 categories in the marketplace.
+8 categories in the marketplace.
 
 | Category | Plugins | Description |
 |----------|---------|-------------|
@@ -18,3 +18,4 @@ title: Categories
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
 | [Development Tools](development-tools.md) | 2 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 2 | Skills for requirements, RFEs, and product strategy |
+| [Model Serving](model-serving.md) | 1 | Skills for the RHOAI Model Serving team — JIRA hygiene, workflow automation, and team-specific tooling |

--- a/site/docs/categories/model-serving.md
+++ b/site/docs/categories/model-serving.md
@@ -1,0 +1,18 @@
+---
+title: Model Serving
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# Model Serving
+
+Skills for the RHOAI Model Serving team — JIRA hygiene, workflow automation, and team-specific tooling
+
+## Plugins
+
+### [model-serving-skills](../plugins/model-serving-skills/index.md)
+
+Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.
+
+**1 skills** - v0.1.0

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-13 plugins | 74 skills | 7 categories
+14 plugins | 75 skills | 8 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -124,6 +124,14 @@ hide:
 
     **1 skills** - Product Planning - v0.2.0
 
+-   **[model-serving-skills](plugins/model-serving-skills/index.md)**
+
+    ---
+
+    Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, component...
+
+    **1 skills** - Model Serving - v0.1.0
+
 </div>
 
 ## Categories
@@ -135,3 +143,4 @@ hide:
 - [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)
 - [Development Tools](categories/development-tools.md) -- Developer productivity tools for packaging, CI/CD debugging, and workflow automation (2 plugins)
 - [Product Planning](categories/planning.md) -- Skills for requirements, RFEs, and product strategy (2 plugins)
+- [Model Serving](categories/model-serving.md) -- Skills for the RHOAI Model Serving team — JIRA hygiene, workflow automation, and team-specific tooling (1 plugin)

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -2175,3 +2175,17 @@ Examples:
 ```
 
 ---
+
+## model-serving-skills
+
+Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.
+
+**Repository**: https://github.com/VedantMahabaleshwarkar/model-serving-skills
+
+### Skills
+
+#### /jira-hygiene
+
+Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels
+
+---

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -17,6 +17,7 @@
 - [aiops-skills](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/): DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Konflux CI/CD, release management, delivery pipelines, and operational tooling.
 - [code-review-skills](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/): AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
 - [spike-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates. 9-step lifecycle: intake, plan, Jira sync, AI research enrichment with hallucination detection, pytest test suites on OpenShift, rubric-based scoring with security gates, and RFE input generation. Supports both runtime and protocol library assessment.
+- [model-serving-skills](https://opendatahub-io.github.io/skills-registry/plugins/model-serving-skills/): Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.
 
 ## Skills
 
@@ -85,6 +86,7 @@
 - [validate-component-onboarding-jira](https://opendatahub-io.github.io/skills-registry/plugins/aiops-skills/validate-component-onboarding-jira/): Pre-flight validation for ODH component onboarding — fetches Jira, downloads YAML, validates against schema
 - [gitlab-code-review](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/gitlab-code-review/): Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
 - [SPIKE-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/SPIKE-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates
+- [jira-hygiene](https://opendatahub-io.github.io/skills-registry/plugins/model-serving-skills/jira-hygiene/): Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels
 
 ## Optional
 

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-13 plugins registered in the marketplace.
+14 plugins registered in the marketplace.
 
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
@@ -24,3 +24,4 @@ title: Plugins
 | [aiops-skills](aiops-skills/index.md) | DevOps & CI/CD | 2 | v0.1.0 |
 | [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |
+| [model-serving-skills](model-serving-skills/index.md) | Model Serving | 1 | v0.1.0 |

--- a/site/docs/plugins/model-serving-skills/index.md
+++ b/site/docs/plugins/model-serving-skills/index.md
@@ -1,0 +1,31 @@
+---
+title: model-serving-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# model-serving-skills
+
+Claude Code skills for the RHOAI Model Serving team. Includes JIRA hygiene enforcement (story points, team, components, activity type, fix version, labels), workflow automation, and team-specific tooling.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.1.0
+    - **Author**: VedantMahabaleshwarkar
+    - **License**: Apache-2.0
+    - **Category**: [Model Serving](../../categories/model-serving.md)
+    - **Repository**: [VedantMahabaleshwarkar/model-serving-skills](https://github.com/VedantMahabaleshwarkar/model-serving-skills)
+    - **Tags**: <span class="tag-pill">jira</span> <span class="tag-pill">hygiene</span> <span class="tag-pill">model-serving</span> <span class="tag-pill">kserve</span> <span class="tag-pill">rhoai</span> <span class="tag-pill">workflow</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/jira-hygiene`](jira-hygiene.md) | Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels | :material-check: |
+
+## Installation
+
+```bash
+/plugin install model-serving-skills@opendatahub-skills
+```

--- a/site/docs/plugins/model-serving-skills/jira-hygiene.md
+++ b/site/docs/plugins/model-serving-skills/jira-hygiene.md
@@ -1,0 +1,18 @@
+---
+title: jira-hygiene
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-hygiene
+
+Enforce JIRA hygiene standards on one or many issues — sets story points, team, components, activity type, fix version, and labels
+
+**Plugin**: [model-serving-skills](index.md) | **:material-check: User-invocable**
+
+## Usage
+
+```bash
+/jira-hygiene
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -153,6 +153,9 @@ nav:
     - spike-executor:
       - plugins/spike-executor/index.md
       - SPIKE-executor: plugins/spike-executor/SPIKE-executor.md
+    - model-serving-skills:
+      - plugins/model-serving-skills/index.md
+      - jira-hygiene: plugins/model-serving-skills/jira-hygiene.md
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md
@@ -162,4 +165,5 @@ nav:
     - Security Review: categories/security.md
     - Development Tools: categories/development-tools.md
     - Product Planning: categories/planning.md
+    - Model Serving: categories/model-serving.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
## Summary

- Adds a new **Model Serving** category to the registry, giving the model serving team an identifiable home for their skills
- Registers the [`model-serving-skills`](https://github.com/VedantMahabaleshwarkar/model-serving-skills) plugin pointing to `VedantMahabaleshwarkar/model-serving-skills`
- Initial skill: **jira-hygiene** — enforces JIRA field standards (story points, team, components, activity type, fix version, labels) across single issues, sprints, or all assigned tickets

## Checklist

- [x] Entry added to `registry.yaml`
- [x] `python3 scripts/validate_registry.py` — PASSED
- [x] `python3 scripts/sync_marketplace.py` — regenerated
- [x] `python3 scripts/generate_catalog.py` — regenerated
- [x] `python3 scripts/generate_site.py` — regenerated
- [x] Source repo has `.claude-plugin/plugin.json` and `skills/jira-hygiene/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `model-serving-skills` plugin to the marketplace for the Model Serving team.
  * Introduced `/jira-hygiene` skill to enforce required JIRA fields including story points, team, components, activity type, fix version, and labels.
  * Marketplace now includes 14 plugins across 8 categories with full documentation and installation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->