### PR TITLE
Add plugin scope field (generic/sdlc/team) for reusability labeling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ plugins:
     description: What your plugin does (one paragraph)
     version: "1.0.0"
     category: evaluation          # Must match a key in 'categories'
+    scope: org                    # generic | org | team (default: org) — see "Plugin scope"
     tags: [tag1, tag2]
     author:
       name: your-name
@@ -70,6 +71,20 @@ For repos without `plugin.json`, add `strict: false` and `skills_dir`:
 ```
 
 The `user-invocable` field mirrors the [native Claude Code SKILL.md frontmatter field](https://code.claude.com/docs/en/skills#frontmatter-reference). Set it to `false` for internal skills that are called only by other skills/agents in the background — they will be hidden from the generated catalog. The registry value is catalog-only, so to actually hide the skill from the `/` menu in Claude Code you must also set `user-invocable: false` in the SKILL.md frontmatter in your source repo.
+
+### Plugin scope
+
+The optional `scope` field declares how reusable the plugin is. It is catalog-only metadata — it is **not** propagated to `marketplace.json` and does not affect installation (every plugin remains installable by anyone via `/plugin install`). It only controls how the plugin is labeled and organized in the catalog and docs site.
+
+| Scope | Meaning | Example |
+|-------|---------|---------|
+| `generic` | Works anywhere, for any user or project | `agent-eval-harness` |
+| `org` (default) | RHOAI/ODH-wide, reusable across teams | `rfe-creator`, `assess-rfe` |
+| `team` | Hardcoded to one team's setup (project keys, custom fields, labels) — not usable by others without modification | a team's JIRA-hygiene skill |
+
+**Prefer making skills reusable.** If a skill only hardcodes team-specific values (project key, team ID, component, custom-field IDs) out of convenience, consider externalizing those into config or env vars so it can be `org`-scoped and shared. Mark `scope: team` only when the skill genuinely serves a single team.
+
+`generic` and `team` plugins are labeled on the site; `team` plugins are listed in a dedicated "Team-Specific" section rather than mixed into function categories. Always use a **function-based** `category` (what the skill does) regardless of scope — do not create team-named categories. Team identity belongs in `tags` and `scope`.
 
 ### 3. Regenerate Artifacts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ plugins:
     description: What your plugin does (one paragraph)
     version: "1.0.0"
     category: evaluation          # Must match a key in 'categories'
-    scope: org                    # generic | org | team (default: org) — see "Plugin scope"
+    scope: sdlc                   # generic | sdlc | team (default: sdlc) — see "Plugin scope"
     tags: [tag1, tag2]
     author:
       name: your-name
@@ -79,10 +79,10 @@ The optional `scope` field declares how reusable the plugin is. It is catalog-on
 | Scope | Meaning | Example |
 |-------|---------|---------|
 | `generic` | Works anywhere, for any user or project | `agent-eval-harness` |
-| `org` (default) | RHOAI/ODH-wide, reusable across teams | `rfe-creator`, `assess-rfe` |
+| `sdlc` (default) | RHOAI/ODH-wide, reusable across teams | `rfe-creator`, `assess-rfe` |
 | `team` | Hardcoded to one team's setup (project keys, custom fields, labels) — not usable by others without modification | a team's JIRA-hygiene skill |
 
-**Prefer making skills reusable.** If a skill only hardcodes team-specific values (project key, team ID, component, custom-field IDs) out of convenience, consider externalizing those into config or env vars so it can be `org`-scoped and shared. Mark `scope: team` only when the skill genuinely serves a single team.
+**Prefer making skills reusable.** If a skill only hardcodes team-specific values (project key, team ID, component, custom-field IDs) out of convenience, consider externalizing those into config or env vars so it can be `sdlc`-scoped and shared. Mark `scope: team` only when the skill genuinely serves a single team.
 
 `generic` and `team` plugins are labeled on the site; `team` plugins are listed in a dedicated "Team-Specific" section rather than mixed into function categories. Always use a **function-based** `category` (what the skill does) regardless of scope — do not create team-named categories. Team identity belongs in `tags` and `scope`.
 

--- a/catalog.md
+++ b/catalog.md
@@ -81,7 +81,7 @@ Tags: quality, testing, ci-cd, build-validation, analysis
 
 Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and iteratively improve agent skills with MLflow support for experiment tracking, tracing, and reporting. Schema-driven evaluation via eval.yaml with support for inline, LLM-based, and external judges.
 
-v1.4.0 | [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
+v1.4.0 | Generic | [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
 
 Tags: evaluation, testing, skills, agents, mlflow, optimization, scoring
 
@@ -207,7 +207,7 @@ Developer productivity tools for packaging, CI/CD debugging, and workflow automa
 
 Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
 
-v0.1.0 | Apache-2.0 | [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
+v0.1.0 | Generic | Apache-2.0 | [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
 
 Tags: python-packaging, licensing, dependencies, gitlab, jira, adr, git, automation
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -286,6 +286,7 @@ plugins:
       GitLab pipelines, reviewing ADRs, and more.
     version: "0.1.0"
     category: development-tools
+    scope: generic
     tags: [python-packaging, licensing, dependencies, gitlab, jira, adr, git, automation]
     author:
       name: opendatahub-io
@@ -374,6 +375,7 @@ plugins:
       support for inline, LLM-based, and external judges.
     version: "1.4.0"
     category: evaluation
+    scope: generic
     tags: [evaluation, testing, skills, agents, mlflow, optimization, scoring]
     author:
       name: Antonin Stefanutti

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -69,6 +69,12 @@
           "type": "string",
           "description": "Category key from the categories map"
         },
+        "scope": {
+          "type": "string",
+          "enum": ["generic", "org", "team"],
+          "default": "org",
+          "description": "Reusability scope. 'generic' works anywhere; 'org' (default) is RHOAI/ODH-wide and reusable across teams; 'team' is hardcoded to a specific team's setup and not generally reusable. The catalog and site label generic and team plugins. Catalog-only metadata — not propagated to marketplace.json."
+        },
         "tags": {
           "type": "array",
           "items": { "type": "string" }

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -71,9 +71,9 @@
         },
         "scope": {
           "type": "string",
-          "enum": ["generic", "org", "team"],
-          "default": "org",
-          "description": "Reusability scope. 'generic' works anywhere; 'org' (default) is RHOAI/ODH-wide and reusable across teams; 'team' is hardcoded to a specific team's setup and not generally reusable. The catalog and site label generic and team plugins. Catalog-only metadata — not propagated to marketplace.json."
+          "enum": ["generic", "sdlc", "team"],
+          "default": "sdlc",
+          "description": "Reusability scope. 'generic' works anywhere; 'sdlc' (default) is RHOAI/ODH-wide and reusable across teams; 'team' is hardcoded to a specific team's setup and not generally reusable. The catalog and site label generic and team plugins. Catalog-only metadata — not propagated to marketplace.json."
         },
         "tags": {
           "type": "array",

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -101,6 +101,7 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
     repo = plugin["source"].get("repo", "")
     license_str = plugin.get("license", "")
     tags = plugin.get("tags", [])
+    scope = plugin.get("scope", "sdlc")
 
     lines.append(f"### {name}")
     lines.append("")
@@ -117,6 +118,10 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
     meta_parts = []
     if version:
         meta_parts.append(f"v{version}")
+    if scope == "generic":
+        meta_parts.append("Generic")
+    elif scope == "team":
+        meta_parts.append("Team-Specific")
     if license_str:
         meta_parts.append(license_str)
     if repo:

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -39,13 +39,18 @@ def generate_catalog(registry: dict) -> str:
     lines.append("```")
     lines.append("")
 
-    # Group plugins by category
+    # Group plugins by category. Team-scoped plugins are pulled out into a
+    # dedicated section at the end rather than mixed into function categories.
     categories = registry.get("categories", {})
     plugins = registry.get("plugins", [])
     by_category: dict[str, list] = {}
     uncategorized = []
+    team_plugins = []
 
     for plugin in plugins:
+        if plugin.get("scope") == "team":
+            team_plugins.append(plugin)
+            continue
         cat = plugin.get("category")
         if cat and cat in categories:
             by_category.setdefault(cat, []).append(plugin)
@@ -71,6 +76,18 @@ def generate_catalog(registry: dict) -> str:
         lines.append("## Other")
         lines.append("")
         for plugin in uncategorized:
+            lines.extend(render_plugin(plugin, registry["name"]))
+
+    # Team-specific plugins (scope: team) — listed separately at the end
+    if team_plugins:
+        lines.append("## Team-Specific")
+        lines.append("")
+        lines.append(
+            "Plugins hardcoded to a specific team's setup. Not generally reusable "
+            "by other teams without modification."
+        )
+        lines.append("")
+        for plugin in team_plugins:
             lines.extend(render_plugin(plugin, registry["name"]))
 
     return "\n".join(lines)

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -99,7 +99,7 @@ def build_category_plugins(registry: dict) -> dict[str, list]:
     categories = registry.get("categories", {})
     by_cat: dict[str, list] = {k: [] for k in categories}
     for plugin in registry.get("plugins", []):
-        if plugin.get("scope") == "team":
+        if scope_of(plugin) == "team":
             continue
         cat = plugin.get("category")
         if cat and cat in by_cat:
@@ -108,6 +108,14 @@ def build_category_plugins(registry: dict) -> dict[str, list]:
 
 
 SCOPE_BADGE = {"team": "Team-specific", "generic": "Generic"}
+VALID_SCOPES = {"sdlc", "generic", "team"}
+
+
+def scope_of(plugin: dict) -> str:
+    """Normalized scope. Unknown/missing values fall back to the sdlc default
+    so a plugin is never silently dropped from a scope-grouped section."""
+    scope = plugin.get("scope") or "sdlc"
+    return scope if scope in VALID_SCOPES else "sdlc"
 
 
 def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
@@ -164,9 +172,9 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
         lines.append("</div>")
         lines.append("")
 
-    sdlc_plugins = [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]
-    generic_plugins = [p for p in plugins if p.get("scope") == "generic"]
-    team_plugins = [p for p in plugins if p.get("scope") == "team"]
+    sdlc_plugins = [p for p in plugins if scope_of(p) == "sdlc"]
+    generic_plugins = [p for p in plugins if scope_of(p) == "generic"]
+    team_plugins = [p for p in plugins if scope_of(p) == "team"]
 
     render_card_section("SDLC", sdlc_plugins)
     render_card_section("Generic", generic_plugins)
@@ -206,9 +214,9 @@ def generate_plugins_index(registry: dict) -> str:
 
     # Group into one section per scope: SDLC (default), Generic, Teams
     sections = [
-        ("SDLC", [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]),
-        ("Generic", [p for p in plugins if p.get("scope") == "generic"]),
-        ("Teams", [p for p in plugins if p.get("scope") == "team"]),
+        ("SDLC", [p for p in plugins if scope_of(p) == "sdlc"]),
+        ("Generic", [p for p in plugins if scope_of(p) == "generic"]),
+        ("Teams", [p for p in plugins if scope_of(p) == "team"]),
     ]
     for title, group in sections:
         if not group:
@@ -254,7 +262,7 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     # Metadata
     lines.append('!!! info "Plugin Details"')
     lines.append("")
-    scope = plugin.get("scope", "sdlc")
+    scope = scope_of(plugin)
     meta = []
     if version:
         meta.append(f"    - **Version**: {version}")
@@ -497,8 +505,8 @@ def generate_category_page(cat_key: str, cat_meta: dict,
             lines.append("")
 
     # Split into SDLC and Generic subsections (team plugins aren't in categories)
-    sdlc_group = [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]
-    generic_group = [p for p in plugins if p.get("scope") == "generic"]
+    sdlc_group = [p for p in plugins if scope_of(p) == "sdlc"]
+    generic_group = [p for p in plugins if scope_of(p) == "generic"]
     for title, group in (("SDLC", sdlc_group), ("Generic", generic_group)):
         if not group:
             continue

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -94,14 +94,27 @@ def clean_generated(output_dir: Path):
 
 
 def build_category_plugins(registry: dict) -> dict[str, list]:
-    """Group plugins by category key."""
+    """Group plugins by category key. Team-scoped plugins are excluded — they
+    are surfaced in a dedicated Team-Specific section, not function categories."""
     categories = registry.get("categories", {})
     by_cat: dict[str, list] = {k: [] for k in categories}
     for plugin in registry.get("plugins", []):
+        if plugin.get("scope") == "team":
+            continue
         cat = plugin.get("category")
         if cat and cat in by_cat:
             by_cat[cat].append(plugin)
     return by_cat
+
+
+def split_by_scope(plugins: list) -> tuple[list, list]:
+    """Return (shared_plugins, team_plugins) preserving order."""
+    shared = [p for p in plugins if p.get("scope") != "team"]
+    team = [p for p in plugins if p.get("scope") == "team"]
+    return shared, team
+
+
+SCOPE_BADGE = {"team": "Team-specific", "generic": "Generic"}
 
 
 def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
@@ -127,12 +140,9 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
     lines.append("")
     lines.append("---")
     lines.append("")
-    lines.append("## Plugins")
-    lines.append("")
-    lines.append('<div class="grid cards" markdown>')
-    lines.append("")
+    shared_plugins, team_plugins = split_by_scope(plugins)
 
-    for plugin in plugins:
+    def render_card(plugin):
         name = plugin["name"]
         desc = plugin["description"].strip().split("\n")[0]
         if len(desc) > 120:
@@ -144,15 +154,33 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
 
         lines.append(f"-   **[{name}](plugins/{name}/index.md)**")
         lines.append("")
-        lines.append(f"    ---")
+        lines.append("    ---")
         lines.append("")
         lines.append(f"    {desc}")
         lines.append("")
         lines.append(f"    **{skill_count} skills** - {cat_name} - v{version}")
         lines.append("")
 
+    lines.append("## Plugins")
+    lines.append("")
+    lines.append('<div class="grid cards" markdown>')
+    lines.append("")
+    for plugin in shared_plugins:
+        render_card(plugin)
     lines.append("</div>")
     lines.append("")
+
+    if team_plugins:
+        lines.append("## Team-Specific Plugins")
+        lines.append("")
+        lines.append("Hardcoded to a specific team's setup — not generally reusable by other teams.")
+        lines.append("")
+        lines.append('<div class="grid cards" markdown>')
+        lines.append("")
+        for plugin in team_plugins:
+            render_card(plugin)
+        lines.append("</div>")
+        lines.append("")
 
     lines.append("## Categories")
     lines.append("")
@@ -177,16 +205,34 @@ def generate_plugins_index(registry: dict) -> str:
     lines.append("")
     lines.append(f"{len(plugins)} plugins registered in the marketplace.")
     lines.append("")
-    lines.append("| Plugin | Category | Skills | Version |")
-    lines.append("|--------|----------|--------|---------|")
-    for plugin in plugins:
+
+    shared_plugins, team_plugins = split_by_scope(plugins)
+
+    def render_row(plugin):
         name = plugin["name"]
         cat_key = plugin.get("category", "")
         cat_name = categories.get(cat_key, {}).get("name", cat_key)
         skill_count = len(plugin.get("skills", []))
         version = plugin.get("version", "")
         lines.append(f"| [{name}]({name}/index.md) | {cat_name} | {skill_count} | v{version} |")
+
+    lines.append("| Plugin | Category | Skills | Version |")
+    lines.append("|--------|----------|--------|---------|")
+    for plugin in shared_plugins:
+        render_row(plugin)
     lines.append("")
+
+    if team_plugins:
+        lines.append("## Team-Specific")
+        lines.append("")
+        lines.append("Hardcoded to a specific team's setup — not generally reusable by other teams.")
+        lines.append("")
+        lines.append("| Plugin | Category | Skills | Version |")
+        lines.append("|--------|----------|--------|---------|")
+        for plugin in team_plugins:
+            render_row(plugin)
+        lines.append("")
+
     return "\n".join(lines)
 
 
@@ -220,6 +266,7 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     # Metadata
     lines.append('!!! info "Plugin Details"')
     lines.append("")
+    scope = plugin.get("scope", "org")
     meta = []
     if version:
         meta.append(f"    - **Version**: {version}")
@@ -227,6 +274,8 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
         meta.append(f"    - **Author**: {author}")
     if license_str:
         meta.append(f"    - **License**: {license_str}")
+    if scope in SCOPE_BADGE:
+        meta.append(f"    - **Scope**: {SCOPE_BADGE[scope]}")
     if category:
         meta.append(f"    - **Category**: [{cat_name}](../../categories/{category}.md)")
     if repo:

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -107,13 +107,6 @@ def build_category_plugins(registry: dict) -> dict[str, list]:
     return by_cat
 
 
-def split_by_scope(plugins: list) -> tuple[list, list]:
-    """Return (shared_plugins, team_plugins) preserving order."""
-    shared = [p for p in plugins if p.get("scope") != "team"]
-    team = [p for p in plugins if p.get("scope") == "team"]
-    return shared, team
-
-
 SCOPE_BADGE = {"team": "Team-specific", "generic": "Generic"}
 
 
@@ -140,8 +133,6 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
     lines.append("")
     lines.append("---")
     lines.append("")
-    shared_plugins, team_plugins = split_by_scope(plugins)
-
     def render_card(plugin):
         name = plugin["name"]
         desc = plugin["description"].strip().split("\n")[0]
@@ -161,26 +152,25 @@ def generate_landing_page(registry: dict, cat_plugins: dict[str, list]) -> str:
         lines.append(f"    **{skill_count} skills** - {cat_name} - v{version}")
         lines.append("")
 
-    lines.append("## Plugins")
-    lines.append("")
-    lines.append('<div class="grid cards" markdown>')
-    lines.append("")
-    for plugin in shared_plugins:
-        render_card(plugin)
-    lines.append("</div>")
-    lines.append("")
-
-    if team_plugins:
-        lines.append("## Team-Specific Plugins")
-        lines.append("")
-        lines.append("Hardcoded to a specific team's setup — not generally reusable by other teams.")
+    def render_card_section(title, group):
+        if not group:
+            return
+        lines.append(f"## {title}")
         lines.append("")
         lines.append('<div class="grid cards" markdown>')
         lines.append("")
-        for plugin in team_plugins:
+        for plugin in group:
             render_card(plugin)
         lines.append("</div>")
         lines.append("")
+
+    sdlc_plugins = [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]
+    generic_plugins = [p for p in plugins if p.get("scope") == "generic"]
+    team_plugins = [p for p in plugins if p.get("scope") == "team"]
+
+    render_card_section("SDLC", sdlc_plugins)
+    render_card_section("Generic", generic_plugins)
+    render_card_section("Teams", team_plugins)
 
     lines.append("## Categories")
     lines.append("")
@@ -206,8 +196,6 @@ def generate_plugins_index(registry: dict) -> str:
     lines.append(f"{len(plugins)} plugins registered in the marketplace.")
     lines.append("")
 
-    shared_plugins, team_plugins = split_by_scope(plugins)
-
     def render_row(plugin):
         name = plugin["name"]
         cat_key = plugin.get("category", "")
@@ -216,20 +204,20 @@ def generate_plugins_index(registry: dict) -> str:
         version = plugin.get("version", "")
         lines.append(f"| [{name}]({name}/index.md) | {cat_name} | {skill_count} | v{version} |")
 
-    lines.append("| Plugin | Category | Skills | Version |")
-    lines.append("|--------|----------|--------|---------|")
-    for plugin in shared_plugins:
-        render_row(plugin)
-    lines.append("")
-
-    if team_plugins:
-        lines.append("## Team-Specific")
-        lines.append("")
-        lines.append("Hardcoded to a specific team's setup — not generally reusable by other teams.")
+    # Group into one section per scope: SDLC (default), Generic, Teams
+    sections = [
+        ("SDLC", [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]),
+        ("Generic", [p for p in plugins if p.get("scope") == "generic"]),
+        ("Teams", [p for p in plugins if p.get("scope") == "team"]),
+    ]
+    for title, group in sections:
+        if not group:
+            continue
+        lines.append(f"## {title}")
         lines.append("")
         lines.append("| Plugin | Category | Skills | Version |")
         lines.append("|--------|----------|--------|---------|")
-        for plugin in team_plugins:
+        for plugin in group:
             render_row(plugin)
         lines.append("")
 
@@ -266,7 +254,7 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     # Metadata
     lines.append('!!! info "Plugin Details"')
     lines.append("")
-    scope = plugin.get("scope", "org")
+    scope = plugin.get("scope", "sdlc")
     meta = []
     if version:
         meta.append(f"    - **Version**: {version}")
@@ -495,10 +483,8 @@ def generate_category_page(cat_key: str, cat_meta: dict,
     lines.append(cat_meta.get("description", ""))
     lines.append("")
 
-    if plugins:
-        lines.append("## Plugins")
-        lines.append("")
-        for plugin in plugins:
+    def render_plugin_entries(group):
+        for plugin in group:
             name = plugin["name"]
             desc = plugin["description"].strip()
             skill_count = len(plugin.get("skills", []))
@@ -509,6 +495,16 @@ def generate_category_page(cat_key: str, cat_meta: dict,
             lines.append("")
             lines.append(f"**{skill_count} skills** - v{version}")
             lines.append("")
+
+    # Split into SDLC and Generic subsections (team plugins aren't in categories)
+    sdlc_group = [p for p in plugins if p.get("scope", "sdlc") == "sdlc"]
+    generic_group = [p for p in plugins if p.get("scope") == "generic"]
+    for title, group in (("SDLC", sdlc_group), ("Generic", generic_group)):
+        if not group:
+            continue
+        lines.append(f"## {title}")
+        lines.append("")
+        render_plugin_entries(group)
 
     return "\n".join(lines)
 

--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -442,6 +442,13 @@ label.md-nav__link--active {
 }
 
 /* ── Plugin cards ── */
+/* Use auto-fill so a section with a single card keeps normal card width
+   instead of stretching to fill the entire row (Material's auto-fit default).
+   The grid lives on the .grid div; the inner <ul> is display:contents. */
+.md-typeset .grid.cards {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 16rem), 1fr));
+}
+
 .md-typeset .grid.cards > ul > li {
   border: 1px solid var(--sr-border);
   border-radius: 10px;

--- a/site/docs/categories/code-quality.md
+++ b/site/docs/categories/code-quality.md
@@ -9,7 +9,7 @@ title: Code Quality
 
 Code review, linting, and quality enforcement
 
-## Plugins
+## SDLC
 
 ### [code-review-skills](../plugins/code-review-skills/index.md)
 

--- a/site/docs/categories/development-tools.md
+++ b/site/docs/categories/development-tools.md
@@ -9,16 +9,18 @@ title: Development Tools
 
 Developer productivity tools for packaging, CI/CD debugging, and workflow automation
 
-## Plugins
-
-### [odh-ai-helpers](../plugins/odh-ai-helpers/index.md)
-
-Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
-
-**19 skills** - v0.1.0
+## SDLC
 
 ### [autofix-skills](../plugins/autofix-skills/index.md)
 
 Claude Code plugin for the Jira autofix pipeline. Provides orchestrator skills, agent prompt files, and deterministic Python scripts for automated bug fixing, CVE remediation, and ticket triage. Designed to run inside a Claude Code container as part of a CI pipeline.
 
 **4 skills** - v0.1.0
+
+## Generic
+
+### [odh-ai-helpers](../plugins/odh-ai-helpers/index.md)
+
+Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for analyzing package build complexity, resolving dependencies, finding licenses, debugging GitLab pipelines, reviewing ADRs, and more.
+
+**19 skills** - v0.1.0

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -9,7 +9,7 @@ title: DevOps & CI/CD
 
 Skills for deployment, CI/CD, and infrastructure
 
-## Plugins
+## SDLC
 
 ### [disconnected-readiness-scorer](../plugins/disconnected-readiness-scorer/index.md)
 

--- a/site/docs/categories/documentation.md
+++ b/site/docs/categories/documentation.md
@@ -9,7 +9,7 @@ title: Documentation
 
 Skills for generating and maintaining documentation
 
-## Plugins
+## SDLC
 
 ### [knowledge-skills](../plugins/knowledge-skills/index.md)
 

--- a/site/docs/categories/evaluation.md
+++ b/site/docs/categories/evaluation.md
@@ -9,7 +9,7 @@ title: Evaluation & Testing
 
 Skills for evaluating and testing AI agent skills
 
-## Plugins
+## SDLC
 
 ### [assess-rfe](../plugins/assess-rfe/index.md)
 
@@ -28,6 +28,8 @@ End-to-end test planning workflow for RHOAI: generate test plans from strategies
 Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validation, and test pattern extraction.
 
 **5 skills** - v1.0.0
+
+## Generic
 
 ### [agent-eval-harness](../plugins/agent-eval-harness/index.md)
 

--- a/site/docs/categories/planning.md
+++ b/site/docs/categories/planning.md
@@ -9,7 +9,7 @@ title: Product Planning
 
 Skills for requirements, RFEs, and product strategy
 
-## Plugins
+## SDLC
 
 ### [rfe-creator](../plugins/rfe-creator/index.md)
 

--- a/site/docs/categories/security.md
+++ b/site/docs/categories/security.md
@@ -9,7 +9,7 @@ title: Security Review
 
 Security analysis, threat modeling, and compliance review
 
-## Plugins
+## SDLC
 
 ### [rhoai-security-reviewer](../plugins/rhoai-security-reviewer/index.md)
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -16,7 +16,7 @@ hide:
 
 ---
 
-## Plugins
+## SDLC
 
 <div class="grid cards" markdown>
 
@@ -59,22 +59,6 @@ hide:
     Quality tooling and automation for RHOAI component development. Includes automated repository analysis, build validat...
 
     **5 skills** - Evaluation & Testing - v1.0.0
-
--   **[odh-ai-helpers](plugins/odh-ai-helpers/index.md)**
-
-    ---
-
-    Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for anal...
-
-    **19 skills** - Development Tools - v0.1.0
-
--   **[agent-eval-harness](plugins/agent-eval-harness/index.md)**
-
-    ---
-
-    Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and ite...
-
-    **7 skills** - Evaluation & Testing - v1.4.0
 
 -   **[knowledge-skills](plugins/knowledge-skills/index.md)**
 
@@ -123,6 +107,28 @@ hide:
     Execute RHOAI SPIKE investigations with human-in-the-loop approval gates. 9-step lifecycle: intake, plan, Jira sync, ...
 
     **1 skills** - Product Planning - v0.2.0
+
+</div>
+
+## Generic
+
+<div class="grid cards" markdown>
+
+-   **[odh-ai-helpers](plugins/odh-ai-helpers/index.md)**
+
+    ---
+
+    Developer productivity tools for Python packaging, CI/CD debugging, and workflow automation. Includes skills for anal...
+
+    **19 skills** - Development Tools - v0.1.0
+
+-   **[agent-eval-harness](plugins/agent-eval-harness/index.md)**
+
+    ---
+
+    Generic agentic evaluation for skills and agents. Provides end-to-end skills to analyze, test, score, review, and ite...
+
+    **7 skills** - Evaluation & Testing - v1.4.0
 
 </div>
 

--- a/site/docs/plugins/agent-eval-harness/index.md
+++ b/site/docs/plugins/agent-eval-harness/index.md
@@ -30,6 +30,7 @@ containerized execution.
 
     - **Version**: 1.4.0
     - **Author**: Antonin Stefanutti
+    - **Scope**: Generic
     - **Category**: [Evaluation & Testing](../../categories/evaluation.md)
     - **Repository**: [opendatahub-io/agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness)
     - **Tags**: <span class="tag-pill">evaluation</span> <span class="tag-pill">testing</span> <span class="tag-pill">skills</span> <span class="tag-pill">agents</span> <span class="tag-pill">mlflow</span> <span class="tag-pill">optimization</span> <span class="tag-pill">scoring</span>

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -9,6 +9,8 @@ title: Plugins
 
 13 plugins registered in the marketplace.
 
+## SDLC
+
 | Plugin | Category | Skills | Version |
 |--------|----------|--------|---------|
 | [rfe-creator](rfe-creator/index.md) | Product Planning | 12 | v0.1.0 |
@@ -16,11 +18,16 @@ title: Plugins
 | [rhoai-security-reviewer](rhoai-security-reviewer/index.md) | Security Review | 2 | v0.1.0 |
 | [test-plan](test-plan/index.md) | Evaluation & Testing | 17 | v1.0.0 |
 | [quality-tooling](quality-tooling/index.md) | Evaluation & Testing | 5 | v1.0.0 |
-| [odh-ai-helpers](odh-ai-helpers/index.md) | Development Tools | 19 | v0.1.0 |
-| [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 7 | v1.4.0 |
 | [knowledge-skills](knowledge-skills/index.md) | Documentation | 1 | v0.1.0 |
 | [autofix-skills](autofix-skills/index.md) | Development Tools | 4 | v0.1.0 |
 | [disconnected-readiness-scorer](disconnected-readiness-scorer/index.md) | DevOps & CI/CD | 1 | v0.1.0 |
 | [aiops-skills](aiops-skills/index.md) | DevOps & CI/CD | 2 | v0.1.0 |
 | [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |
+
+## Generic
+
+| Plugin | Category | Skills | Version |
+|--------|----------|--------|---------|
+| [odh-ai-helpers](odh-ai-helpers/index.md) | Development Tools | 19 | v0.1.0 |
+| [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 7 | v1.4.0 |

--- a/site/docs/plugins/odh-ai-helpers/index.md
+++ b/site/docs/plugins/odh-ai-helpers/index.md
@@ -33,6 +33,7 @@ with each stage producing JSON artifacts consumed by the next.
     - **Version**: 0.1.0
     - **Author**: opendatahub-io
     - **License**: Apache-2.0
+    - **Scope**: Generic
     - **Category**: [Development Tools](../../categories/development-tools.md)
     - **Repository**: [opendatahub-io/ai-helpers](https://github.com/opendatahub-io/ai-helpers)
     - **Tags**: <span class="tag-pill">python-packaging</span> <span class="tag-pill">licensing</span> <span class="tag-pill">dependencies</span> <span class="tag-pill">gitlab</span> <span class="tag-pill">jira</span> <span class="tag-pill">adr</span> <span class="tag-pill">git</span> <span class="tag-pill">automation</span>


### PR DESCRIPTION
## Summary

Introduces an optional `scope` field on plugin entries to capture how reusable a plugin is, separating *reusability* (a property of the plugin) from *category* (what it does).

- **Values**: `generic` (works anywhere), `sdlc` (RHOAI/ODH-wide, reusable across teams — the default), `team` (hardcoded to one team's setup, not generally reusable)
- **Catalog-only metadata** — not propagated to `marketplace.json` (same as `depends_on`), so it does **not** affect installation. Every plugin remains installable by anyone; teams simply don't install plugins they don't need.
- **Site organization**: the home page, Plugins index, and category pages are split into **SDLC / Generic / Teams** sections by scope. Plugin pages show a scope badge for `generic` and `team`. `team` plugins are kept out of function-category counts.
- **CSS fix**: card grids use `auto-fill` so a section with a single card keeps normal card width instead of stretching full-width.
- **CONTRIBUTING.md**: documents the field, the "prefer reusable / parameterize team-specific values" guidance, and that `category` must stay function-based (team identity goes in `tags` + `scope`, not team-named categories).

## Scope assignments in this PR

- `generic`: `agent-eval-harness`, `odh-ai-helpers`
- `sdlc` (default): everything else
- `team`: none yet

## Background

Came out of the discussion on PR #62 (model-serving-skills), which proposed a team-named *category*. This gives a principled alternative: keep categories function-based and mark team-specificity with `scope`.

## Test plan

- [x] `validate_registry.py`, `sync_marketplace.py`, `generate_catalog.py`, `generate_site.py` all pass
- [x] Verified SDLC/Generic/Teams split renders on the home page, Plugins index, and category pages (previewed locally via `mkdocs serve`)
- [x] Confirmed `scope` is not propagated to `marketplace.json`
- [ ] Follow-up: apply `scope: team` to model-serving-skills (PR #62); consider `generic` for knowledge-skills and code-review-skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
