### PR TITLE
feat: add software-catalog plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -364,6 +364,29 @@
       },
       "strict": false,
       "version": "0.2.0"
+    },
+    {
+      "author": {
+        "name": "Kevin Howell"
+      },
+      "category": "development-tools",
+      "description": "Query the software catalog to find mappings between Red Hat products, Jira projects, Jira components, GitHub repos, build artifacts, and scrum teams.\n",
+      "keywords": [
+        "red-hat",
+        "jira",
+        "github",
+        "catalog",
+        "mapping",
+        "query"
+      ],
+      "license": "Apache-2.0",
+      "name": "software-catalog",
+      "source": {
+        "ref": "main",
+        "repo": "opendatahub-io/software-catalog",
+        "source": "github"
+      },
+      "version": "1.0.0"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -261,6 +261,22 @@ Tags: autofix, jira, cve, bug-fixing, triage, pipeline, ci-cd
 /plugin install autofix-skills@opendatahub-skills
 ```
 
+### software-catalog
+
+Query the software catalog to find mappings between Red Hat products, Jira projects, Jira components, GitHub repos, build artifacts, and scrum teams.
+
+v1.0.0 | Apache-2.0 | [opendatahub-io/software-catalog](https://github.com/opendatahub-io/software-catalog)
+
+Tags: red-hat, jira, github, catalog, mapping, query
+
+| Skill | Description |
+|-------|-------------|
+| `/software-catalog-query` | Query mappings between Red Hat products, Jira projects/components, GitHub repos, build artifacts, and scrum teams |
+
+```bash
+/plugin install software-catalog@opendatahub-skills
+```
+
 ## Product Planning
 
 Skills for requirements, RFEs, and product strategy

--- a/registry.yaml
+++ b/registry.yaml
@@ -600,3 +600,30 @@ plugins:
       package: spike-executor
       requires_python: ">=3.10"
     depends_on: []
+
+  - name: software-catalog
+    description: >
+      Query the software catalog to find mappings between Red Hat products,
+      Jira projects, Jira components, GitHub repos, build artifacts, and scrum teams.
+    version: "1.0.0"
+    category: development-tools
+    scope: sdlc
+    tags: [red-hat, jira, github, catalog, mapping, query]
+    author:
+      name: Kevin Howell
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/software-catalog
+      ref: main
+    skills_dir: .claude/skills
+    skills:
+      - name: software-catalog-query
+        description: Query mappings between Red Hat products, Jira projects/components, GitHub repos, build artifacts, and scrum teams
+        user-invocable: true
+    harnesses:
+      claude-code:
+        install: "/plugin install software-catalog@opendatahub-skills"
+    python:
+      requires_python: ">=3.9"
+    depends_on: []


### PR DESCRIPTION
Adds the `software-catalog` plugin for querying Red Hat AI product mappings.

## What this adds
The software-catalog plugin provides a skill for querying mappings between:
- Red Hat products (RHOAI, Red Hat AI Inference Server, Open Data Hub)                                                                                                                                         
- Jira projects and components                                        
- GitHub repositories                                                                                                                                                                                          
- Build artifacts (container images, Python wheels)                                                                                                                                                            
- Scrum teams                                      
                                                                                                                                                                                                                 
## Key features  
               
- Works entirely from local cached JSON files
- No CLI tools or network access needed at query time                                                                                                                                                          
- Supports filtering by version, tier (upstream/midstream/downstream), and product relationships (embedded/dependency)
- Tracks inter-product relationships (embedded components and runtime dependencies)                                                                                                                            
                                                                                   
## Repository                                                                                                                                                                                                  

https://github.com/opendatahub-io/software-catalog

(NOTE: software-catalog contains some sensitive information (e.g. team info), so uses non-public visibility)

<!--- Provide a general summary of your changes in the Title above -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced software-catalog plugin (v1.0.0) as a new development tool for managing software catalogs
- Added `/software-catalog-query` skill enabling users to query software catalog information  
- Plugin installable via `/plugin install software-catalog@opendatahub-skills` command
- Requires Python 3.9 or higher

<!-- end of auto-generated comment: release notes by coderabbit.ai -->