### PR TITLE
feat: support non-GitHub git source types (#74)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,6 +113,15 @@ that contains the actual skills:
 Note: `skills_dir` must not be specified without `strict: false`. The schema
 and validation scripts enforce this constraint.
 
+### Source Types
+
+- **`type: github`** — shorthand for GitHub repos. Only requires `repo: owner/name`;
+  clone and browse URLs are derived automatically.
+- **`type: git`** — explicit clone URL for any git forge (GitLab, Gitea, Bitbucket, etc.).
+  Requires `url` (the clone URL). Browse links strip the trailing `.git` suffix.
+- **`type: git-subdir`** — subdirectory within a git repo (uses `path`).
+- **`type: npm`** / **`type: local`** — non-git source types.
+
 ### Dependencies
 
 Plugins can declare `depends_on: [other-plugin]` to express inter-plugin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ For repos without `plugin.json`, add `strict: false` and `skills_dir`:
     skills_dir: .claude/skills
 ```
 
+For plugins hosted on non-GitHub forges (GitLab, Gitea, etc.), use `type: git` with an explicit `url`:
+```yaml
+    source:
+      type: git
+      url: https://gitlab.corp.example.com/team/your-repo.git
+      ref: main
+```
+
 The `user-invocable` field mirrors the [native Claude Code SKILL.md frontmatter field](https://code.claude.com/docs/en/skills#frontmatter-reference). Set it to `false` for internal skills that are called only by other skills/agents in the background — they will be hidden from the generated catalog. The registry value is catalog-only, so to actually hide the skill from the `/` menu in Claude Code you must also set `user-invocable: false` in the SKILL.md frontmatter in your source repo.
 
 ### Plugin scope

--- a/docs/superpowers/plans/2026-07-02-git-source-type.md
+++ b/docs/superpowers/plans/2026-07-02-git-source-type.md
@@ -1,0 +1,1074 @@
+# Git Source Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Support non-GitHub source types in the registry by adding a `type: git` source with an explicit `url` field, while keeping `type: github` as ergonomic sugar.
+
+**Architecture:** Add three helper functions to `registry_contracts.py` (`source_clone_url`, `source_display_name`, `source_browse_url`) that centralize URL derivation. Update the JSON Schema with conditional validation. Modify all scripts to use helpers instead of hardcoded GitHub URLs. TDD throughout.
+
+**Tech Stack:** Python 3.12, JSON Schema (Draft 2020-12), PyYAML, jsonschema, unittest
+
+---
+
+### Task 1: Add helper functions to `registry_contracts.py`
+
+**Files:**
+- Modify: `scripts/registry_contracts.py` (add functions after line 68)
+- Test: `tests/test_registry_contracts.py`
+
+- [ ] **Step 1: Write failing tests for `source_clone_url`**
+
+Add to `tests/test_registry_contracts.py`:
+
+```python
+from scripts.registry_contracts import (
+    SkillKey,
+    detect_touched_skills,
+    load_registry_from_ref,
+    load_staged_registry,
+    source_browse_url,
+    source_clone_url,
+    source_display_name,
+)
+
+
+class SourceHelperTests(unittest.TestCase):
+    def test_source_clone_url_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("https://github.com/opendatahub-io/rfe-creator.git", source_clone_url(source))
+
+    def test_source_clone_url_git(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin.git", source_clone_url(source))
+
+    def test_source_clone_url_unsupported_type_raises(self):
+        with self.assertRaises(ValueError):
+            source_clone_url({"type": "npm", "repo": "foo"})
+
+    def test_source_display_name_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("opendatahub-io/rfe-creator", source_display_name(source))
+
+    def test_source_display_name_git_strips_scheme_and_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("gitlab.corp.example.com/team/my-plugin", source_display_name(source))
+
+    def test_source_display_name_git_no_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
+        self.assertEqual("gitlab.corp.example.com/team/my-plugin", source_display_name(source))
+
+    def test_source_browse_url_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("https://github.com/opendatahub-io/rfe-creator", source_browse_url(source))
+
+    def test_source_browse_url_git_strips_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
+
+    def test_source_browse_url_git_no_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_registry_contracts.SourceHelperTests -v`
+Expected: FAIL with ImportError (functions don't exist yet)
+
+- [ ] **Step 3: Implement the three helper functions**
+
+Add to `scripts/registry_contracts.py` after line 68 (after `PLUGIN_FIELDS_THAT_TOUCH_ALL_SKILLS`):
+
+```python
+import re as _re
+
+_SCHEME_RE = _re.compile(r"^https?://")
+GIT_CLONE_TYPES = frozenset({"github", "git"})
+
+
+def source_clone_url(source: dict) -> str:
+    """Return the git clone URL for a plugin source entry."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return f"https://github.com/{source['repo']}.git"
+    if source_type == "git":
+        return source["url"]
+    raise ValueError(f"unsupported source type for cloning: {source_type!r}")
+
+
+def source_display_name(source: dict) -> str:
+    """Return a human-readable display name (scheme-stripped, no trailing .git)."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return source["repo"]
+    if source_type == "git":
+        url = source["url"]
+        name = _SCHEME_RE.sub("", url)
+        if name.endswith(".git"):
+            name = name[:-4]
+        return name
+    return source.get("repo") or source.get("url") or "<unknown>"
+
+
+def source_browse_url(source: dict) -> str:
+    """Return a browsable URL for linking in markdown."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return f"https://github.com/{source['repo']}"
+    if source_type == "git":
+        url = source["url"]
+        if url.endswith(".git"):
+            return url[:-4]
+        return url
+    return source.get("url") or f"https://github.com/{source.get('repo', '')}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_registry_contracts.SourceHelperTests -v`
+Expected: PASS (all 10 tests)
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/registry_contracts.py tests/test_registry_contracts.py
+git commit -S -s -m "feat: add source URL helper functions for git source type (#74)
+
+Add source_clone_url, source_display_name, and source_browse_url to
+registry_contracts.py. These centralize URL derivation for both
+type: github (inferred from repo slug) and type: git (explicit url).
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Update JSON Schema to support `type: git`
+
+**Files:**
+- Modify: `schema/registry.schema.json:390-418`
+- Test: `tests/test_validate_registry.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Add to `tests/test_validate_registry.py` in `SchemaTests`:
+
+```python
+    def test_schema_accepts_git_source_with_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.corp.example.com/team/my-plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertEqual([], errors)
+
+    def test_schema_rejects_git_source_without_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
+    def test_schema_rejects_github_source_without_repo(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "github",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("repo" in error for error in errors), errors)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_validate_registry.SchemaTests.test_schema_accepts_git_source_with_url tests.test_validate_registry.SchemaTests.test_schema_rejects_git_source_without_url tests.test_validate_registry.SchemaTests.test_schema_rejects_github_source_without_repo -v`
+Expected: `test_schema_accepts_git_source_with_url` FAILs (git not in enum), the other two may pass or fail depending on current required fields
+
+- [ ] **Step 3: Update the schema**
+
+Modify `schema/registry.schema.json` lines 390-418. Replace the `source` definition:
+
+```json
+"source": {
+  "type": "object",
+  "required": ["type"],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["github", "git", "git-subdir", "npm", "local"],
+      "description": "Source type"
+    },
+    "repo": {
+      "type": "string",
+      "description": "Repository identifier (e.g., owner/repo) — required for github type"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Clone URL — required for git type"
+    },
+    "ref": {
+      "type": "string",
+      "description": "Git branch, tag, or ref"
+    },
+    "sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Exact commit SHA"
+    },
+    "path": {
+      "type": "string",
+      "description": "Subdirectory path (for git-subdir type)"
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "const": "github" } }, "required": ["type"] },
+      "then": { "required": ["repo"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
+      "then": { "required": ["url"] }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_validate_registry.SchemaTests -v`
+Expected: All schema tests pass including the three new ones
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add schema/registry.schema.json tests/test_validate_registry.py
+git commit -S -s -m "feat: add git source type to registry schema (#74)
+
+Add 'git' to source type enum and 'url' property. Use conditional
+validation (if/then) to require 'repo' for github and 'url' for git.
+Change source required from ['type', 'repo'] to ['type'].
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update `validate_registry.py` to support git sources
+
+**Files:**
+- Modify: `scripts/validate_registry.py:253-348`
+- Test: `tests/test_validate_registry.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_validate_registry.py` in `RemotePluginValidationTests`:
+
+```python
+    @mock.patch("subprocess.run")
+    def test_check_sources_uses_ls_remote_for_git_type(self, run_mock):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ["git", "ls-remote"], 0, stdout="", stderr=""
+        )
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        errors = self.validate_registry.check_sources(registry)
+
+        self.assertEqual([], errors)
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args[0][0]
+        self.assertEqual(cmd[0], "git")
+        self.assertIn("ls-remote", cmd)
+
+    @mock.patch("subprocess.run")
+    def test_validate_remote_plugin_accepts_git_type(self, run_mock):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ["git", "clone"], 0, stdout="", stderr=""
+        )
+        plugin = {
+            "name": "git-plugin",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.example.com/team/plugin.git",
+                "ref": "main",
+            },
+        }
+
+        # Will fail on clone (mock returns empty dir) but should not
+        # skip due to source type
+        errors = self.validate_registry.validate_remote_plugin(plugin)
+
+        self.assertTrue(run_mock.called)
+        cmd = run_mock.call_args[0][0]
+        self.assertIn("https://gitlab.example.com/team/plugin.git", cmd)
+```
+
+Add `import subprocess` to the imports at top of `tests/test_validate_registry.py` if not already present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_validate_registry.RemotePluginValidationTests -v`
+Expected: FAIL — `check_sources` skips non-github, `validate_remote_plugin` skips non-github
+
+- [ ] **Step 3: Update `check_sources` in `validate_registry.py`**
+
+Replace lines 253-271:
+
+```python
+def check_sources(registry: dict) -> list[str]:
+    """Check that source repos are accessible."""
+    from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url
+
+    errors = []
+    for plugin in registry.get("plugins", []):
+        source = plugin.get("source")
+        if not source:
+            continue
+        source_type = source.get("type")
+        if source_type not in GIT_CLONE_TYPES:
+            continue
+        name = plugin.get("name", "<unknown>")
+        if source_type == "github":
+            repo = source.get("repo")
+            if not repo:
+                continue
+            result = subprocess.run(
+                ["gh", "api", f"repos/{repo}", "--silent"],
+                capture_output=True, text=True,
+            )
+        else:
+            try:
+                clone_url = source_clone_url(source)
+            except (ValueError, KeyError):
+                errors.append(f"  Plugin '{name}': invalid source configuration")
+                continue
+            result = subprocess.run(
+                ["git", "ls-remote", "--exit-code", "--quiet", clone_url],
+                capture_output=True, text=True,
+            )
+        if result.returncode != 0:
+            errors.append(f"  Plugin '{name}': source not accessible")
+        else:
+            print(f"  OK: {name}")
+    return errors
+```
+
+- [ ] **Step 4: Update `validate_remote_plugin` in `validate_registry.py`**
+
+Replace the source type check and clone URL construction (around lines 288-308). Change:
+
+```python
+    source = plugin.get("source")
+    if not source or source.get("type") != "github":
+        return errors
+```
+
+to:
+
+```python
+    from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url
+
+    source = plugin.get("source")
+    if not source or source.get("type") not in GIT_CLONE_TYPES:
+        return errors
+```
+
+And replace the hardcoded clone URL:
+
+```python
+    clone_url = f"https://github.com/{repo}.git"
+```
+
+with:
+
+```python
+    try:
+        clone_url = source_clone_url(source)
+    except (ValueError, KeyError):
+        errors.append(f"  Plugin '{plugin['name']}': invalid source configuration")
+        return errors
+```
+
+Remove the `repo = source["repo"]` line that preceded the old clone_url construction (the `repo` variable is no longer needed for the URL).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_validate_registry.RemotePluginValidationTests -v`
+Expected: All pass
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/validate_registry.py tests/test_validate_registry.py
+git commit -S -s -m "feat: validate_registry supports git source type (#74)
+
+check_sources uses git ls-remote for type: git, keeps gh api for
+type: github. validate_remote_plugin uses source_clone_url helper
+for both types.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update `run_skill_linter.py` to support git sources
+
+**Files:**
+- Modify: `scripts/run_skill_linter.py:180-267`
+- Test: `tests/test_run_skill_linter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_run_skill_linter.py` in `SkillLinterWrapperTests`:
+
+```python
+    def test_skill_is_skill_linter_candidate_accepts_git_type(self):
+        plugin_git = {
+            "name": "p",
+            "source": {"type": "git", "url": "https://gitlab.example.com/t/p.git"},
+        }
+        skill_ok = {
+            "name": "t",
+            "contract": {"source_assertions": {"skill_path": ".claude/skills/t/SKILL.md"}},
+        }
+        self.assertTrue(skill_is_skill_linter_candidate(plugin_git, skill_ok))
+
+    def test_skill_is_skill_linter_candidate_rejects_git_without_url(self):
+        plugin_git = {"name": "p", "source": {"type": "git"}}
+        skill_ok = {
+            "name": "t",
+            "contract": {"source_assertions": {"skill_path": ".claude/skills/t/SKILL.md"}},
+        }
+        self.assertFalse(skill_is_skill_linter_candidate(plugin_git, skill_ok))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_run_skill_linter.SkillLinterWrapperTests.test_skill_is_skill_linter_candidate_accepts_git_type tests.test_run_skill_linter.SkillLinterWrapperTests.test_skill_is_skill_linter_candidate_rejects_git_without_url -v`
+Expected: `test_skill_is_skill_linter_candidate_accepts_git_type` FAILs (git type not accepted)
+
+- [ ] **Step 3: Update `skill_is_skill_linter_candidate`**
+
+In `scripts/run_skill_linter.py`, replace lines 193-199:
+
+```python
+    source = plugin.get("source") or {}
+    if not isinstance(source, dict) or source.get("type") != "github":
+        return False
+    repo = source.get("repo")
+    if not isinstance(repo, str) or not repo.strip():
+        return False
+```
+
+with:
+
+```python
+    source = plugin.get("source") or {}
+    if not isinstance(source, dict):
+        return False
+    source_type = source.get("type")
+    if source_type not in GIT_CLONE_TYPES:
+        return False
+    if source_type == "github":
+        repo = source.get("repo")
+        if not isinstance(repo, str) or not repo.strip():
+            return False
+    elif source_type == "git":
+        url = source.get("url")
+        if not isinstance(url, str) or not url.strip():
+            return False
+```
+
+Add `GIT_CLONE_TYPES` to the imports from `scripts.registry_contracts` at the top of the file (line 22-32):
+
+```python
+from scripts.registry_contracts import (  # noqa: E402
+    GIT_CLONE_TYPES,
+    SKILL_LINTER_VERSION,
+    SkillKey,
+    ...
+)
+```
+
+- [ ] **Step 4: Update `_ensure_github_repo` -> `_ensure_repo`**
+
+Rename the function (line 214) and replace the clone URL construction (line 217):
+
+```python
+def _ensure_repo(source: dict) -> Path:
+    clone_url = source_clone_url(source)
+    source_type = source.get("type")
+    if source_type == "github":
+        repo = source["repo"]
+        ref = normalize_git_ref(source.get("ref", "main"))
+    else:
+        repo = source_display_name(source)
+        ref = normalize_git_ref(source.get("ref", "main"))
+```
+
+Add `source_clone_url` and `source_display_name` to the imports from `scripts.registry_contracts`.
+
+Update the `_cache_destination` call to use `source_display_name(source)` instead of `repo`:
+
+```python
+    destination = _cache_destination(source_display_name(source), ref)
+```
+
+Replace `clone_url = f"https://github.com/{repo}.git"` with just using the `clone_url` from above.
+
+- [ ] **Step 5: Update `_run_one_skill` to use `_ensure_repo`**
+
+Replace the github-only gate (lines 295-319) in `_run_one_skill`. Change:
+
+```python
+    source = plugin.get("source") or {}
+    if not isinstance(source, dict) or source.get("type") != "github":
+        print(
+            f"ERROR: Plugin '{plug_name}' skill '{ski_name}' "
+            "has contract source_assertions but source is not type 'github'",
+            file=sys.stderr,
+        )
+        return 1
+```
+
+to:
+
+```python
+    source = plugin.get("source") or {}
+    if not isinstance(source, dict) or source.get("type") not in GIT_CLONE_TYPES:
+        print(
+            f"ERROR: Plugin '{plug_name}' skill '{ski_name}' "
+            "has contract source_assertions but source type is not cloneable",
+            file=sys.stderr,
+        )
+        return 1
+```
+
+Replace:
+
+```python
+    repo = source.get("repo")
+    if not isinstance(repo, str) or not repo.strip():
+        print(
+            f"ERROR: Plugin '{plug_name}' is missing source.repo.",
+            file=sys.stderr,
+        )
+        return 1
+```
+
+with:
+
+```python
+    try:
+        _ = source_clone_url(source)
+    except (ValueError, KeyError):
+        print(
+            f"ERROR: Plugin '{plug_name}' has invalid source configuration.",
+            file=sys.stderr,
+        )
+        return 1
+```
+
+Change `repo_root = _ensure_github_repo(repo, plugin_ref)` to `repo_root = _ensure_repo(source)`.
+
+Update the print line: replace `repo={repo} ref={plugin_ref}` with `source={source_display_name(source)}`:
+
+```python
+    print(f"Running skill-linter for {plug_name}/{ski_name} (source={source_display_name(source)})...")
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_run_skill_linter -v`
+Expected: All pass
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/run_skill_linter.py tests/test_run_skill_linter.py
+git commit -S -s -m "feat: skill linter supports git source type (#74)
+
+Rename _ensure_github_repo to _ensure_repo. Use source_clone_url and
+source_display_name helpers. Accept type: git alongside type: github
+for linter candidacy.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update `check_versions.py` to support git sources
+
+**Files:**
+- Modify: `scripts/check_versions.py:42-63,76-79`
+
+- [ ] **Step 1: Add `fetch_remote_version_via_clone` function**
+
+Add after `fetch_remote_version` (line 63):
+
+```python
+def fetch_remote_version_via_clone(clone_url: str, ref: str = "main") -> str | None:
+    """Fetch version from remote plugin.json via shallow clone."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
+            capture_output=True, text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            return None
+        plugin_json = Path(tmpdir) / ".claude-plugin" / "plugin.json"
+        if not plugin_json.exists():
+            return None
+        try:
+            data = json.loads(plugin_json.read_text())
+            return data.get("version")
+        except (json.JSONDecodeError, OSError):
+            return None
+```
+
+Add `import tempfile` and `from pathlib import Path` to the imports at the top (line 1-6). Also add:
+
+```python
+from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url, normalize_git_ref
+```
+
+- [ ] **Step 2: Update the main loop to handle git sources**
+
+Replace the source type check (lines 76-79):
+
+```python
+        if source.get("type") != "github":
+            continue
+```
+
+with:
+
+```python
+        source_type = source.get("type")
+        if source_type not in GIT_CLONE_TYPES:
+            continue
+```
+
+Replace the remote version fetch call (line 90):
+
+```python
+        remote = fetch_remote_version(repo, source.get("ref", "main"))
+```
+
+with:
+
+```python
+        if source_type == "github":
+            remote = fetch_remote_version(repo, source.get("ref", "main"))
+        else:
+            try:
+                clone_url = source_clone_url(source)
+                ref = normalize_git_ref(source.get("ref", "main"))
+            except (ValueError, KeyError):
+                print(f"  SKIP: {name} (invalid source configuration)")
+                continue
+            remote = fetch_remote_version_via_clone(clone_url, ref)
+```
+
+Note: the `repo` variable used for `fetch_remote_version` is still read from `source.get("repo")` on line 85. For git type, `repo` will be `None`, which is fine because that branch uses `source_clone_url` instead.
+
+- [ ] **Step 3: Run validation to check nothing broke**
+
+Run: `python3 scripts/check_versions.py --dry-run`
+Expected: Runs and shows current plugin versions (all github, so existing path)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check_versions.py
+git commit -S -s -m "feat: check_versions supports git source type (#74)
+
+For type: git, shallow clone to a temp directory to read plugin.json
+instead of using the GitHub API. Weekly job, performance not critical.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update `generate_catalog.py` to use source helpers
+
+**Files:**
+- Modify: `scripts/generate_catalog.py:216`
+- Test: `tests/test_generate_catalog.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_generate_catalog.py`:
+
+```python
+class CatalogGitSourceTests(unittest.TestCase):
+    def test_catalog_renders_git_source_browse_link(self):
+        registry = build_registry_with_contract()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        content = generate_catalog.generate_catalog(registry)
+
+        self.assertIn("[gitlab.example.com/team/plugin](https://gitlab.example.com/team/plugin)", content)
+        self.assertNotIn("github.com", content.split("Quick Start")[1])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest tests.test_generate_catalog.CatalogGitSourceTests -v`
+Expected: FAIL — current code builds `https://github.com/{repo}` which will fail on missing repo key or produce wrong URL
+
+- [ ] **Step 3: Update `render_plugin` in `generate_catalog.py`**
+
+Add import at top of file (after line 23):
+
+```python
+from scripts.registry_contracts import source_browse_url, source_display_name
+```
+
+Replace line 216:
+
+```python
+        meta_parts.append(f"[{repo}](https://github.com/{repo})")
+```
+
+with:
+
+```python
+        display = source_display_name(plugin["source"])
+        browse = source_browse_url(plugin["source"])
+        meta_parts.append(f"[{display}]({browse})")
+```
+
+Remove the `repo = plugin["source"].get("repo", "")` line (around line 189) and the `if repo:` guard (around line 215-216). Replace them with:
+
+```python
+    source = plugin["source"]
+    source_type = source.get("type", "")
+```
+
+And change the guard to:
+
+```python
+    if source_type in ("github", "git"):
+        display = source_display_name(source)
+        browse = source_browse_url(source)
+        meta_parts.append(f"[{display}]({browse})")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_generate_catalog -v`
+Expected: All pass
+
+- [ ] **Step 5: Regenerate catalog.md and verify**
+
+Run: `python3 scripts/generate_catalog.py`
+Expected: Generates successfully. Existing github links unchanged (since all current plugins are github).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/generate_catalog.py tests/test_generate_catalog.py
+git commit -S -s -m "feat: catalog generator supports git source type (#74)
+
+Use source_browse_url and source_display_name helpers instead of
+hardcoded GitHub URL construction.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Update `generate_site.py` to use source helpers
+
+**Files:**
+- Modify: `scripts/generate_site.py:398,869`
+- Test: `tests/test_generate_site.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_generate_site.py`:
+
+```python
+class SiteGitSourceTests(unittest.TestCase):
+    def test_plugin_page_renders_git_source_link(self):
+        registry = build_registry_with_contract()
+        plugin = registry["plugins"][0]
+        plugin["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        page = generate_site.generate_plugin_page(plugin, registry, enrichment=None, plugin_dir=None)
+
+        self.assertIn("gitlab.example.com/team/plugin", page)
+        self.assertIn("https://gitlab.example.com/team/plugin", page)
+        self.assertNotIn("https://github.com/", page)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest tests.test_generate_site.SiteGitSourceTests -v`
+Expected: FAIL — current code builds `https://github.com/{repo}`
+
+- [ ] **Step 3: Update `generate_plugin_page`**
+
+Add imports at top (after line 27):
+
+```python
+from scripts.registry_contracts import (
+    ...
+    source_browse_url,
+    source_display_name,
+)
+```
+
+Replace line 398:
+
+```python
+    if repo:
+        meta.append(f"    - **Repository**: [{repo}](https://github.com/{repo})")
+```
+
+with:
+
+```python
+    source = plugin.get("source", {})
+    source_type = source.get("type", "")
+    if source_type in ("github", "git"):
+        display = source_display_name(source)
+        browse = source_browse_url(source)
+        meta.append(f"    - **Repository**: [{display}]({browse})")
+```
+
+Remove the `repo = plugin.get("source", {}).get("repo", "")` line earlier in the function (around line 364) since we now use `source` directly. Keep other uses of `repo` variable if they exist in the function — check and replace each.
+
+- [ ] **Step 4: Update `generate_llms_full_txt`**
+
+Replace line 869:
+
+```python
+        if repo:
+            lines.append(f"**Repository**: https://github.com/{repo}")
+```
+
+with:
+
+```python
+        source = p.get("source", {})
+        source_type = source.get("type", "")
+        if source_type in ("github", "git"):
+            lines.append(f"**Repository**: {source_browse_url(source)}")
+```
+
+Remove the `repo = p.get("source", {}).get("repo", "")` line (around line 859).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_generate_site -v`
+Expected: All pass
+
+- [ ] **Step 6: Regenerate site and verify**
+
+Run: `python3 scripts/generate_site.py`
+Expected: Generates successfully, existing github links unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/generate_site.py tests/test_generate_site.py
+git commit -S -s -m "feat: site generator supports git source type (#74)
+
+Use source_browse_url and source_display_name helpers in plugin pages
+and llms-full.txt instead of hardcoded GitHub URL construction.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Update `sync_marketplace.py` to emit `url` for git sources
+
+**Files:**
+- Modify: `scripts/sync_marketplace.py:44-55`
+
+- [ ] **Step 1: Update `plugin_to_marketplace_entry`**
+
+Replace lines 46-55 (the source mapping block):
+
+```python
+    # Map source
+    source = plugin["source"]
+    entry["source"] = {
+        "source": source["type"],
+        "repo": source["repo"],
+    }
+    if "ref" in source:
+        entry["source"]["ref"] = source["ref"]
+    if "sha" in source:
+        entry["source"]["sha"] = source["sha"]
+    if "path" in source:
+        entry["source"]["path"] = source["path"]
+```
+
+with:
+
+```python
+    # Map source
+    source = plugin["source"]
+    mapped = {"source": source["type"]}
+    if "repo" in source:
+        mapped["repo"] = source["repo"]
+    if "url" in source:
+        mapped["url"] = source["url"]
+    if "ref" in source:
+        mapped["ref"] = source["ref"]
+    if "sha" in source:
+        mapped["sha"] = source["sha"]
+    if "path" in source:
+        mapped["path"] = source["path"]
+    entry["source"] = mapped
+```
+
+- [ ] **Step 2: Regenerate marketplace.json and verify no diff**
+
+Run: `python3 scripts/sync_marketplace.py`
+Expected: No changes to marketplace.json (all current plugins are github, so `repo` is still emitted).
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/sync_marketplace.py
+git commit -S -s -m "feat: marketplace sync emits url for git source type (#74)
+
+Pass through url field for type: git sources alongside the existing
+repo field for type: github sources.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Regenerate all artifacts and run CI checks
+
+**Files:**
+- Regenerate: `.claude-plugin/marketplace.json`, `catalog.md`, `site/`
+
+- [ ] **Step 1: Run validation**
+
+Run: `python3 scripts/validate_registry.py`
+Expected: PASSED
+
+- [ ] **Step 2: Regenerate all artifacts**
+
+Run: `python3 scripts/sync_marketplace.py && python3 scripts/generate_catalog.py && python3 scripts/generate_site.py`
+Expected: All generate successfully
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+Expected: All pass
+
+- [ ] **Step 4: Verify no unexpected diffs in generated files**
+
+Run: `git diff --stat`
+Expected: No changes (all current plugins are github, so generated files should be identical)
+
+- [ ] **Step 5: Run linter**
+
+Run: `python3 -m py_compile scripts/registry_contracts.py && python3 -m py_compile scripts/validate_registry.py && python3 -m py_compile scripts/run_skill_linter.py && python3 -m py_compile scripts/check_versions.py && python3 -m py_compile scripts/generate_catalog.py && python3 -m py_compile scripts/generate_site.py && python3 -m py_compile scripts/sync_marketplace.py`
+Expected: All compile cleanly
+
+---
+
+### Task 10: Update documentation
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update CONTRIBUTING.md**
+
+In the "Add Your Entry to registry.yaml" section, after the existing `source:` example block, add a new subsection:
+
+```markdown
+For plugins hosted on non-GitHub forges (GitLab, Gitea, etc.), use `type: git` with an explicit `url`:
+```yaml
+    source:
+      type: git
+      url: https://gitlab.corp.example.com/team/your-repo.git
+      ref: main
+```
+```
+
+- [ ] **Step 2: Update ARCHITECTURE.md**
+
+In the "Plugin Model" section, after the existing diagram showing `github` sources, add a paragraph:
+
+```markdown
+### Source Types
+
+- **`type: github`** — shorthand for GitHub repos. Only requires `repo: owner/name`;
+  clone and browse URLs are derived automatically.
+- **`type: git`** — explicit clone URL for any git forge (GitLab, Gitea, Bitbucket, etc.).
+  Requires `url` (the clone URL). Browse links strip the trailing `.git` suffix.
+- **`type: git-subdir`** — subdirectory within a git repo (uses `path`).
+- **`type: npm`** / **`type: local`** — non-git source types.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md ARCHITECTURE.md
+git commit -S -s -m "docs: document git source type in CONTRIBUTING and ARCHITECTURE (#74)
+
+Add type: git example to CONTRIBUTING.md and a Source Types reference
+section to ARCHITECTURE.md.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-07-02-git-source-type-design.md
+++ b/docs/superpowers/specs/2026-07-02-git-source-type-design.md
@@ -1,0 +1,168 @@
+# Support non-GitHub source types (e.g. GitLab)
+
+Closes: https://github.com/opendatahub-io/skills-registry/issues/74
+
+## Problem
+
+All git-based source types assume GitHub hosting. URLs like
+`https://github.com/{repo}.git` and `https://raw.githubusercontent.com/...`
+are hardcoded across scripts. Plugins hosted on GitLab or other forges
+cannot be registered.
+
+## Approach
+
+Add a `git` source type with an explicit `url` field. Keep `github` as
+ergonomic sugar where `repo: owner/name` implies the GitHub URL. Introduce
+shared helper functions so every script resolves URLs through one place.
+
+## Schema
+
+The `source` definition uses conditional validation (`if`/`then`) to enforce
+the right fields per type:
+
+- **`type: github`** (existing, backwards-compatible): requires `repo`
+  (owner/slug). `url` is forbidden. Optional: `ref`, `sha`, `path`.
+- **`type: git`** (new): requires `url`. `repo` is forbidden.
+  Optional: `ref`, `sha`, `path`.
+
+Other types (`git-subdir`, `npm`, `local`) are unchanged.
+
+Example `type: git` entry:
+
+```yaml
+source:
+  type: git
+  url: https://gitlab.corp.example.com/team/my-plugin.git
+  ref: main
+```
+
+### Schema changes to `source` definition
+
+Add `url` property:
+
+```json
+"url": {
+  "type": "string",
+  "format": "uri",
+  "description": "Clone URL for git source type"
+}
+```
+
+Add conditional validation:
+
+```json
+"allOf": [
+  {
+    "if": { "properties": { "type": { "const": "github" } }, "required": ["type"] },
+    "then": { "required": ["repo"] }
+  },
+  {
+    "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
+    "then": { "required": ["url"] }
+  }
+]
+```
+
+Change `required` on `source` from `["type", "repo"]` to `["type"]` (since
+`git` type uses `url` instead of `repo`).
+
+## Helper functions
+
+Add to `registry_contracts.py`:
+
+### `source_clone_url(source: dict) -> str`
+
+- `github` -> `https://github.com/{repo}.git`
+- `git` -> `source["url"]`
+- Other types -> raise `ValueError`
+
+### `source_display_name(source: dict) -> str`
+
+For use in catalogs, site pages, and log messages.
+
+- `github` -> `repo` as-is (e.g. `opendatahub-io/rfe-creator`)
+- `git` -> strip scheme and trailing `.git` from `url`
+  (e.g. `https://gitlab.corp.example.com/team/my-plugin.git`
+  -> `gitlab.corp.example.com/team/my-plugin`)
+
+### `source_browse_url(source: dict) -> str`
+
+For constructing clickable links in markdown.
+
+- `github` -> `https://github.com/{repo}`
+- `git` -> `url` stripped of trailing `.git`
+
+## Script changes
+
+### `validate_registry.py`
+
+- `check_sources()`: for `type: git`, use `git ls-remote <url>` instead of
+  `gh api`. Keep `gh api` for `github`.
+- `validate_remote_plugin()`: use `source_clone_url()` instead of hardcoded
+  `https://github.com/{repo}.git`. Accept both `github` and `git` types
+  (currently skips non-github).
+
+### `run_skill_linter.py`
+
+- Rename `_ensure_github_repo` -> `_ensure_repo`.
+- Use `source_clone_url()` for clone URLs.
+- `skill_is_skill_linter_candidate()`: accept `git` type alongside `github`.
+  The gate becomes: source type is `github` or `git`, has a valid clone URL,
+  and has `contract.source_assertions.skill_path`.
+- `_run_one_skill()`: same generalization — remove the `github`-only gate.
+
+### `check_versions.py`
+
+- For `type: github`: keep existing `gh api` path (fast, no clone).
+- For `type: git`: shallow clone to a `tempfile.TemporaryDirectory()`, read
+  `.claude-plugin/plugin.json`, parse version, clean up. This is a weekly
+  job; performance is not critical.
+- Use `source_clone_url()` for the clone URL.
+
+### `generate_catalog.py`
+
+- `render_plugin()`: replace `https://github.com/{repo}` with
+  `source_browse_url()` and `source_display_name()`.
+
+### `generate_site.py`
+
+- `generate_plugin_page()`: replace `https://github.com/{repo}` link with
+  `source_browse_url()` / `source_display_name()`.
+- `generate_llms_full_txt()`: same replacement.
+
+### `sync_marketplace.py`
+
+- `plugin_to_marketplace_entry()`: for `git` type, emit `url` in the
+  marketplace source block instead of `repo`.
+
+## Test changes
+
+- Add unit tests for `source_clone_url`, `source_display_name`,
+  `source_browse_url` in `test_registry_contracts.py`.
+- Add `type: git` fixtures to existing test files where `type: github`
+  fixtures exist.
+- Test schema validation accepts `type: git` with `url`, rejects `type: git`
+  without `url`, rejects `type: github` without `repo`.
+- Test `check_sources` with `git ls-remote` path.
+- Test `check_versions` shallow-clone path.
+- Test `skill_is_skill_linter_candidate` accepts `git` type.
+
+## Documentation changes
+
+- `CONTRIBUTING.md`: add `type: git` example alongside the existing
+  `type: github` example.
+- `ARCHITECTURE.md`: update the Plugin Model section to mention the `git`
+  source type.
+- `CLAUDE.md`: no changes needed (it references source types generically).
+
+## Backwards compatibility
+
+Fully backwards-compatible. All existing `type: github` entries work
+unchanged. The `repo` field keeps its current meaning for `github` sources.
+No migration needed.
+
+## Out of scope
+
+- Adding forge-specific sugar types like `gitlab` (can be added later if
+  there's demand; `type: git` with a URL covers all forges).
+- `discover_skills.py` — one-time script, already run, not part of CI.

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -423,11 +423,11 @@
       "allOf": [
         {
           "if": { "properties": { "type": { "const": "github" } }, "required": ["type"] },
-          "then": { "required": ["repo"] }
+          "then": { "required": ["repo"], "not": { "required": ["url"] } }
         },
         {
           "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
-          "then": { "required": ["url"] }
+          "then": { "required": ["url"], "not": { "required": ["repo"] } }
         }
       ]
     },

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -389,17 +389,22 @@
     },
     "source": {
       "type": "object",
-      "required": ["type", "repo"],
+      "required": ["type"],
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["github", "git-subdir", "npm", "local"],
+          "enum": ["github", "git", "git-subdir", "npm", "local"],
           "description": "Source type"
         },
         "repo": {
           "type": "string",
-          "description": "Repository identifier (e.g., owner/repo)"
+          "description": "Repository identifier (e.g., owner/repo) — required for github type"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Clone URL — required for git type"
         },
         "ref": {
           "type": "string",
@@ -414,7 +419,17 @@
           "type": "string",
           "description": "Subdirectory path (for git-subdir type)"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "github" } }, "required": ["type"] },
+          "then": { "required": ["repo"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
+          "then": { "required": ["url"] }
+        }
+      ]
     },
     "skill": {
       "type": "object",

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -22,7 +22,13 @@ from urllib.parse import quote
 
 import yaml
 
-from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url, normalize_git_ref
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+_REPO_ROOT_STR = str(_REPO_ROOT)
+sys.path[:] = [entry for entry in sys.path if entry != _REPO_ROOT_STR]
+sys.path.insert(0, _REPO_ROOT_STR)
+
+from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url, normalize_git_ref, shallow_clone  # noqa: E402
 
 
 def load_registry(path: str = "registry.yaml") -> dict:
@@ -69,11 +75,10 @@ def fetch_remote_version(repo: str, ref: str = "main") -> str | None:
 def fetch_remote_version_via_clone(clone_url: str, ref: str = "main") -> str | None:
     """Fetch version from remote plugin.json via shallow clone."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
-            capture_output=True, text=True,
-            timeout=120,
-        )
+        try:
+            result = shallow_clone(clone_url, ref, tmpdir)
+        except RuntimeError:
+            return None
         if result.returncode != 0:
             return None
         plugin_json = Path(tmpdir) / ".claude-plugin" / "plugin.json"

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -108,12 +108,12 @@ def main():
             continue
 
         name = plugin.get("name", "<unknown>")
-        repo = source.get("repo")
-        if not repo:
-            print(f"  SKIP: {name} (missing source.repo)")
-            continue
         current = plugin.get("version", "0.0.0")
         if source_type == "github":
+            repo = source.get("repo")
+            if not repo:
+                print(f"  SKIP: {name} (missing source.repo)")
+                continue
             remote = fetch_remote_version(repo, source.get("ref", "main"))
         else:
             try:

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -16,9 +16,13 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 from urllib.parse import quote
 
 import yaml
+
+from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url, normalize_git_ref
 
 
 def load_registry(path: str = "registry.yaml") -> dict:
@@ -62,6 +66,26 @@ def fetch_remote_version(repo: str, ref: str = "main") -> str | None:
         return None
 
 
+def fetch_remote_version_via_clone(clone_url: str, ref: str = "main") -> str | None:
+    """Fetch version from remote plugin.json via shallow clone."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
+            capture_output=True, text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            return None
+        plugin_json = Path(tmpdir) / ".claude-plugin" / "plugin.json"
+        if not plugin_json.exists():
+            return None
+        try:
+            data = json.loads(plugin_json.read_text())
+            return data.get("version")
+        except (json.JSONDecodeError, OSError):
+            return None
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -75,21 +99,30 @@ def main():
 
     for plugin in registry.get("plugins", []):
         source = plugin.get("source") or {}
-        if source.get("type") != "github":
+        source_type = source.get("type")
+        if source_type not in GIT_CLONE_TYPES:
             continue
 
         # Only check strict-mode plugins (they have their own plugin.json)
         if plugin.get("strict", True) is False:
             continue
 
+        name = plugin.get("name", "<unknown>")
         repo = source.get("repo")
         if not repo:
-            print(f"  SKIP: {plugin.get('name', '<unknown>')} (missing source.repo)")
+            print(f"  SKIP: {name} (missing source.repo)")
             continue
         current = plugin.get("version", "0.0.0")
-        remote = fetch_remote_version(repo, source.get("ref", "main"))
-
-        name = plugin.get("name", "<unknown>")
+        if source_type == "github":
+            remote = fetch_remote_version(repo, source.get("ref", "main"))
+        else:
+            try:
+                clone_url = source_clone_url(source)
+                ref = normalize_git_ref(source.get("ref", "main"))
+            except (ValueError, KeyError):
+                print(f"  SKIP: {name} (invalid source configuration)")
+                continue
+            remote = fetch_remote_version_via_clone(clone_url, ref)
         if remote is None:
             print(f"  SKIP: {name} (could not fetch remote version)")
             continue

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -26,6 +26,8 @@ from scripts.registry_contracts import (  # noqa: E402
     MEASURE_DOCS,
     contract_metrics_as_dicts,
     skill_contract_mapping,
+    source_browse_url,
+    source_display_name,
 )
 
 
@@ -186,7 +188,8 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
     name = plugin["name"]
     desc = plugin["description"].strip()
     version = plugin.get("version", "")
-    repo = plugin["source"].get("repo", "")
+    source = plugin["source"]
+    source_type = source.get("type", "")
     license_str = plugin.get("license", "")
     tags = plugin.get("tags", [])
     scope = plugin.get("scope", "sdlc")
@@ -212,8 +215,10 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
         meta_parts.append("Team-Specific")
     if license_str:
         meta_parts.append(license_str)
-    if repo:
-        meta_parts.append(f"[{repo}](https://github.com/{repo})")
+    if source_type in ("github", "git"):
+        display = source_display_name(source)
+        browse = source_browse_url(source)
+        meta_parts.append(f"[{display}]({browse})")
     if meta_parts:
         lines.append(" | ".join(meta_parts))
         lines.append("")

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -30,6 +30,8 @@ from scripts.registry_contracts import (  # noqa: E402
     mapping_if_dict,
     sequence_as_list,
     skill_contract_mapping,
+    source_browse_url,
+    source_display_name,
 )
 
 
@@ -361,7 +363,8 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     license_str = plugin.get("license", "")
     category = plugin.get("category", "")
     tags = plugin.get("tags", [])
-    repo = plugin.get("source", {}).get("repo", "")
+    source = plugin.get("source", {})
+    source_type = source.get("type", "")
     deps = plugin.get("depends_on", [])
     skills = plugin.get("skills", [])
     agents = plugin.get("agents", [])
@@ -394,8 +397,10 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
         meta.append(f"    - **Scope**: {SCOPE_BADGE[scope]}")
     if category:
         meta.append(f"    - **Category**: [{cat_name}](../../categories/{category}.md)")
-    if repo:
-        meta.append(f"    - **Repository**: [{repo}](https://github.com/{repo})")
+    if source_type in ("github", "git"):
+        display = source_display_name(source)
+        browse = source_browse_url(source)
+        meta.append(f"    - **Repository**: [{display}]({browse})")
     if tags:
         pills = " ".join(f'<span class="tag-pill">{t}</span>' for t in tags)
         meta.append(f"    - **Tags**: {pills}")
@@ -856,7 +861,8 @@ def generate_llms_full_txt(registry: dict, docs_dir: Path) -> str:
     for p in plugins:
         name = p["name"]
         desc = p["description"].strip()
-        repo = p.get("source", {}).get("repo", "")
+        source = p.get("source", {})
+        source_type = source.get("type", "")
         enrichment = load_enrichment(docs_dir / "plugins" / name)
         edesc = enrichment.get("description", desc).strip() if enrichment else desc
         arch = (enrichment.get("architecture_notes", "").strip()
@@ -865,8 +871,8 @@ def generate_llms_full_txt(registry: dict, docs_dir: Path) -> str:
         lines.append("")
         lines.append(edesc)
         lines.append("")
-        if repo:
-            lines.append(f"**Repository**: https://github.com/{repo}")
+        if source_type in ("github", "git"):
+            lines.append(f"**Repository**: {source_browse_url(source)}")
             lines.append("")
         if arch:
             lines.append("### Architecture")

--- a/scripts/registry_contracts.py
+++ b/scripts/registry_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re as _re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,6 +67,46 @@ MEASURE_DOCS = {
 CANONICAL_FUNCTIONS = frozenset(CANONICAL_FUNCTION_DOCS)
 CANONICAL_METRICS = frozenset(CANONICAL_METRIC_DOCS)
 PLUGIN_FIELDS_THAT_TOUCH_ALL_SKILLS = {"source", "strict", "skills_dir"}
+
+_SCHEME_RE = _re.compile(r"^https?://")
+GIT_CLONE_TYPES = frozenset({"github", "git"})
+
+
+def source_clone_url(source: dict) -> str:
+    """Return the git clone URL for a plugin source entry."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return f"https://github.com/{source['repo']}.git"
+    if source_type == "git":
+        return source["url"]
+    raise ValueError(f"unsupported source type for cloning: {source_type!r}")
+
+
+def source_display_name(source: dict) -> str:
+    """Return a human-readable display name (scheme-stripped, no trailing .git)."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return source["repo"]
+    if source_type == "git":
+        url = source["url"]
+        name = _SCHEME_RE.sub("", url)
+        if name.endswith(".git"):
+            name = name[:-4]
+        return name
+    return source.get("repo") or source.get("url") or "<unknown>"
+
+
+def source_browse_url(source: dict) -> str:
+    """Return a browsable URL for linking in markdown."""
+    source_type = source.get("type")
+    if source_type == "github":
+        return f"https://github.com/{source['repo']}"
+    if source_type == "git":
+        url = source["url"]
+        if url.endswith(".git"):
+            return url[:-4]
+        return url
+    return source.get("url") or f"https://github.com/{source.get('repo', '')}"
 
 
 def mapping_if_dict(value) -> dict | None:

--- a/scripts/registry_contracts.py
+++ b/scripts/registry_contracts.py
@@ -130,10 +130,14 @@ def shallow_clone(clone_url: str, ref: str, dest: str, *,
     if result.returncode == 0:
         return result
 
-    # --branch fails for SHA refs; fall back to full clone + checkout --detach
+    # --branch fails for SHA refs; fall back to a full clone + checkout --detach.
+    # The fallback must NOT be shallow: a --depth 1 clone only contains the
+    # default-branch tip, so `git checkout --detach <sha>` fails for any commit
+    # that isn't the tip (fatal: unable to read tree). A full clone contains
+    # every reachable commit, so an arbitrary historical SHA can be checked out.
     try:
         result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--", clone_url, dest],
+            ["git", "clone", "--", clone_url, dest],
             capture_output=True, text=True,
             timeout=timeout,
         )

--- a/scripts/registry_contracts.py
+++ b/scripts/registry_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re as _re
+import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -107,6 +108,56 @@ def source_browse_url(source: dict) -> str:
             return url[:-4]
         return url
     return source.get("url") or f"https://github.com/{source.get('repo', '')}"
+
+
+def shallow_clone(clone_url: str, ref: str, dest: str, *,
+                   timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    """Shallow-clone a repo, falling back to full clone + detached checkout for SHA refs.
+
+    Returns the CompletedProcess of the successful clone (returncode == 0) or the
+    last failed attempt.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, dest],
+            capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"git clone timed out after {timeout}s: {shlex.join(['git', 'clone', '--', clone_url])}"
+        ) from exc
+    if result.returncode == 0:
+        return result
+
+    # --branch fails for SHA refs; fall back to full clone + checkout --detach
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--", clone_url, dest],
+            capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"git clone timed out after {timeout}s: {shlex.join(['git', 'clone', '--', clone_url])}"
+        ) from exc
+    if result.returncode != 0:
+        return result
+
+    try:
+        checkout = subprocess.run(
+            ["git", "-C", dest, "checkout", "--detach", ref],
+            capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"git checkout timed out after {timeout}s for ref {ref}"
+        ) from exc
+    if checkout.returncode != 0:
+        # Return a failed result so the caller sees the error
+        return checkout
+    return result
 
 
 def mapping_if_dict(value) -> dict | None:

--- a/scripts/run_skill_linter.py
+++ b/scripts/run_skill_linter.py
@@ -30,6 +30,7 @@ from scripts.registry_contracts import (  # noqa: E402
     load_registry_from_ref,
     load_staged_registry,
     normalize_git_ref,
+    shallow_clone,
     source_clone_url,
     source_display_name,
 )
@@ -230,24 +231,10 @@ def _ensure_repo(source: dict) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     if not (destination / ".git").exists():
-        shallow = run_captured_command(
-            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, str(destination)],
-            timeout_seconds=GIT_COMMAND_TIMEOUT_SECONDS,
-        )
-        if shallow.returncode != 0:
-            full = run_captured_command(
-                ["git", "clone", "--depth", "1", "--", clone_url, str(destination)],
-                timeout_seconds=GIT_COMMAND_TIMEOUT_SECONDS,
-            )
-            if full.returncode != 0:
-                raise RuntimeError(f"clone failed for {clone_url}: {full.stderr}".strip())
-
-            chk = run_captured_command(
-                ["git", "-C", str(destination), "checkout", "--detach", ref],
-                timeout_seconds=GIT_COMMAND_TIMEOUT_SECONDS,
-            )
-            if chk.returncode != 0:
-                raise RuntimeError(f"checkout {ref} failed for {clone_url}: {chk.stderr}".strip())
+        result = shallow_clone(clone_url, ref, str(destination),
+                               timeout=GIT_COMMAND_TIMEOUT_SECONDS)
+        if result.returncode != 0:
+            raise RuntimeError(f"clone failed for {clone_url}: {result.stderr}".strip())
     else:
         fetch = run_captured_command(
             ["git", "-C", str(destination), "fetch", "--depth", "1", "origin", ref],
@@ -315,7 +302,7 @@ def _run_one_skill(plugin: dict, skill: dict, config_abs: Path) -> int:
         return 1
 
     try:
-        _ = source_clone_url(source)
+        source_clone_url(source)
     except (ValueError, KeyError):
         print(
             f"ERROR: Plugin '{plug_name}' has invalid source configuration.",
@@ -324,7 +311,7 @@ def _run_one_skill(plugin: dict, skill: dict, config_abs: Path) -> int:
         return 1
 
     try:
-        plugin_ref = normalize_git_ref(source.get("ref", "main"))
+        normalize_git_ref(source.get("ref", "main"))
     except ValueError:
         print(
             f"ERROR: Plugin '{plug_name}' has invalid source.ref.",

--- a/scripts/run_skill_linter.py
+++ b/scripts/run_skill_linter.py
@@ -20,6 +20,7 @@ sys.path[:] = [entry for entry in sys.path if entry != _REPO_ROOT_STR]
 sys.path.insert(0, _REPO_ROOT_STR)
 
 from scripts.registry_contracts import (  # noqa: E402
+    GIT_CLONE_TYPES,
     SKILL_LINTER_VERSION,
     SkillKey,
     detect_touched_skills,
@@ -29,6 +30,8 @@ from scripts.registry_contracts import (  # noqa: E402
     load_registry_from_ref,
     load_staged_registry,
     normalize_git_ref,
+    source_clone_url,
+    source_display_name,
 )
 
 CACHE_ROOT = Path(".cache/skills-registry/repos")
@@ -192,11 +195,19 @@ def skill_is_skill_linter_candidate(plugin: dict, skill: dict) -> bool:
         return False
 
     source = plugin.get("source") or {}
-    if not isinstance(source, dict) or source.get("type") != "github":
+    if not isinstance(source, dict):
         return False
-    repo = source.get("repo")
-    if not isinstance(repo, str) or not repo.strip():
+    source_type = source.get("type")
+    if source_type not in GIT_CLONE_TYPES:
         return False
+    if source_type == "github":
+        repo = source.get("repo")
+        if not isinstance(repo, str) or not repo.strip():
+            return False
+    elif source_type == "git":
+        url = source.get("url")
+        if not isinstance(url, str) or not url.strip():
+            return False
 
     try:
         normalize_git_ref(source.get("ref", "main"))
@@ -211,10 +222,12 @@ def _cache_destination(repo: str, ref: str) -> Path:
     return CACHE_ROOT.resolve() / f"{safe_repo}__{safe_ref}"
 
 
-def _ensure_github_repo(repo: str, ref: str) -> Path:
-    destination = _cache_destination(repo, ref)
+def _ensure_repo(source: dict) -> Path:
+    clone_url = source_clone_url(source)
+    display = source_display_name(source)
+    ref = normalize_git_ref(source.get("ref", "main"))
+    destination = _cache_destination(display, ref)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    clone_url = f"https://github.com/{repo}.git"
 
     if not (destination / ".git").exists():
         shallow = run_captured_command(
@@ -293,18 +306,19 @@ def _run_one_skill(plugin: dict, skill: dict, config_abs: Path) -> int:
         return 0
 
     source = plugin.get("source") or {}
-    if not isinstance(source, dict) or source.get("type") != "github":
+    if not isinstance(source, dict) or source.get("type") not in GIT_CLONE_TYPES:
         print(
             f"ERROR: Plugin '{plug_name}' skill '{ski_name}' "
-            "has contract source_assertions but source is not type 'github'",
+            "has contract source_assertions but source type is not cloneable",
             file=sys.stderr,
         )
         return 1
 
-    repo = source.get("repo")
-    if not isinstance(repo, str) or not repo.strip():
+    try:
+        _ = source_clone_url(source)
+    except (ValueError, KeyError):
         print(
-            f"ERROR: Plugin '{plug_name}' is missing source.repo.",
+            f"ERROR: Plugin '{plug_name}' has invalid source configuration.",
             file=sys.stderr,
         )
         return 1
@@ -320,7 +334,7 @@ def _run_one_skill(plugin: dict, skill: dict, config_abs: Path) -> int:
 
     supporting = _normalize_supporting_paths(source_assertions)
 
-    repo_root = _ensure_github_repo(repo, plugin_ref)
+    repo_root = _ensure_repo(source)
     try:
         resolved_skill_dir = skill_linter_dir_from_contract_skill_path(repo_root, skill_path_raw)
     except (ValueError, FileNotFoundError) as exc:
@@ -337,7 +351,7 @@ def _run_one_skill(plugin: dict, skill: dict, config_abs: Path) -> int:
     )
 
     command = build_skill_linter_command(resolved_skill_dir, config_abs)
-    print(f"Running skill-linter for {plug_name}/{ski_name} (repo={repo} ref={plugin_ref})...")
+    print(f"Running skill-linter for {plug_name}/{ski_name} (source={source_display_name(source)})...")
 
     proc = run_captured_command(
         command,

--- a/scripts/sync_marketplace.py
+++ b/scripts/sync_marketplace.py
@@ -16,6 +16,10 @@ from pathlib import Path
 import yaml
 
 
+# Map registry source types to marketplace source types.
+# Claude Code's marketplace format uses "url" (not "git") for arbitrary clone URLs.
+_SOURCE_TYPE_MAP = {"git": "url"}
+
 # Fields from registry.yaml plugin entries that map directly to marketplace.json
 DIRECT_FIELDS = {
     "name", "description", "version", "author", "homepage",
@@ -43,7 +47,7 @@ def plugin_to_marketplace_entry(plugin: dict) -> dict:
 
     # Map source
     source = plugin["source"]
-    mapped = {"source": source["type"]}
+    mapped = {"source": _SOURCE_TYPE_MAP.get(source["type"], source["type"])}
     if "repo" in source:
         mapped["repo"] = source["repo"]
     if "url" in source:

--- a/scripts/sync_marketplace.py
+++ b/scripts/sync_marketplace.py
@@ -43,16 +43,18 @@ def plugin_to_marketplace_entry(plugin: dict) -> dict:
 
     # Map source
     source = plugin["source"]
-    entry["source"] = {
-        "source": source["type"],
-        "repo": source["repo"],
-    }
+    mapped = {"source": source["type"]}
+    if "repo" in source:
+        mapped["repo"] = source["repo"]
+    if "url" in source:
+        mapped["url"] = source["url"]
     if "ref" in source:
-        entry["source"]["ref"] = source["ref"]
+        mapped["ref"] = source["ref"]
     if "sha" in source:
-        entry["source"]["sha"] = source["sha"]
+        mapped["sha"] = source["sha"]
     if "path" in source:
-        entry["source"]["path"] = source["path"]
+        mapped["path"] = source["path"]
+    entry["source"] = mapped
 
     # Handle strict: false plugins
     if plugin.get("strict") is False:

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -251,23 +251,40 @@ def check_skill_contracts(registry: dict, required_skills: set[SkillKey]) -> lis
 
 
 def check_sources(registry: dict) -> list[str]:
-    """Check that GitHub repos are accessible via the GitHub API."""
+    """Check that source repos are accessible."""
+    from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url
+
     errors = []
     for plugin in registry.get("plugins", []):
         source = plugin.get("source")
-        if not source or source.get("type") != "github":
+        if not source:
             continue
-        repo = source.get("repo")
-        if not repo:
+        source_type = source.get("type")
+        if source_type not in GIT_CLONE_TYPES:
             continue
-        result = subprocess.run(
-            ["gh", "api", f"repos/{repo}", "--silent"],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            errors.append(f"  Plugin '{plugin['name']}': repo '{repo}' not accessible")
+        name = plugin.get("name", "<unknown>")
+        if source_type == "github":
+            repo = source.get("repo")
+            if not repo:
+                continue
+            result = subprocess.run(
+                ["gh", "api", f"repos/{repo}", "--silent"],
+                capture_output=True, text=True,
+            )
         else:
-            print(f"  OK: {repo}")
+            try:
+                clone_url = source_clone_url(source)
+            except (ValueError, KeyError):
+                errors.append(f"  Plugin '{name}': invalid source configuration")
+                continue
+            result = subprocess.run(
+                ["git", "ls-remote", "--exit-code", "--quiet", clone_url],
+                capture_output=True, text=True,
+            )
+        if result.returncode != 0:
+            errors.append(f"  Plugin '{name}': source not accessible")
+        else:
+            print(f"  OK: {name}")
     return errors
 
 
@@ -287,12 +304,13 @@ def diff_plugins(registry: dict, base_ref: str) -> list[str]:
 
 def validate_remote_plugin(plugin: dict) -> list[str]:
     """Clone a plugin repo and validate its structure."""
+    from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url
+
     errors = []
     source = plugin.get("source")
-    if not source or source.get("type") != "github":
+    if not source or source.get("type") not in GIT_CLONE_TYPES:
         return errors
 
-    repo = source["repo"]
     try:
         ref = normalize_git_ref(source.get("ref", "main"))
     except ValueError:
@@ -301,7 +319,11 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
     strict = plugin.get("strict", True)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        clone_url = f"https://github.com/{repo}.git"
+        try:
+            clone_url = source_clone_url(source)
+        except (ValueError, KeyError):
+            errors.append(f"  Plugin '{plugin['name']}': invalid source configuration")
+            return errors
         result = subprocess.run(
             ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
             capture_output=True, text=True,

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -37,6 +37,7 @@ from scripts.registry_contracts import (  # noqa: E402
     load_registry_from_ref,
     load_staged_registry,
     normalize_git_ref,
+    shallow_clone,
 )
 
 try:
@@ -104,6 +105,23 @@ def check_strict_consistency(registry: dict) -> list[str]:
             errors.append(
                 f"  Plugin '{name}': skills_dir requires strict: false. "
                 "Remove skills_dir or set strict: false"
+            )
+    return errors
+
+
+def check_source_urls(registry: dict) -> list[str]:
+    """Check that git-type source URLs use https:// (not SSH or other schemes)."""
+    errors = []
+    for plugin in registry.get("plugins", []):
+        source = plugin.get("source")
+        if not source or source.get("type") != "git":
+            continue
+        name = plugin.get("name", "<unknown>")
+        url = source.get("url", "")
+        if not url.startswith("https://"):
+            errors.append(
+                f"  Plugin '{name}': git source url must use https:// "
+                f"(got {url!r})"
             )
     return errors
 
@@ -278,8 +296,9 @@ def check_sources(registry: dict) -> list[str]:
                 errors.append(f"  Plugin '{name}': invalid source configuration")
                 continue
             result = subprocess.run(
-                ["git", "ls-remote", "--exit-code", "--quiet", clone_url],
+                ["git", "ls-remote", "--exit-code", "--quiet", "--", clone_url],
                 capture_output=True, text=True,
+                timeout=30,
             )
         if result.returncode != 0:
             errors.append(f"  Plugin '{name}': source not accessible")
@@ -324,10 +343,11 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
         except (ValueError, KeyError):
             errors.append(f"  Plugin '{plugin['name']}': invalid source configuration")
             return errors
-        result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, tmpdir],
-            capture_output=True, text=True,
-        )
+        try:
+            result = shallow_clone(clone_url, ref, tmpdir)
+        except RuntimeError as exc:
+            errors.append(f"  Plugin '{plugin['name']}': {exc}")
+            return errors
         if result.returncode != 0:
             errors.append(f"  Plugin '{plugin['name']}': failed to clone {clone_url} (ref={ref})")
             return errors
@@ -431,6 +451,17 @@ def main() -> None:
     all_errors.extend(errors)
     if errors:
         print(f"  FAIL: {len(errors)} consistency error(s)")
+        for e in errors:
+            print(e)
+    else:
+        print("  OK")
+
+    # Source URL validation
+    print("Checking source URLs...")
+    errors = check_source_urls(registry)
+    all_errors.extend(errors)
+    if errors:
+        print(f"  FAIL: {len(errors)} source URL error(s)")
         for e in errors:
             print(e)
     else:

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest import mock
+
+from scripts.check_versions import fetch_remote_version_via_clone
+
+
+class FetchRemoteVersionViaCloneTests(unittest.TestCase):
+    @mock.patch("scripts.check_versions.subprocess.run")
+    def test_returns_none_on_clone_failure(self, run_mock):
+        run_mock.return_value = mock.Mock(returncode=1)
+
+        result = fetch_remote_version_via_clone("https://example.com/repo.git", "main")
+
+        self.assertIsNone(result)
+
+    @mock.patch("scripts.check_versions.subprocess.run")
+    def test_returns_version_from_cloned_plugin_json(self, run_mock):
+        import json
+        import tempfile
+        from pathlib import Path
+
+        # Create a real temp dir with plugin.json so the function can read it
+        real_tmpdir = tempfile.mkdtemp()
+        plugin_dir = Path(real_tmpdir) / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "2.0.0"}))
+
+        # Make subprocess.run succeed, and patch tempfile to return our dir
+        run_mock.return_value = mock.Mock(returncode=0)
+
+        with mock.patch("scripts.check_versions.tempfile.TemporaryDirectory") as td_mock:
+            td_mock.return_value.__enter__ = mock.Mock(return_value=real_tmpdir)
+            td_mock.return_value.__exit__ = mock.Mock(return_value=False)
+
+            result = fetch_remote_version_via_clone("https://example.com/repo.git", "main")
+
+        self.assertEqual("2.0.0", result)
+
+        # Clean up
+        import shutil
+        shutil.rmtree(real_tmpdir, ignore_errors=True)
+
+
+class CheckVersionsMainLoopTests(unittest.TestCase):
+    """Test that the main loop dispatches correctly for git vs github types."""
+
+    @mock.patch("scripts.check_versions.fetch_remote_version_via_clone")
+    @mock.patch("scripts.check_versions.load_registry")
+    def test_git_type_calls_clone_based_version_check(self, load_mock, clone_mock):
+        load_mock.return_value = {
+            "plugins": [{
+                "name": "git-plugin",
+                "version": "1.0.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://gitlab.example.com/team/plugin.git",
+                    "ref": "main",
+                },
+            }],
+        }
+        clone_mock.return_value = "1.0.0"
+
+        from scripts.check_versions import main
+        with mock.patch("sys.argv", ["check_versions.py", "--dry-run"]):
+            main()
+
+        clone_mock.assert_called_once_with(
+            "https://gitlab.example.com/team/plugin.git", "main"
+        )
+
+    @mock.patch("scripts.check_versions.fetch_remote_version")
+    @mock.patch("scripts.check_versions.load_registry")
+    def test_github_type_calls_api_based_version_check(self, load_mock, api_mock):
+        load_mock.return_value = {
+            "plugins": [{
+                "name": "gh-plugin",
+                "version": "1.0.0",
+                "source": {
+                    "type": "github",
+                    "repo": "org/repo",
+                    "ref": "main",
+                },
+            }],
+        }
+        api_mock.return_value = "1.0.0"
+
+        from scripts.check_versions import main
+        with mock.patch("sys.argv", ["check_versions.py", "--dry-run"]):
+            main()
+
+        api_mock.assert_called_once_with("org/repo", "main")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_catalog.py
+++ b/tests/test_generate_catalog.py
@@ -31,6 +31,20 @@ class CatalogContractRenderingTests(unittest.TestCase):
         self.assertNotIn("| Skill | Description | Functions | Metrics |", content)
 
 
+class CatalogGitSourceTests(unittest.TestCase):
+    def test_catalog_renders_git_source_browse_link(self):
+        registry = build_registry_with_contract()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        content = generate_catalog.generate_catalog(registry)
+
+        self.assertIn("[gitlab.example.com/team/plugin](https://gitlab.example.com/team/plugin)", content)
+        self.assertNotIn("github.com", content.split("Quick Start")[1])
+
+
 class CatalogMalformedContractRenderingTests(unittest.TestCase):
     def test_catalog_skips_non_dict_contract_for_columns(self):
         registry = build_registry_with_contract()

--- a/tests/test_generate_site.py
+++ b/tests/test_generate_site.py
@@ -123,6 +123,20 @@ class SiteContractRenderingTests(unittest.TestCase):
             ],
         )
 
+    def test_plugin_page_renders_git_source_link(self):
+        registry = build_registry_with_contract()
+        plugin = registry["plugins"][0]
+        plugin["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        page = generate_site.generate_plugin_page(plugin, registry, enrichment=None, plugin_dir=None)
+
+        self.assertIn("gitlab.example.com/team/plugin", page)
+        self.assertIn("https://gitlab.example.com/team/plugin", page)
+        self.assertNotIn("https://github.com/", page)
+
     def test_append_code_block_uses_longer_fence_when_needed(self):
         lines = []
 

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -170,7 +170,7 @@ class ShallowCloneTests(unittest.TestCase):
 
     @mock.patch("scripts.registry_contracts.subprocess.run")
     def test_shallow_clone_falls_back_for_sha(self, run_mock):
-        sha = "abc123" * 7 + "ab"  # 40 hex chars
+        sha = "a" * 40
         branch_fail = subprocess.CompletedProcess(["git", "clone"], 128, stdout="", stderr="")
         clone_ok = subprocess.CompletedProcess(["git", "clone"], 0, stdout="", stderr="")
         checkout_ok = subprocess.CompletedProcess(["git", "checkout"], 0, stdout="", stderr="")

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -7,6 +7,9 @@ from scripts.registry_contracts import (
     detect_touched_skills,
     load_registry_from_ref,
     load_staged_registry,
+    source_browse_url,
+    source_clone_url,
+    source_display_name,
 )
 
 
@@ -109,6 +112,44 @@ class RegistryGitReadTests(unittest.TestCase):
         load_registry_from_ref("HEAD")
         _, kwargs = run_mock.call_args
         self.assertEqual(kwargs["timeout"], 30)
+
+
+class SourceHelperTests(unittest.TestCase):
+    def test_source_clone_url_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("https://github.com/opendatahub-io/rfe-creator.git", source_clone_url(source))
+
+    def test_source_clone_url_git(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin.git", source_clone_url(source))
+
+    def test_source_clone_url_unsupported_type_raises(self):
+        with self.assertRaises(ValueError):
+            source_clone_url({"type": "npm", "repo": "foo"})
+
+    def test_source_display_name_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("opendatahub-io/rfe-creator", source_display_name(source))
+
+    def test_source_display_name_git_strips_scheme_and_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("gitlab.corp.example.com/team/my-plugin", source_display_name(source))
+
+    def test_source_display_name_git_no_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
+        self.assertEqual("gitlab.corp.example.com/team/my-plugin", source_display_name(source))
+
+    def test_source_browse_url_github(self):
+        source = {"type": "github", "repo": "opendatahub-io/rfe-creator"}
+        self.assertEqual("https://github.com/opendatahub-io/rfe-creator", source_browse_url(source))
+
+    def test_source_browse_url_git_strips_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin.git"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
+
+    def test_source_browse_url_git_no_dotgit(self):
+        source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
+        self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
 
 
 if __name__ == "__main__":

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -7,6 +7,7 @@ from scripts.registry_contracts import (
     detect_touched_skills,
     load_registry_from_ref,
     load_staged_registry,
+    shallow_clone,
     source_browse_url,
     source_clone_url,
     source_display_name,
@@ -150,6 +151,55 @@ class SourceHelperTests(unittest.TestCase):
     def test_source_browse_url_git_no_dotgit(self):
         source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
         self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
+
+
+class ShallowCloneTests(unittest.TestCase):
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_succeeds_with_branch(self, run_mock):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ["git", "clone"], 0, stdout="", stderr=""
+        )
+
+        result = shallow_clone("https://example.com/repo.git", "main", "/tmp/dest")
+
+        self.assertEqual(0, result.returncode)
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args[0][0]
+        self.assertIn("--branch", cmd)
+        self.assertIn("main", cmd)
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_falls_back_for_sha(self, run_mock):
+        sha = "abc123" * 7 + "ab"  # 40 hex chars
+        branch_fail = subprocess.CompletedProcess(["git", "clone"], 128, stdout="", stderr="")
+        clone_ok = subprocess.CompletedProcess(["git", "clone"], 0, stdout="", stderr="")
+        checkout_ok = subprocess.CompletedProcess(["git", "checkout"], 0, stdout="", stderr="")
+        run_mock.side_effect = [branch_fail, clone_ok, checkout_ok]
+
+        result = shallow_clone("https://example.com/repo.git", sha, "/tmp/dest")
+
+        self.assertEqual(0, result.returncode)
+        self.assertEqual(3, run_mock.call_count)
+        # Third call should be checkout --detach <sha>
+        checkout_cmd = run_mock.call_args_list[2][0][0]
+        self.assertIn("--detach", checkout_cmd)
+        self.assertIn(sha, checkout_cmd)
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_returns_failure_when_both_fail(self, run_mock):
+        fail = subprocess.CompletedProcess(["git"], 128, stdout="", stderr="fatal")
+        run_mock.return_value = fail
+
+        result = shallow_clone("https://example.com/repo.git", "main", "/tmp/dest")
+
+        self.assertNotEqual(0, result.returncode)
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_raises_on_timeout(self, run_mock):
+        run_mock.side_effect = subprocess.TimeoutExpired(["git"], 120)
+
+        with self.assertRaises(RuntimeError):
+            shallow_clone("https://example.com/repo.git", "main", "/tmp/dest")
 
 
 if __name__ == "__main__":

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -1,4 +1,7 @@
+import os
+import shutil
 import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
@@ -180,6 +183,10 @@ class ShallowCloneTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode)
         self.assertEqual(3, run_mock.call_count)
+        # Second call is the fallback clone: it MUST be a full (non-shallow) clone,
+        # otherwise a historical SHA cannot be checked out (see the integration test).
+        fallback_cmd = run_mock.call_args_list[1][0][0]
+        self.assertNotIn("--depth", fallback_cmd)
         # Third call should be checkout --detach <sha>
         checkout_cmd = run_mock.call_args_list[2][0][0]
         self.assertIn("--detach", checkout_cmd)
@@ -200,6 +207,61 @@ class ShallowCloneTests(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             shallow_clone("https://example.com/repo.git", "main", "/tmp/dest")
+
+
+@unittest.skipUnless(shutil.which("git"), "git is required for integration tests")
+class ShallowCloneIntegrationTests(unittest.TestCase):
+    """End-to-end against a real local repo (no mocks) — exercises the SHA fallback."""
+
+    _GIT_ENV = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True, env=self._GIT_ENV
+        )
+
+    def _make_repo(self, path: str) -> str:
+        """Create a repo with three commits; return the SHA of the first (historical) one."""
+        os.makedirs(path)
+        self._git("init", "-q", path)
+        shas = []
+        for msg in ("c1", "c2", "c3"):
+            self._git("-C", path, "commit", "-q", "--allow-empty", "-m", msg)
+            shas.append(self._git("-C", path, "rev-parse", "HEAD").stdout.strip())
+        return shas[0]  # historical commit, NOT the default-branch tip
+
+    def test_checks_out_historical_sha(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            historical = self._make_repo(src)
+            dest = os.path.join(tmp, "dest")
+            # Use file:// so git honors --depth. A bare local-path clone silently
+            # ignores --depth (full clone), which would mask a shallow regression.
+            url = f"file://{src}"
+
+            result = shallow_clone(url, historical, dest)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            head = subprocess.run(
+                ["git", "-C", dest, "rev-parse", "HEAD"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+            self.assertEqual(historical, head)
+
+    def test_checks_out_branch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            self._make_repo(src)
+            branch = self._git("-C", src, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+            dest = os.path.join(tmp, "dest")
+
+            result = shallow_clone(f"file://{src}", branch, dest)
+
+            self.assertEqual(0, result.returncode, result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_run_skill_linter.py
+++ b/tests/test_run_skill_linter.py
@@ -218,6 +218,25 @@ class SkillLinterWrapperTests(unittest.TestCase):
         self.assertTrue(any("git ref" in error.lower() or "could not load" in error.lower()
                             for error in errors))
 
+    def test_skill_is_skill_linter_candidate_accepts_git_type(self):
+        plugin_git = {
+            "name": "p",
+            "source": {"type": "git", "url": "https://gitlab.example.com/t/p.git"},
+        }
+        skill_ok = {
+            "name": "t",
+            "contract": {"source_assertions": {"skill_path": ".claude/skills/t/SKILL.md"}},
+        }
+        self.assertTrue(skill_is_skill_linter_candidate(plugin_git, skill_ok))
+
+    def test_skill_is_skill_linter_candidate_rejects_git_without_url(self):
+        plugin_git = {"name": "p", "source": {"type": "git"}}
+        skill_ok = {
+            "name": "t",
+            "contract": {"source_assertions": {"skill_path": ".claude/skills/t/SKILL.md"}},
+        }
+        self.assertFalse(skill_is_skill_linter_candidate(plugin_git, skill_ok))
+
     @mock.patch("scripts.run_skill_linter.subprocess.run")
     def test_run_captured_command_passes_timeout(self, run_mock):
         run_captured_command(["git", "status"], timeout_seconds=123)

--- a/tests/test_script_bootstrap.py
+++ b/tests/test_script_bootstrap.py
@@ -12,6 +12,7 @@ SCRIPT_PATHS = [
     "scripts/validate_registry.py",
     "scripts/run_skill_linter.py",
     "scripts/generate_catalog.py",
+    "scripts/check_versions.py",
 ]
 POISON_SENTINEL = "poisoned registry_contracts import"
 

--- a/tests/test_sync_marketplace.py
+++ b/tests/test_sync_marketplace.py
@@ -1,0 +1,43 @@
+import unittest
+
+import scripts.sync_marketplace as sync_marketplace
+
+
+class SourceTypeMappingTests(unittest.TestCase):
+    """Verify that registry source types map to correct marketplace source types."""
+
+    def _make_plugin(self, source):
+        return {
+            "name": "test-plugin",
+            "description": "A test plugin",
+            "version": "1.0.0",
+            "source": source,
+        }
+
+    def test_github_source_maps_to_github(self):
+        plugin = self._make_plugin({
+            "type": "github",
+            "repo": "opendatahub-io/test-repo",
+            "ref": "main",
+        })
+        entry = sync_marketplace.plugin_to_marketplace_entry(plugin)
+        self.assertEqual(entry["source"]["source"], "github")
+
+    def test_git_source_maps_to_url(self):
+        plugin = self._make_plugin({
+            "type": "git",
+            "url": "https://gitlab.example.com/team/repo.git",
+            "ref": "main",
+        })
+        entry = sync_marketplace.plugin_to_marketplace_entry(plugin)
+        self.assertEqual(entry["source"]["source"], "url")
+
+    def test_git_source_preserves_url_field(self):
+        clone_url = "https://gitlab.example.com/team/repo.git"
+        plugin = self._make_plugin({
+            "type": "git",
+            "url": clone_url,
+            "ref": "main",
+        })
+        entry = sync_marketplace.plugin_to_marketplace_entry(plugin)
+        self.assertEqual(entry["source"]["url"], clone_url)

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -282,7 +282,7 @@ class SchemaTests(unittest.TestCase):
 
         errors = self.validate_registry.validate_schema(registry, self.schema)
 
-        self.assertNotEqual([], errors)
+        self.assertTrue(any("repo" in error for error in errors), errors)
 
     def test_schema_rejects_github_source_with_url(self):
         registry = build_registry()
@@ -295,7 +295,7 @@ class SchemaTests(unittest.TestCase):
 
         errors = self.validate_registry.validate_schema(registry, self.schema)
 
-        self.assertNotEqual([], errors)
+        self.assertTrue(any("url" in error for error in errors), errors)
 
     def test_schema_accepts_dot_prefixed_skill_path(self):
         registry = build_registry()

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -236,6 +236,40 @@ class SchemaTests(unittest.TestCase):
         self.assertNotEqual([], errors, errors)
         self.assertTrue(any("supporting_paths" in error for error in errors), errors)
 
+    def test_schema_accepts_git_source_with_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.corp.example.com/team/my-plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertEqual([], errors)
+
+    def test_schema_rejects_git_source_without_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
+    def test_schema_rejects_github_source_without_repo(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "github",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("repo" in error for error in errors), errors)
+
     def test_schema_accepts_dot_prefixed_skill_path(self):
         registry = build_registry()
         add_minimal_contract(registry["plugins"][0]["skills"][0])

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -271,6 +271,32 @@ class SchemaTests(unittest.TestCase):
 
         self.assertTrue(any("repo" in error for error in errors), errors)
 
+    def test_schema_rejects_git_source_with_repo(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+            "repo": "team/plugin",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertNotEqual([], errors)
+
+    def test_schema_rejects_github_source_with_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "github",
+            "repo": "example-org/example-plugin",
+            "url": "https://github.com/example-org/example-plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertNotEqual([], errors)
+
     def test_schema_accepts_dot_prefixed_skill_path(self):
         registry = build_registry()
         add_minimal_contract(registry["plugins"][0]["skills"][0])
@@ -452,6 +478,41 @@ class ContractValidatorTests(unittest.TestCase):
         )
 
 
+class SourceURLValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.validate_registry = get_validate_registry_module()
+
+    def test_check_source_urls_accepts_https(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        errors = self.validate_registry.check_source_urls(registry)
+
+        self.assertEqual([], errors)
+
+    def test_check_source_urls_rejects_ssh(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "git@gitlab.example.com:team/plugin.git",
+        }
+
+        errors = self.validate_registry.check_source_urls(registry)
+
+        self.assertTrue(any("https://" in e for e in errors), errors)
+
+    def test_check_source_urls_skips_github_type(self):
+        registry = build_registry()
+
+        errors = self.validate_registry.check_source_urls(registry)
+
+        self.assertEqual([], errors)
+
+
 class RemotePluginValidationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -475,9 +536,13 @@ class RemotePluginValidationTests(unittest.TestCase):
         cmd = run_mock.call_args[0][0]
         self.assertEqual(cmd[0], "git")
         self.assertIn("ls-remote", cmd)
+        self.assertIn("--", cmd)
 
     @mock.patch("subprocess.run")
     def test_validate_remote_plugin_accepts_git_type(self, run_mock):
+        import tempfile
+        import os
+
         run_mock.return_value = subprocess.CompletedProcess(
             ["git", "clone"], 0, stdout="", stderr=""
         )
@@ -490,11 +555,31 @@ class RemotePluginValidationTests(unittest.TestCase):
             },
         }
 
-        errors = self.validate_registry.validate_remote_plugin(plugin)
+        real_tmpdir = tempfile.mkdtemp()
+        try:
+            # Set up the directory structure that post-clone validation expects
+            plugin_dir = os.path.join(real_tmpdir, ".claude-plugin")
+            os.makedirs(plugin_dir)
+            with open(os.path.join(plugin_dir, "plugin.json"), "w") as f:
+                f.write('{"name": "git-plugin", "version": "1.0.0"}')
+            skill_dir = os.path.join(real_tmpdir, "skills", "example-skill")
+            os.makedirs(skill_dir)
+            with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+                f.write("# Example Skill")
 
-        self.assertTrue(run_mock.called)
-        cmd = run_mock.call_args[0][0]
-        self.assertIn("https://gitlab.example.com/team/plugin.git", cmd)
+            ctx = mock.MagicMock()
+            ctx.__enter__ = mock.Mock(return_value=real_tmpdir)
+            ctx.__exit__ = mock.Mock(return_value=False)
+            with mock.patch("tempfile.TemporaryDirectory", return_value=ctx):
+                errors = self.validate_registry.validate_remote_plugin(plugin)
+
+            self.assertTrue(run_mock.called)
+            cmd = run_mock.call_args[0][0]
+            self.assertIn("https://gitlab.example.com/team/plugin.git", cmd)
+            self.assertEqual([], errors)
+        finally:
+            import shutil
+            shutil.rmtree(real_tmpdir)
 
     @mock.patch("subprocess.run")
     def test_validate_remote_plugin_rejects_invalid_ref_before_git(self, run_mock):

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.util
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -455,6 +456,45 @@ class RemotePluginValidationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.validate_registry = get_validate_registry_module()
+
+    @mock.patch("subprocess.run")
+    def test_check_sources_uses_ls_remote_for_git_type(self, run_mock):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ["git", "ls-remote"], 0, stdout="", stderr=""
+        )
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+        }
+
+        errors = self.validate_registry.check_sources(registry)
+
+        self.assertEqual([], errors)
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args[0][0]
+        self.assertEqual(cmd[0], "git")
+        self.assertIn("ls-remote", cmd)
+
+    @mock.patch("subprocess.run")
+    def test_validate_remote_plugin_accepts_git_type(self, run_mock):
+        run_mock.return_value = subprocess.CompletedProcess(
+            ["git", "clone"], 0, stdout="", stderr=""
+        )
+        plugin = {
+            "name": "git-plugin",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.example.com/team/plugin.git",
+                "ref": "main",
+            },
+        }
+
+        errors = self.validate_registry.validate_remote_plugin(plugin)
+
+        self.assertTrue(run_mock.called)
+        cmd = run_mock.call_args[0][0]
+        self.assertIn("https://gitlab.example.com/team/plugin.git", cmd)
 
     @mock.patch("subprocess.run")
     def test_validate_remote_plugin_rejects_invalid_ref_before_git(self, run_mock):


### PR DESCRIPTION
## Summary

Closes #74.

- Adds `type: git` source type with explicit `url` field for plugins hosted on GitLab or other git forges
- Keeps `type: github` unchanged (backwards-compatible)
- Centralizes URL derivation in three helpers: `source_clone_url()`, `source_display_name()`, `source_browse_url()`
- Updates all 7 scripts (`validate_registry`, `run_skill_linter`, `check_versions`, `generate_catalog`, `generate_site`, `sync_marketplace`, `registry_contracts`)
- Adds conditional JSON Schema validation (`if`/`then`) requiring `repo` for github and `url` for git
- 96 tests passing

## Example registry entry

```yaml
source:
  type: git
  url: https://gitlab.corp.example.com/team/my-plugin.git
  ref: main
```

## Test plan

- [ ] `python3 -m pytest tests/ -v` — 96 tests pass
- [ ] `python3 scripts/validate_registry.py` — validates cleanly
- [ ] `python3 scripts/sync_marketplace.py` — no diff (no git-type plugins yet)
- [ ] Manual: add a `type: git` plugin entry, run sync, verify marketplace.json output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for non-GitHub git plugin sources, including URL-based entries and updated source display/link handling across the app.
  * Catalog, site pages, and marketplace sync now render source information for both GitHub and git-hosted plugins.

* **Bug Fixes**
  * Improved validation for plugin source URLs and source types.
  * Remote version checks and linting now work with git-hosted repositories, not just GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->