### PR TITLE
fix: harden git source type (https, git-subdir, discover_skills, tests)

### DIFF
--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -404,8 +404,8 @@
         "url": {
           "type": "string",
           "format": "uri",
-          "pattern": "^https://",
-          "description": "Clone URL — required for git and git-subdir types; must be https://"
+          "pattern": "^https://[^@]+$",
+          "description": "Clone URL — required for git and git-subdir types; must be https:// and must not embed userinfo (credentials)"
         },
         "ref": {
           "type": "string",

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -404,7 +404,8 @@
         "url": {
           "type": "string",
           "format": "uri",
-          "description": "Clone URL — required for git type"
+          "pattern": "^https://",
+          "description": "Clone URL — required for git and git-subdir types; must be https://"
         },
         "ref": {
           "type": "string",
@@ -428,6 +429,10 @@
         {
           "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
           "then": { "required": ["url"], "not": { "required": ["repo"] } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "git-subdir" } }, "required": ["type"] },
+          "then": { "required": ["url", "path"], "not": { "required": ["repo"] } }
         }
       ]
     },

--- a/scripts/discover_skills.py
+++ b/scripts/discover_skills.py
@@ -30,6 +30,16 @@ sys.path.insert(0, _REPO_ROOT_STR)
 from scripts.registry_contracts import source_clone_url, shallow_clone  # noqa: E402
 
 
+# Strip user[:token]@ credentials from any URL in the given text before logging.
+# Catches both the URL we hold (clone_url) and URLs that git echoes back in
+# stderr / RuntimeError messages. Prevents credential leaks in logs (CWE-532).
+_CREDENTIAL_URL_RE = re.compile(r"(https?://)[^/@\s]*@")
+
+
+def _redact_url(text: str) -> str:
+    return _CREDENTIAL_URL_RE.sub(r"\1***@", text)
+
+
 def load_registry(path: str = "registry.yaml") -> dict:
     with open(path) as f:
         return yaml.safe_load(f)
@@ -111,10 +121,11 @@ def discover_git_skills(clone_url: str, ref: str = "main") -> list[dict]:
         try:
             result = shallow_clone(clone_url, ref, tmpdir)
         except RuntimeError as exc:
-            print(f"  ERROR: {exc}", file=sys.stderr)
+            print(f"  ERROR: {_redact_url(str(exc))}", file=sys.stderr)
             return []
         if result.returncode != 0:
-            print(f"  ERROR: clone failed for {clone_url}: {result.stderr.strip()}",
+            print(f"  ERROR: clone failed for {_redact_url(clone_url)}: "
+                  f"{_redact_url(result.stderr.strip())}",
                   file=sys.stderr)
             return []
 
@@ -240,7 +251,7 @@ def main():
         except (ValueError, KeyError):
             print(f"ERROR: plugin '{args.plugin}' has an invalid git source", file=sys.stderr)
             sys.exit(1)
-        print(f"Discovering skills for {args.plugin} from {clone_url}@{ref}...")
+        print(f"Discovering skills for {args.plugin} from {_redact_url(clone_url)}@{ref}...")
         skills = discover_git_skills(clone_url, ref)
     else:
         print(

--- a/scripts/discover_skills.py
+++ b/scripts/discover_skills.py
@@ -27,17 +27,7 @@ _REPO_ROOT_STR = str(_SCRIPT_DIR.parent)
 sys.path[:] = [entry for entry in sys.path if entry != _REPO_ROOT_STR]
 sys.path.insert(0, _REPO_ROOT_STR)
 
-from scripts.registry_contracts import source_clone_url, shallow_clone  # noqa: E402
-
-
-# Strip user[:token]@ credentials from any URL in the given text before logging.
-# Catches both the URL we hold (clone_url) and URLs that git echoes back in
-# stderr / RuntimeError messages. Prevents credential leaks in logs (CWE-532).
-_CREDENTIAL_URL_RE = re.compile(r"(https?://)[^/@\s]*@")
-
-
-def _redact_url(text: str) -> str:
-    return _CREDENTIAL_URL_RE.sub(r"\1***@", text)
+from scripts.registry_contracts import redact_url, source_clone_url, shallow_clone  # noqa: E402
 
 
 def load_registry(path: str = "registry.yaml") -> dict:
@@ -121,11 +111,11 @@ def discover_git_skills(clone_url: str, ref: str = "main") -> list[dict]:
         try:
             result = shallow_clone(clone_url, ref, tmpdir)
         except RuntimeError as exc:
-            print(f"  ERROR: {_redact_url(str(exc))}", file=sys.stderr)
+            print(f"  ERROR: {redact_url(str(exc))}", file=sys.stderr)
             return []
         if result.returncode != 0:
-            print(f"  ERROR: clone failed for {_redact_url(clone_url)}: "
-                  f"{_redact_url(result.stderr.strip())}",
+            print(f"  ERROR: clone failed for {redact_url(clone_url)}: "
+                  f"{redact_url(result.stderr.strip())}",
                   file=sys.stderr)
             return []
 
@@ -251,7 +241,7 @@ def main():
         except (ValueError, KeyError):
             print(f"ERROR: plugin '{args.plugin}' has an invalid git source", file=sys.stderr)
             sys.exit(1)
-        print(f"Discovering skills for {args.plugin} from {_redact_url(clone_url)}@{ref}...")
+        print(f"Discovering skills for {args.plugin} from {redact_url(clone_url)}@{ref}...")
         skills = discover_git_skills(clone_url, ref)
     else:
         print(

--- a/scripts/discover_skills.py
+++ b/scripts/discover_skills.py
@@ -14,11 +14,20 @@ import json
 import os
 import re
 import sys
+import tempfile
 import textwrap
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import yaml
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT_STR = str(_SCRIPT_DIR.parent)
+sys.path[:] = [entry for entry in sys.path if entry != _REPO_ROOT_STR]
+sys.path.insert(0, _REPO_ROOT_STR)
+
+from scripts.registry_contracts import source_clone_url, shallow_clone  # noqa: E402
 
 
 def load_registry(path: str = "registry.yaml") -> dict:
@@ -90,6 +99,35 @@ def discover_remote_skills(repo: str, ref: str = "main") -> list[dict]:
         skills = list(pool.map(fetch_one, sorted(skill_entries)))
 
     return sorted(skills, key=lambda s: s["name"])
+
+
+def discover_git_skills(clone_url: str, ref: str = "main") -> list[dict]:
+    """Discover skills by cloning a git repo and walking for SKILL.md files.
+
+    Used for non-GitHub ``type: git`` sources, where the GitHub tree/raw APIs
+    are unavailable.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            result = shallow_clone(clone_url, ref, tmpdir)
+        except RuntimeError as exc:
+            print(f"  ERROR: {exc}", file=sys.stderr)
+            return []
+        if result.returncode != 0:
+            print(f"  ERROR: clone failed for {clone_url}: {result.stderr.strip()}",
+                  file=sys.stderr)
+            return []
+
+        skills = []
+        for skill_md in Path(tmpdir).rglob("SKILL.md"):
+            content = skill_md.read_text(encoding="utf-8", errors="replace")
+            fm = parse_frontmatter(content)
+            skills.append({
+                "name": fm.get("name", skill_md.parent.name),
+                "description": fm.get("description", ""),
+                "user-invocable": fm.get("user-invocable", True),
+            })
+        return sorted(skills, key=lambda s: s["name"])
 
 
 def format_skills_yaml(skills: list[dict]) -> str:
@@ -186,15 +224,31 @@ def main():
         sys.exit(1)
 
     source = plugin.get("source") or {}
-    repo = source.get("repo")
-    if not repo:
-        print(f"ERROR: plugin '{args.plugin}' has no source.repo", file=sys.stderr)
-        sys.exit(1)
-
+    source_type = source.get("type")
     ref = source.get("ref", "main")
-    print(f"Discovering skills for {args.plugin} from {repo}@{ref}...")
 
-    skills = discover_remote_skills(repo, ref)
+    if source_type == "github":
+        repo = source.get("repo")
+        if not repo:
+            print(f"ERROR: plugin '{args.plugin}' has no source.repo", file=sys.stderr)
+            sys.exit(1)
+        print(f"Discovering skills for {args.plugin} from {repo}@{ref}...")
+        skills = discover_remote_skills(repo, ref)
+    elif source_type == "git":
+        try:
+            clone_url = source_clone_url(source)
+        except (ValueError, KeyError):
+            print(f"ERROR: plugin '{args.plugin}' has an invalid git source", file=sys.stderr)
+            sys.exit(1)
+        print(f"Discovering skills for {args.plugin} from {clone_url}@{ref}...")
+        skills = discover_git_skills(clone_url, ref)
+    else:
+        print(
+            f"ERROR: plugin '{args.plugin}' source type {source_type!r} is not "
+            "supported for skill discovery (expected 'github' or 'git')",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if not skills:
         print("  No skills found.")
         return

--- a/scripts/registry_contracts.py
+++ b/scripts/registry_contracts.py
@@ -72,6 +72,16 @@ PLUGIN_FIELDS_THAT_TOUCH_ALL_SKILLS = {"source", "strict", "skills_dir"}
 _SCHEME_RE = _re.compile(r"^https?://")
 GIT_CLONE_TYPES = frozenset({"github", "git"})
 
+# Strip user[:token]@ credentials from any URL in the given text before logging.
+# Applies to both the URL we hold and URLs that git echoes back in stderr /
+# RuntimeError messages. Prevents credential leaks in logs (CWE-532).
+_CREDENTIAL_URL_RE = _re.compile(r"(https?://)[^/@\s]*@")
+
+
+def redact_url(text: str) -> str:
+    """Replace `user[:token]@` in any URL inside `text` with `***@`."""
+    return _CREDENTIAL_URL_RE.sub(r"\1***@", text)
+
 
 def source_clone_url(source: dict) -> str:
     """Return the git clone URL for a plugin source entry."""

--- a/scripts/registry_contracts.py
+++ b/scripts/registry_contracts.py
@@ -117,16 +117,20 @@ def shallow_clone(clone_url: str, ref: str, dest: str, *,
     Returns the CompletedProcess of the successful clone (returncode == 0) or the
     last failed attempt.
     """
-    try:
-        result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, dest],
-            capture_output=True, text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"git clone timed out after {timeout}s: {shlex.join(['git', 'clone', '--', clone_url])}"
-        ) from exc
+    def _run(cmd: list[str], timeout_msg: str) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(timeout_msg) from exc
+
+    clone_timeout_msg = (
+        f"git clone timed out after {timeout}s: {shlex.join(['git', 'clone', '--', clone_url])}"
+    )
+
+    result = _run(
+        ["git", "clone", "--depth", "1", "--branch", ref, "--", clone_url, dest],
+        clone_timeout_msg,
+    )
     if result.returncode == 0:
         return result
 
@@ -135,29 +139,14 @@ def shallow_clone(clone_url: str, ref: str, dest: str, *,
     # default-branch tip, so `git checkout --detach <sha>` fails for any commit
     # that isn't the tip (fatal: unable to read tree). A full clone contains
     # every reachable commit, so an arbitrary historical SHA can be checked out.
-    try:
-        result = subprocess.run(
-            ["git", "clone", "--", clone_url, dest],
-            capture_output=True, text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"git clone timed out after {timeout}s: {shlex.join(['git', 'clone', '--', clone_url])}"
-        ) from exc
+    result = _run(["git", "clone", "--", clone_url, dest], clone_timeout_msg)
     if result.returncode != 0:
         return result
 
-    try:
-        checkout = subprocess.run(
-            ["git", "-C", dest, "checkout", "--detach", ref],
-            capture_output=True, text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"git checkout timed out after {timeout}s for ref {ref}"
-        ) from exc
+    checkout = _run(
+        ["git", "-C", dest, "checkout", "--detach", ref],
+        f"git checkout timed out after {timeout}s for ref {ref}",
+    )
     if checkout.returncode != 0:
         # Return a failed result so the caller sees the error
         return checkout

--- a/scripts/run_skill_linter.py
+++ b/scripts/run_skill_linter.py
@@ -30,6 +30,7 @@ from scripts.registry_contracts import (  # noqa: E402
     load_registry_from_ref,
     load_staged_registry,
     normalize_git_ref,
+    redact_url,
     shallow_clone,
     source_clone_url,
     source_display_name,
@@ -234,7 +235,9 @@ def _ensure_repo(source: dict) -> Path:
         result = shallow_clone(clone_url, ref, str(destination),
                                timeout=GIT_COMMAND_TIMEOUT_SECONDS)
         if result.returncode != 0:
-            raise RuntimeError(f"clone failed for {clone_url}: {result.stderr}".strip())
+            raise RuntimeError(
+                f"clone failed for {redact_url(clone_url)}: {redact_url(result.stderr)}".strip()
+            )
     else:
         fetch = run_captured_command(
             ["git", "-C", str(destination), "fetch", "--depth", "1", "origin", ref],

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -109,23 +109,6 @@ def check_strict_consistency(registry: dict) -> list[str]:
     return errors
 
 
-def check_source_urls(registry: dict) -> list[str]:
-    """Check that git-type source URLs use https:// (not SSH or other schemes)."""
-    errors = []
-    for plugin in registry.get("plugins", []):
-        source = plugin.get("source")
-        if not source or source.get("type") != "git":
-            continue
-        name = plugin.get("name", "<unknown>")
-        url = source.get("url", "")
-        if not url.startswith("https://"):
-            errors.append(
-                f"  Plugin '{name}': git source url must use https:// "
-                f"(got {url!r})"
-            )
-    return errors
-
-
 _PLACEHOLDER_RE = re.compile(
     r"\b(TODO|TBD|FIXME|PLACEHOLDER|XXX)\b|\{\{[\s\S]*?\}\}|\[insert\b",
     re.IGNORECASE,
@@ -451,17 +434,6 @@ def main() -> None:
     all_errors.extend(errors)
     if errors:
         print(f"  FAIL: {len(errors)} consistency error(s)")
-        for e in errors:
-            print(e)
-    else:
-        print("  OK")
-
-    # Source URL validation
-    print("Checking source URLs...")
-    errors = check_source_urls(registry)
-    all_errors.extend(errors)
-    if errors:
-        print(f"  FAIL: {len(errors)} source URL error(s)")
         for e in errors:
             print(e)
     else:

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -271,6 +271,7 @@ def check_sources(registry: dict) -> list[str]:
             result = subprocess.run(
                 ["gh", "api", f"repos/{repo}", "--silent"],
                 capture_output=True, text=True,
+                timeout=30,
             )
         else:
             try:
@@ -306,7 +307,7 @@ def diff_plugins(registry: dict, base_ref: str) -> list[str]:
 
 def validate_remote_plugin(plugin: dict) -> list[str]:
     """Clone a plugin repo and validate its structure."""
-    from scripts.registry_contracts import GIT_CLONE_TYPES, source_clone_url
+    from scripts.registry_contracts import GIT_CLONE_TYPES, redact_url, source_clone_url
 
     errors = []
     source = plugin.get("source")
@@ -329,10 +330,12 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
         try:
             result = shallow_clone(clone_url, ref, tmpdir)
         except RuntimeError as exc:
-            errors.append(f"  Plugin '{plugin['name']}': {exc}")
+            errors.append(f"  Plugin '{plugin['name']}': {redact_url(str(exc))}")
             return errors
         if result.returncode != 0:
-            errors.append(f"  Plugin '{plugin['name']}': failed to clone {clone_url} (ref={ref})")
+            errors.append(
+                f"  Plugin '{plugin['name']}': failed to clone {redact_url(clone_url)} (ref={ref})"
+            )
             return errors
 
         repo_path = Path(tmpdir)

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,3 +1,8 @@
+import json
+import os
+import shutil
+import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
@@ -89,6 +94,46 @@ class CheckVersionsMainLoopTests(unittest.TestCase):
             main()
 
         api_mock.assert_called_once_with("org/repo", "main")
+
+
+@unittest.skipUnless(shutil.which("git"), "git is required for integration tests")
+class FetchRemoteVersionViaCloneIntegrationTests(unittest.TestCase):
+    """End-to-end against a real repo — exercises shallow_clone's SHA fallback."""
+
+    _GIT_ENV = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True, env=self._GIT_ENV
+        )
+
+    def _write_plugin_json(self, src: str, version: str) -> None:
+        os.makedirs(os.path.join(src, ".claude-plugin"), exist_ok=True)
+        with open(os.path.join(src, ".claude-plugin", "plugin.json"), "w") as f:
+            json.dump({"name": "p", "version": version}, f)
+
+    def test_reads_version_at_historical_sha_and_tip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            os.makedirs(src)
+            self._git("init", "-q", src)
+            self._write_plugin_json(src, "1.0.0")
+            self._git("-C", src, "add", "-A")
+            self._git("-C", src, "commit", "-q", "-m", "v1")
+            historical = self._git("-C", src, "rev-parse", "HEAD").stdout.strip()
+            self._write_plugin_json(src, "2.0.0")
+            self._git("-C", src, "commit", "-aq", "-m", "v2")
+            branch = self._git("-C", src, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+            url = f"file://{src}"
+            # Historical SHA drives the --branch-fails -> full-clone -> checkout path.
+            self.assertEqual("1.0.0", fetch_remote_version_via_clone(url, historical))
+            # Branch ref uses the shallow --branch path.
+            self.assertEqual("2.0.0", fetch_remote_version_via_clone(url, branch))
 
 
 if __name__ == "__main__":

--- a/tests/test_discover_skills.py
+++ b/tests/test_discover_skills.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from scripts.discover_skills import discover_git_skills, parse_frontmatter
+
+
+class ParseFrontmatterTests(unittest.TestCase):
+    def test_parses_name_and_description(self):
+        fm = parse_frontmatter("---\nname: foo\ndescription: does foo\n---\n# body\n")
+        self.assertEqual("foo", fm["name"])
+        self.assertEqual("does foo", fm["description"])
+
+    def test_returns_empty_without_frontmatter(self):
+        self.assertEqual({}, parse_frontmatter("# just a heading\n"))
+
+
+@unittest.skipUnless(shutil.which("git"), "git is required for integration tests")
+class DiscoverGitSkillsIntegrationTests(unittest.TestCase):
+    _GIT_ENV = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+
+    def _git(self, *args: str) -> None:
+        subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True, env=self._GIT_ENV
+        )
+
+    def _add_skill(self, src: str, name: str, body: str) -> None:
+        skill_dir = os.path.join(src, "skills", name)
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+            f.write(body)
+
+    def test_discovers_skills_from_clone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            os.makedirs(src)
+            self._git("init", "-q", src)
+            self._add_skill(src, "alpha", "---\nname: alpha\ndescription: the alpha skill\n---\n")
+            self._add_skill(
+                src, "beta",
+                "---\nname: beta\ndescription: the beta skill\nuser-invocable: false\n---\n",
+            )
+            self._git("-C", src, "add", "-A")
+            self._git("-C", src, "commit", "-q", "-m", "add skills")
+
+            skills = discover_git_skills(f"file://{src}", "HEAD")
+
+            self.assertEqual(["alpha", "beta"], [s["name"] for s in skills])
+            self.assertEqual("the alpha skill", skills[0]["description"])
+            self.assertTrue(skills[0]["user-invocable"])
+            self.assertFalse(skills[1]["user-invocable"])
+
+    def test_returns_empty_on_clone_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = f"file://{os.path.join(tmp, 'does-not-exist')}"
+            self.assertEqual([], discover_git_skills(missing, "main"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discover_skills.py
+++ b/tests/test_discover_skills.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import unittest
 
-from scripts.discover_skills import _redact_url, discover_git_skills, parse_frontmatter
+from scripts.discover_skills import discover_git_skills, parse_frontmatter
 
 
 class ParseFrontmatterTests(unittest.TestCase):
@@ -15,31 +15,6 @@ class ParseFrontmatterTests(unittest.TestCase):
 
     def test_returns_empty_without_frontmatter(self):
         self.assertEqual({}, parse_frontmatter("# just a heading\n"))
-
-
-class RedactUrlTests(unittest.TestCase):
-    def test_redacts_user_and_password(self):
-        self.assertEqual(
-            "https://***@host.example.com/x.git",
-            _redact_url("https://user:token@host.example.com/x.git"),
-        )
-
-    def test_redacts_bare_user(self):
-        self.assertEqual(
-            "https://***@host/x.git",
-            _redact_url("https://user@host/x.git"),
-        )
-
-    def test_preserves_url_without_userinfo(self):
-        self.assertEqual(
-            "https://host.example.com/x.git",
-            _redact_url("https://host.example.com/x.git"),
-        )
-
-    def test_redacts_credentials_in_stderr_like_text(self):
-        text = "fatal: unable to access 'https://oauth2:SECRET@gitlab.com/team/x.git/': ..."
-        self.assertNotIn("SECRET", _redact_url(text))
-        self.assertIn("https://***@gitlab.com", _redact_url(text))
 
 
 @unittest.skipUnless(shutil.which("git"), "git is required for integration tests")

--- a/tests/test_discover_skills.py
+++ b/tests/test_discover_skills.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import unittest
 
-from scripts.discover_skills import discover_git_skills, parse_frontmatter
+from scripts.discover_skills import _redact_url, discover_git_skills, parse_frontmatter
 
 
 class ParseFrontmatterTests(unittest.TestCase):
@@ -17,6 +17,31 @@ class ParseFrontmatterTests(unittest.TestCase):
         self.assertEqual({}, parse_frontmatter("# just a heading\n"))
 
 
+class RedactUrlTests(unittest.TestCase):
+    def test_redacts_user_and_password(self):
+        self.assertEqual(
+            "https://***@host.example.com/x.git",
+            _redact_url("https://user:token@host.example.com/x.git"),
+        )
+
+    def test_redacts_bare_user(self):
+        self.assertEqual(
+            "https://***@host/x.git",
+            _redact_url("https://user@host/x.git"),
+        )
+
+    def test_preserves_url_without_userinfo(self):
+        self.assertEqual(
+            "https://host.example.com/x.git",
+            _redact_url("https://host.example.com/x.git"),
+        )
+
+    def test_redacts_credentials_in_stderr_like_text(self):
+        text = "fatal: unable to access 'https://oauth2:SECRET@gitlab.com/team/x.git/': ..."
+        self.assertNotIn("SECRET", _redact_url(text))
+        self.assertIn("https://***@gitlab.com", _redact_url(text))
+
+
 @unittest.skipUnless(shutil.which("git"), "git is required for integration tests")
 class DiscoverGitSkillsIntegrationTests(unittest.TestCase):
     _GIT_ENV = {
@@ -25,8 +50,8 @@ class DiscoverGitSkillsIntegrationTests(unittest.TestCase):
         "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
     }
 
-    def _git(self, *args: str) -> None:
-        subprocess.run(
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
             ["git", *args], capture_output=True, text=True, check=True, env=self._GIT_ENV
         )
 
@@ -48,8 +73,11 @@ class DiscoverGitSkillsIntegrationTests(unittest.TestCase):
             )
             self._git("-C", src, "add", "-A")
             self._git("-C", src, "commit", "-q", "-m", "add skills")
+            # Resolve the real branch name: `git clone --branch HEAD` treats HEAD
+            # as a literal ref, not the default-branch alias.
+            branch = self._git("-C", src, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
 
-            skills = discover_git_skills(f"file://{src}", "HEAD")
+            skills = discover_git_skills(f"file://{src}", branch)
 
             self.assertEqual(["alpha", "beta"], [s["name"] for s in skills])
             self.assertEqual("the alpha skill", skills[0]["description"])

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -10,6 +10,7 @@ from scripts.registry_contracts import (
     detect_touched_skills,
     load_registry_from_ref,
     load_staged_registry,
+    redact_url,
     shallow_clone,
     source_browse_url,
     source_clone_url,
@@ -154,6 +155,31 @@ class SourceHelperTests(unittest.TestCase):
     def test_source_browse_url_git_no_dotgit(self):
         source = {"type": "git", "url": "https://gitlab.corp.example.com/team/my-plugin"}
         self.assertEqual("https://gitlab.corp.example.com/team/my-plugin", source_browse_url(source))
+
+
+class RedactUrlTests(unittest.TestCase):
+    def test_redacts_user_and_password(self):
+        self.assertEqual(
+            "https://***@host.example.com/x.git",
+            redact_url("https://user:token@host.example.com/x.git"),
+        )
+
+    def test_redacts_bare_user(self):
+        self.assertEqual(
+            "https://***@host/x.git",
+            redact_url("https://user@host/x.git"),
+        )
+
+    def test_preserves_url_without_userinfo(self):
+        self.assertEqual(
+            "https://host.example.com/x.git",
+            redact_url("https://host.example.com/x.git"),
+        )
+
+    def test_redacts_credentials_in_stderr_like_text(self):
+        text = "fatal: unable to access 'https://oauth2:SECRET@gitlab.com/team/x.git/': ..."
+        self.assertNotIn("SECRET", redact_url(text))
+        self.assertIn("https://***@gitlab.com", redact_url(text))
 
 
 class ShallowCloneTests(unittest.TestCase):

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -202,11 +202,45 @@ class ShallowCloneTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
 
     @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_returns_failed_checkout(self, run_mock):
+        sha = "b" * 40
+        branch_fail = subprocess.CompletedProcess(["git", "clone"], 128, stdout="", stderr="")
+        clone_ok = subprocess.CompletedProcess(["git", "clone"], 0, stdout="", stderr="")
+        checkout_fail = subprocess.CompletedProcess(
+            ["git", "checkout"], 1, stdout="", stderr="fatal: unable to read tree"
+        )
+        run_mock.side_effect = [branch_fail, clone_ok, checkout_fail]
+
+        result = shallow_clone("https://example.com/repo.git", sha, "/tmp/dest")
+
+        # The failed checkout is surfaced to the caller (not masked as clone success).
+        self.assertEqual(3, run_mock.call_count)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("unable to read tree", result.stderr)
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
     def test_shallow_clone_raises_on_timeout(self, run_mock):
         run_mock.side_effect = subprocess.TimeoutExpired(["git"], 120)
 
         with self.assertRaises(RuntimeError):
             shallow_clone("https://example.com/repo.git", "main", "/tmp/dest")
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_raises_on_fallback_clone_timeout(self, run_mock):
+        branch_fail = subprocess.CompletedProcess(["git", "clone"], 128, stdout="", stderr="")
+        run_mock.side_effect = [branch_fail, subprocess.TimeoutExpired(["git"], 120)]
+
+        with self.assertRaises(RuntimeError):
+            shallow_clone("https://example.com/repo.git", "c" * 40, "/tmp/dest")
+
+    @mock.patch("scripts.registry_contracts.subprocess.run")
+    def test_shallow_clone_raises_on_checkout_timeout(self, run_mock):
+        branch_fail = subprocess.CompletedProcess(["git", "clone"], 128, stdout="", stderr="")
+        clone_ok = subprocess.CompletedProcess(["git", "clone"], 0, stdout="", stderr="")
+        run_mock.side_effect = [branch_fail, clone_ok, subprocess.TimeoutExpired(["git"], 120)]
+
+        with self.assertRaises(RuntimeError):
+            shallow_clone("https://example.com/repo.git", "d" * 40, "/tmp/dest")
 
 
 @unittest.skipUnless(shutil.which("git"), "git is required for integration tests")

--- a/tests/test_script_bootstrap.py
+++ b/tests/test_script_bootstrap.py
@@ -13,6 +13,7 @@ SCRIPT_PATHS = [
     "scripts/run_skill_linter.py",
     "scripts/generate_catalog.py",
     "scripts/check_versions.py",
+    "scripts/discover_skills.py",
 ]
 POISON_SENTINEL = "poisoned registry_contracts import"
 

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -297,6 +297,62 @@ class SchemaTests(unittest.TestCase):
 
         self.assertTrue(any("url" in error for error in errors), errors)
 
+    def test_schema_rejects_non_https_git_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "git@gitlab.example.com:team/plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
+    def test_schema_accepts_https_git_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://gitlab.example.com/team/plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertEqual([], errors)
+
+    def test_schema_requires_url_and_path_for_git_subdir(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {"type": "git-subdir", "ref": "main"}
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(errors)
+
+    def test_schema_accepts_git_subdir_with_url_and_path(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git-subdir",
+            "url": "https://github.com/acme/monorepo.git",
+            "path": "tools/plugin",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertEqual([], errors)
+
+    def test_schema_rejects_non_https_git_subdir_url(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git-subdir",
+            "url": "git@github.com:acme/monorepo.git",
+            "path": "tools/plugin",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
     def test_schema_accepts_dot_prefixed_skill_path(self):
         registry = build_registry()
         add_minimal_contract(registry["plugins"][0]["skills"][0])
@@ -476,41 +532,6 @@ class ContractValidatorTests(unittest.TestCase):
             any("git ref" in e.lower() or "could not load" in e.lower() for e in errs),
             errs,
         )
-
-
-class SourceURLValidationTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.validate_registry = get_validate_registry_module()
-
-    def test_check_source_urls_accepts_https(self):
-        registry = build_registry()
-        registry["plugins"][0]["source"] = {
-            "type": "git",
-            "url": "https://gitlab.example.com/team/plugin.git",
-        }
-
-        errors = self.validate_registry.check_source_urls(registry)
-
-        self.assertEqual([], errors)
-
-    def test_check_source_urls_rejects_ssh(self):
-        registry = build_registry()
-        registry["plugins"][0]["source"] = {
-            "type": "git",
-            "url": "git@gitlab.example.com:team/plugin.git",
-        }
-
-        errors = self.validate_registry.check_source_urls(registry)
-
-        self.assertTrue(any("https://" in e for e in errors), errors)
-
-    def test_check_source_urls_skips_github_type(self):
-        registry = build_registry()
-
-        errors = self.validate_registry.check_source_urls(registry)
-
-        self.assertEqual([], errors)
 
 
 class RemotePluginValidationTests(unittest.TestCase):

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -353,6 +353,19 @@ class SchemaTests(unittest.TestCase):
 
         self.assertTrue(any("url" in error for error in errors), errors)
 
+    def test_schema_rejects_git_subdir_source_with_repo(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git-subdir",
+            "url": "https://github.com/acme/monorepo.git",
+            "path": "tools/plugin",
+            "repo": "acme/monorepo",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("repo" in error for error in errors), errors)
+
     def test_schema_accepts_dot_prefixed_skill_path(self):
         registry = build_registry()
         add_minimal_contract(registry["plugins"][0]["skills"][0])

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -309,6 +309,30 @@ class SchemaTests(unittest.TestCase):
 
         self.assertTrue(any("url" in error for error in errors), errors)
 
+    def test_schema_rejects_git_url_with_embedded_credentials(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git",
+            "url": "https://user:token@gitlab.example.com/team/plugin.git",
+            "ref": "main",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
+    def test_schema_rejects_git_subdir_url_with_embedded_credentials(self):
+        registry = build_registry()
+        registry["plugins"][0]["source"] = {
+            "type": "git-subdir",
+            "url": "https://oauth2:SECRET@github.com/acme/monorepo.git",
+            "path": "tools/plugin",
+        }
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertTrue(any("url" in error for error in errors), errors)
+
     def test_schema_accepts_https_git_url(self):
         registry = build_registry()
         registry["plugins"][0]["source"] = {


### PR DESCRIPTION
Follow-up to #75 (git source type). Addresses the residual review items that were deferred as fast-follows. No registry data changes; `main` is github-only today, so these are latent-path hardening.

## Changes

**Schema — enforce https git URLs declaratively**
- Add `pattern: "^https://"` to `source.url` (the `format: uri` keyword is inert under `Draft202012Validator` — no format checker is registered). Covers both `git` and `git-subdir`.
- Add a conditional requiring `url` + `path` for `git-subdir` (and forbidding `repo`), matching the `github`/`git` pattern.
- Remove the now-redundant `check_source_urls` Python pass — the rule now lives in one declarative place (schema), addressing the "3 layers of git-url validation" note.

**`discover_skills.py` — support `type: git`**
- Add a clone-based discovery path (`source_clone_url` + `shallow_clone`) that walks `SKILL.md` files, dispatching on source type; previously it was github-only and errored on a missing `source.repo`.
- Add the `sys.path` bootstrap so `python3 scripts/discover_skills.py` runs standalone (same fix as #75 applied to `check_versions.py`), and add it to the bootstrap test.

**`shallow_clone` cleanup**
- Dedup the three identical `try/except subprocess.TimeoutExpired` blocks into a small local helper (no behavior change).

**Tests**
- `shallow_clone`: cover the failed-checkout branch and the fallback-clone / checkout timeout branches (previously untested).
- Real-git end-to-end tests: `check_versions` reads the version at a historical SHA (exercises the SHA fallback), and `discover_skills` git discovery.
- Schema tests for https enforcement (git + git-subdir) and git-subdir url+path.

## Investigated, no change

The warm-cache SHA path in `run_skill_linter._ensure_repo` was left unchanged: with the ref-keyed cache and git's local object persistence, the existing path checks out historical SHAs correctly (verified against a real repo), so the earlier "cold/warm divergence" concern was theoretical.

## Deferred

The broader github-vs-git dispatch centralization (a `resolve_clone_target(source)` helper across `check_versions`/`validate_registry`) is left out — it's a larger refactor with more regression surface and low value for a two-type system.

All 120 tests pass locally; changed files are ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skill discovery support for generic `git` sources (not just GitHub).
* **Validation**
  * Strengthened registry schema validation for `git`/`git-subdir` sources: requires `https://` clone URLs, enforces `url` + `path` for `git-subdir`, and rejects unsupported fields.
* **Bug Fixes**
  * Improved robustness and reporting for shallow clone, checkout, and timeout/failure scenarios during remote resolution.
* **Tests**
  * Added unit and integration coverage for frontmatter parsing, URL redaction, and git-based discovery/version fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->