### PR TITLE
chore: bump docs-skills plugin to 0.3.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -416,7 +416,7 @@
         "repo": "opendatahub-io/docs-skills",
         "source": "github"
       },
-      "version": "0.3.8"
+      "version": "0.3.15"
     }
   ]
 }

--- a/catalog.md
+++ b/catalog.md
@@ -186,7 +186,7 @@ Tags: knowledge, context, claude-md, agents-md, pr-analysis, automation
 
 Documentation review, writing, and workflow tools for AsciiDoc and Markdown documentation. Includes an orchestrated multi-step pipeline, standalone review skills, codebase analysis for onboarding, and JIRA/PR integration.
 
-v0.3.8 | Apache-2.0 | [opendatahub-io/docs-skills](https://github.com/opendatahub-io/docs-skills)
+v0.3.15 | Apache-2.0 | [opendatahub-io/docs-skills](https://github.com/opendatahub-io/docs-skills)
 
 Tags: documentation, asciidoc, mkdocs, workflow, review, style-guide, jira, onboarding, code-analysis
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -763,7 +763,7 @@ plugins:
       Markdown documentation. Includes an orchestrated multi-step pipeline,
       standalone review skills, codebase analysis for onboarding, and
       JIRA/PR integration.
-    version: "0.3.8"
+    version: "0.3.15"
     category: documentation
     tags: [documentation, asciidoc, mkdocs, workflow, review, style-guide, jira, onboarding, code-analysis]
     author:

--- a/site/docs/categories/documentation.md
+++ b/site/docs/categories/documentation.md
@@ -21,4 +21,4 @@ Autonomous knowledge management skills for keeping AI context files (CLAUDE.md, 
 
 Documentation review, writing, and workflow tools for AsciiDoc and Markdown documentation. Includes an orchestrated multi-step pipeline, standalone review skills, codebase analysis for onboarding, and JIRA/PR integration.
 
-**1 skills** - v0.3.8
+**1 skills** - v0.3.15

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -122,7 +122,7 @@ hide:
 
     Documentation review, writing, and workflow tools for AsciiDoc and Markdown documentation. Includes an orchestrated m...
 
-    **1 skills** - Documentation - v0.3.8
+    **1 skills** - Documentation - v0.3.15
 
 </div>
 

--- a/site/docs/plugins/docs-skills/index.md
+++ b/site/docs/plugins/docs-skills/index.md
@@ -45,7 +45,7 @@ and actions reviewer comments on a PR/MR.
 
 !!! info "Plugin Details"
 
-    - **Version**: 0.3.8
+    - **Version**: 0.3.15
     - **Author**: opendatahub-io
     - **License**: Apache-2.0
     - **Category**: [Documentation](../../categories/documentation.md)

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -25,7 +25,7 @@ title: Plugins
 | [pipeline-skills](pipeline-skills/index.md) | DevOps & CI/CD | 2 | v0.1.0 |
 | [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |
-| [docs-skills](docs-skills/index.md) | Documentation | 1 | v0.3.8 |
+| [docs-skills](docs-skills/index.md) | Documentation | 1 | v0.3.15 |
 
 ## Generic
 


### PR DESCRIPTION
## Summary
- Bumps docs-skills plugin version from 0.3.8 to 0.3.15 to match upstream `opendatahub-io/docs-skills` main branch
- Regenerated all artifacts (marketplace.json, catalog.md, site/)

## Test plan
- [x] `validate_registry.py` passes
- [x] `sync_marketplace.py` regenerated marketplace.json
- [x] `generate_catalog.py` regenerated catalog.md
- [x] `generate_site.py` regenerated site/

🤖 Generated with [Claude Code](https://claude.com/claude-code)