### PR TITLE
Redesign skill contract section as a structured spec card

### DIFF
--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import html
 import os
 import shutil
 import sys
@@ -514,6 +515,260 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     return "\n".join(lines)
 
 
+# ─── Contract card helpers ───────────────────────────────────────────
+# The contract renders as a bespoke "spec-sheet" HTML card (§01–§04)
+# with per-section left-spine accents. Templates + CSS live together;
+# markup is emitted here, styles in site/docs/assets/stylesheets/extra.css
+# under the `.skill-contract` block.
+
+
+def _esc(value) -> str:
+    """HTML-escape a value for safe inclusion in generated markup."""
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _parse_contract_ref_url(ref: str | None) -> str | None:
+    """Parse `owner/repo@sha:path` into a GitHub blob URL, or None if malformed."""
+    if not isinstance(ref, str):
+        return None
+    ref = ref.strip()
+    if "@" not in ref or ":" not in ref:
+        return None
+    try:
+        repo, rest = ref.split("@", 1)
+        sha, path = rest.split(":", 1)
+    except ValueError:
+        return None
+    if "/" not in repo or not sha or not path:
+        return None
+    return f"https://github.com/{repo}/blob/{sha}/{path}"
+
+
+def _short_contract_ref_label(ref: str | None) -> str:
+    """Compact `filename @ abc1234` label from `owner/repo@sha:path/to/file`."""
+    if not isinstance(ref, str):
+        return ""
+    ref = ref.strip()
+    if "@" not in ref:
+        return ref
+    _repo, rest = ref.split("@", 1)
+    if ":" in rest:
+        sha, path = rest.split(":", 1)
+        filename = path.rsplit("/", 1)[-1] or path
+        return f"{filename} @ {sha[:7]}"
+    return f"@ {rest[:7]}"
+
+
+def _render_contract_card(contract: dict, plugin: dict) -> list[str]:
+    """Return HTML lines for the skill contract card (spec-sheet aesthetic)."""
+
+    lines: list[str] = []
+
+    version = _esc(str(contract.get("version") or "").strip())
+    problem = str(contract.get("problem_statement") or "").strip()
+
+    source = plugin.get("source") or {}
+    base_url: str | None = None
+    ref_name = "main"
+    if isinstance(source, dict) and source.get("type") in ("github", "git"):
+        try:
+            base_url = source_browse_url(source)
+            ref_name = source.get("ref") or "main"
+        except (KeyError, ValueError):
+            base_url = None
+
+    lines.append('<div class="skill-contract">')
+    lines.append('  <header class="skill-contract__header">')
+    lines.append('    <span class="skill-contract__eyebrow">Skill Contract</span>')
+    if version:
+        lines.append(f'    <span class="skill-contract__version">{version}</span>')
+    lines.append('  </header>')
+    if problem:
+        lines.append(
+            f'  <p class="skill-contract__lede">{_esc(problem)}</p>'
+        )
+
+    # §01 IDENTITY — functions + success conditions
+    functions = _string_list(contract.get("functions"))
+    success = _string_list(contract.get("success_conditions"))
+    if functions or success:
+        lines.append('  <section class="skill-contract__section" data-section="01">')
+        lines.append(
+            '    <h3 class="skill-contract__section-title">'
+            '<span class="skill-contract__section-name">Identity</span>'
+            '</h3>'
+        )
+        if functions:
+            lines.append('    <div class="skill-contract__row">')
+            lines.append('      <span class="skill-contract__field">Functions</span>')
+            lines.append('      <div class="skill-contract__inline">')
+            for fn in functions:
+                lines.append(
+                    f'        <span class="skill-contract__chip skill-contract__chip--function">{_esc(fn)}</span>'
+                )
+            lines.append('      </div>')
+            lines.append('    </div>')
+        if success:
+            lines.append('    <div class="skill-contract__row">')
+            lines.append('      <span class="skill-contract__field">Success</span>')
+            lines.append('      <ul class="skill-contract__list">')
+            for cond in success:
+                lines.append(f'        <li>{_esc(cond)}</li>')
+            lines.append('      </ul>')
+            lines.append('    </div>')
+        lines.append('  </section>')
+
+    # §02 OPTIMIZATION TARGETS — metrics as compact spec rows
+    metrics = contract_metrics_as_dicts(contract.get("metrics"))
+    if metrics:
+        lines.append('  <section class="skill-contract__section" data-section="02">')
+        lines.append(
+            '    <h3 class="skill-contract__section-title">'
+            '<span class="skill-contract__section-name">Optimization Targets</span>'
+            '</h3>'
+        )
+        lines.append('    <div class="skill-contract__metrics">')
+        for m in metrics:
+            metric_id = _esc(m.get("id", ""))
+            measure = str(m.get("measure") or "").strip()
+            ref_val = m.get("rubric_ref") or m.get("verifier_ref")
+            lines.append('      <div class="skill-contract__metric">')
+            lines.append(f'        <code class="skill-contract__metric-id">{metric_id}</code>')
+            if measure:
+                lines.append(
+                    f'        <span class="skill-contract__measure skill-contract__measure--{_esc(measure)}">{_esc(measure)}</span>'
+                )
+            else:
+                lines.append('        <span class="skill-contract__measure-placeholder"></span>')
+            if ref_val:
+                url = _parse_contract_ref_url(ref_val)
+                label = _short_contract_ref_label(ref_val)
+                title_attr = _esc(str(ref_val))
+                if url:
+                    lines.append(
+                        f'        <a class="skill-contract__ref" href="{_esc(url)}" title="{title_attr}">'
+                        f'{_esc(label)}<span class="skill-contract__ref-arrow" aria-hidden="true">→</span></a>'
+                    )
+                else:
+                    lines.append(
+                        f'        <span class="skill-contract__ref" title="{title_attr}">{_esc(label)}</span>'
+                    )
+            else:
+                lines.append('        <span class="skill-contract__ref-placeholder"></span>')
+            lines.append('      </div>')
+        lines.append('    </div>')
+        lines.append('  </section>')
+
+    # §03 INVARIANTS — must_preserve + fixed_context
+    invariants = mapping_if_dict(contract.get("invariants"))
+    if invariants:
+        must = _string_list(invariants.get("must_preserve"))
+        fixed = mapping_if_dict(invariants.get("fixed_context")) or {}
+        tools = _string_list(fixed.get("tools"))
+        cli = _string_list(fixed.get("cli"))
+        documents = _string_list(fixed.get("documents"))
+        kinputs = [
+            item for item in sequence_as_list(fixed.get("knowledge_inputs"))
+            if isinstance(item, dict)
+        ]
+
+        if must or tools or cli or documents or kinputs:
+            lines.append('  <section class="skill-contract__section" data-section="03">')
+            lines.append(
+                '    <h3 class="skill-contract__section-title">'
+                '<span class="skill-contract__section-name">Invariants</span>'
+                '</h3>'
+            )
+            if must:
+                lines.append('    <div class="skill-contract__row">')
+                lines.append('      <span class="skill-contract__field">Must Not</span>')
+                lines.append('      <ul class="skill-contract__list">')
+                for item in must:
+                    lines.append(f'        <li>{_esc(item)}</li>')
+                lines.append('      </ul>')
+                lines.append('    </div>')
+
+            # Fixed context — tools / cli / documents / knowledge rendered as
+            # one recessed code block (config-style), so the literal identifier
+            # lists read as a single contained surface instead of loose tokens.
+            def _code_line(key: str, value_html: str) -> str:
+                return (
+                    '      <div class="skill-contract__code-line">'
+                    f'<span class="skill-contract__code-key">{_esc(key)}</span>'
+                    f'<span class="skill-contract__code-val">{value_html}</span>'
+                    '</div>'
+                )
+
+            code_lines: list[str] = []
+            if tools:
+                code_lines.append(_code_line("tools", ", ".join(_esc(t) for t in tools)))
+            if cli:
+                code_lines.append(_code_line("cli", ", ".join(_esc(c) for c in cli)))
+            if documents:
+                code_lines.append(_code_line("documents", ", ".join(_esc(d) for d in documents)))
+            if kinputs:
+                parts = []
+                for ki in kinputs:
+                    kind = _esc(ki.get("kind", "unknown"))
+                    privacy = str(ki.get("privacy") or "unknown").strip() or "unknown"
+                    parts.append(
+                        f'{kind}<span class="skill-contract__privacy">{_esc(privacy)}</span>'
+                    )
+                code_lines.append(_code_line("knowledge", ", ".join(parts)))
+
+            if code_lines:
+                lines.append('    <div class="skill-contract__row">')
+                lines.append('      <span class="skill-contract__field">Fixed Context</span>')
+                lines.append('      <div class="skill-contract__code">')
+                lines.extend(code_lines)
+                lines.append('      </div>')
+                lines.append('    </div>')
+
+            lines.append('  </section>')
+
+    # §04 TRACEABILITY — source_assertions
+    source_assertions = mapping_if_dict(contract.get("source_assertions"))
+    if source_assertions:
+        skill_path_val = str(source_assertions.get("skill_path") or "").strip()
+        supp = _string_list(source_assertions.get("supporting_paths"))
+        if skill_path_val or supp:
+            lines.append('  <section class="skill-contract__section" data-section="04">')
+            lines.append(
+                '    <h3 class="skill-contract__section-title">'
+                '<span class="skill-contract__section-name">Traceability</span>'
+                '</h3>'
+            )
+
+            def _path_markup(path: str) -> str:
+                path_esc = _esc(path)
+                if base_url:
+                    href = f"{base_url}/blob/{_esc(ref_name)}/{path_esc}"
+                    return (
+                        f'<a class="skill-contract__path" href="{href}">'
+                        '<span class="skill-contract__ref-arrow" aria-hidden="true">↗</span>'
+                        f'<code>{path_esc}</code></a>'
+                    )
+                return f'<code class="skill-contract__mono">{path_esc}</code>'
+
+            if skill_path_val:
+                lines.append('    <div class="skill-contract__row">')
+                lines.append('      <span class="skill-contract__field">Skill</span>')
+                lines.append(f'      <div class="skill-contract__inline">{_path_markup(skill_path_val)}</div>')
+                lines.append('    </div>')
+            if supp:
+                lines.append('    <div class="skill-contract__row">')
+                lines.append('      <span class="skill-contract__field">Supporting</span>')
+                lines.append('      <ul class="skill-contract__paths">')
+                for path in supp:
+                    lines.append(f'        <li>{_path_markup(path)}</li>')
+                lines.append('      </ul>')
+                lines.append('    </div>')
+            lines.append('  </section>')
+
+    lines.append('</div>')
+    return lines
+
+
 def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
                         plugin_dir: Path | None = None) -> str:
     sname = skill["name"]
@@ -544,84 +799,8 @@ def generate_skill_page(skill: dict, plugin: dict, enrichment: dict | None,
     if contract:
         lines.append("## Contract")
         lines.append("")
-        lines.append('!!! info "Skill Contract"')
+        lines.extend(_render_contract_card(contract, plugin))
         lines.append("")
-        version = contract.get("version")
-        version_txt = "" if version is None else str(version)
-        lines.append(f"    **Version**: `{version_txt}`")
-        lines.append("")
-        problem_statement = contract.get("problem_statement")
-        if isinstance(problem_statement, str) and problem_statement.strip():
-            lines.append(f"    **Problem Statement**: {problem_statement.strip()}")
-            lines.append("")
-        functions = _string_list(contract.get("functions"))
-        lines.append("    **Functions:**")
-        lines.append("")
-        _append_contract_bullets(lines, functions, format_item=_format_contract_function)
-        lines.append("")
-        lines.append("    **Metrics:**")
-        lines.append("")
-        metric_entries = contract_metrics_as_dicts(contract.get("metrics"))
-        _append_contract_bullets(
-            lines, metric_entries, format_item=_format_contract_metric
-        )
-        lines.append("")
-        success_conditions = _string_list(contract.get("success_conditions"))
-        lines.append("    **Success Conditions:**")
-        lines.append("")
-        _append_contract_bullets(lines, success_conditions)
-        lines.append("")
-        invariants = mapping_if_dict(contract.get("invariants"))
-        if invariants:
-            lines.append("    **Must Preserve:**")
-            lines.append("")
-            must_preserve = _string_list(invariants.get("must_preserve"))
-            _append_contract_bullets(lines, must_preserve)
-            lines.append("")
-            fixed_context = mapping_if_dict(invariants.get("fixed_context"))
-            if fixed_context:
-                lines.append("    **Fixed Context:**")
-                lines.append("")
-                tools = _string_list(fixed_context.get("tools"))
-                cli = _string_list(fixed_context.get("cli"))
-                documents = _string_list(fixed_context.get("documents"))
-                knowledge_inputs = [
-                    _knowledge_input_label(item)
-                    for item in sequence_as_list(fixed_context.get("knowledge_inputs"))
-                    if isinstance(item, dict)
-                ]
-                lines.append(
-                    "    - **Tools**: "
-                    + (", ".join(f"`{value}`" for value in tools) if tools else "—")
-                )
-                lines.append(
-                    "    - **CLI**: "
-                    + (", ".join(f"`{value}`" for value in cli) if cli else "—")
-                )
-                lines.append(
-                    "    - **Documents**: "
-                    + (", ".join(f"`{value}`" for value in documents) if documents else "—")
-                )
-                lines.append(
-                    "    - **Knowledge Inputs**: "
-                    + (", ".join(knowledge_inputs) if knowledge_inputs else "—")
-                )
-                lines.append("")
-        source_assertions = mapping_if_dict(contract.get("source_assertions"))
-        if source_assertions:
-            lines.append("    **Source Assertions:**")
-            lines.append("")
-            skill_path = source_assertions.get("skill_path")
-            if isinstance(skill_path, str) and skill_path.strip():
-                lines.append(f"    - **Skill Path**: `{skill_path.strip()}`")
-            else:
-                lines.append("    - **Skill Path**: —")
-            supporting_paths = _string_list(source_assertions.get("supporting_paths"))
-            lines.append(
-                "    - **Supporting Paths**: "
-                + (", ".join(f"`{value}`" for value in supporting_paths) if supporting_paths else "—")
-            )
-            lines.append("")
 
     # Skill diagram (only if SVG exists)
     if plugin_dir and (plugin_dir / f"{sname}.svg").exists():

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -104,36 +104,6 @@ def _string_list(items) -> list[str]:
     return [item.strip() for item in items if isinstance(item, str) and item.strip()]
 
 
-def _knowledge_input_label(item: dict) -> str:
-    kind = item.get("kind")
-    privacy = item.get("privacy")
-    if kind and privacy:
-        return f"`{kind}` ({privacy})"
-    if kind:
-        return f"`{kind}`"
-    return "`unknown`"
-
-
-def _format_contract_function(value: str) -> str:
-    description = CANONICAL_FUNCTION_DOCS.get(value)
-    if description:
-        return f"`{value}`: {description}"
-    return f"`{value}`"
-
-
-def _append_contract_bullets(
-    lines: list[str],
-    items: list,
-    *,
-    format_item=str,
-) -> None:
-    if items:
-        for item in items:
-            lines.append(f"    - {format_item(item)}")
-    else:
-        lines.append("    - —")
-
-
 def _append_code_block(
     lines: list[str],
     block_lines: list[str],
@@ -161,45 +131,6 @@ def _append_code_block(
     lines.append(fence)
     lines.extend(rendered_lines)
     lines.append(fence_ticks)
-
-
-def _format_contract_metric(metric: dict) -> str:
-    metric_id = str(metric["id"])
-    header = f"`{metric_id}`"
-
-    measure = metric.get("measure")
-    if isinstance(measure, str) and measure.strip():
-        header += f" (`{measure.strip()}`)"
-
-    details: list[str] = []
-    metadata = CANONICAL_METRIC_DOCS.get(metric_id)
-    if metadata:
-        details.append(metadata["summary"])
-        details.append(f"Guidance: {metadata['measure_guidance']}")
-
-    for key, label in (
-        ("target_measure", "Target measure"),
-        ("success_mode", "Success mode"),
-    ):
-        value = metric.get(key)
-        if isinstance(value, str) and value.strip():
-            details.append(f"{label}: `{value.strip()}`")
-
-    references = []
-    for ref_key in ("rubric_ref", "verifier_ref", "calibration_ref"):
-        ref_value = metric.get(ref_key)
-        if isinstance(ref_value, str) and ref_value.strip():
-            references.append(f"{ref_key}=`{ref_value.strip()}`")
-    if references:
-        details.append("References: " + ", ".join(references))
-
-    trials = metric.get("trials")
-    if isinstance(trials, int):
-        details.append(f"Trials: `{trials}`")
-
-    if details:
-        return f"{header}: " + " ".join(details)
-    return header
 
 
 def clean_generated(output_dir: Path):
@@ -742,7 +673,7 @@ def _render_contract_card(contract: dict, plugin: dict) -> list[str]:
             def _path_markup(path: str) -> str:
                 path_esc = _esc(path)
                 if base_url:
-                    href = f"{base_url}/blob/{_esc(ref_name)}/{path_esc}"
+                    href = f"{_esc(base_url)}/blob/{_esc(ref_name)}/{path_esc}"
                     return (
                         f'<a class="skill-contract__path" href="{href}">'
                         '<span class="skill-contract__ref-arrow" aria-hidden="true">↗</span>'

--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -625,3 +625,469 @@ label.md-nav__link--active {
   color: var(--md-primary-fg-color);
   font-weight: 600;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+ * Skill contract card
+ * Aesthetic: technical spec sheet × engineering manifest.
+ * Structured clauses (§01-§04) with left-spine accents per section.
+ * Monospace-forward for identifiers. Semantic measure badges +
+ * short-SHA GitHub links replace walls of text.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+.md-typeset .skill-contract {
+  position: relative;
+  max-width: 62rem;
+  margin: 1.4em 0;
+  padding: 1.1rem 1.4rem 0.9rem;
+  background: var(--sr-surface-raised);
+  border: 1px solid var(--sr-border);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--sr-text);
+}
+
+/* Header */
+.md-typeset .skill-contract__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding-bottom: 0.55rem;
+  margin-bottom: 0.7rem;
+  border-bottom: 1px solid var(--sr-border);
+}
+
+.md-typeset .skill-contract__eyebrow {
+  font-family: var(--md-code-font);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--sr-text-dim);
+  font-weight: 600;
+}
+
+.md-typeset .skill-contract__version {
+  font-family: var(--md-code-font);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--sr-text-dim);
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+/* Problem statement — the "abstract" of the spec */
+.md-typeset .skill-contract__lede {
+  margin: 0 0 0.95rem 0;
+  padding: 0;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  font-style: italic;
+  color: var(--sr-text);
+  font-family: var(--md-text-font);
+  font-weight: 400;
+}
+
+.md-typeset .skill-contract__lede::before {
+  content: "\201C";
+  color: var(--sr-text-dim);
+  font-size: 1.4em;
+  line-height: 0;
+  vertical-align: -0.28em;
+  margin-right: 0.1em;
+  opacity: 0.75;
+}
+
+.md-typeset .skill-contract__lede::after {
+  content: "\201D";
+  color: var(--sr-text-dim);
+  font-size: 1.4em;
+  line-height: 0;
+  vertical-align: -0.28em;
+  margin-left: 0.05em;
+  opacity: 0.75;
+}
+
+/* Sections — no top border; the section title's trailing rule is the divider. */
+.md-typeset .skill-contract__section {
+  position: relative;
+  padding: 0;
+  margin: 1.25rem 0 0 0;
+  background: none;
+}
+
+.md-typeset .skill-contract__section:first-of-type {
+  margin-top: 0.6rem;
+}
+
+/* Section title — editorial clause header: NAME followed by a hairline
+   that runs to the card edge, framing each section across the full width. */
+.md-typeset .skill-contract__section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 0 0 0.7rem 0;
+  padding: 0;
+  border: none;
+  font-family: var(--md-code-font);
+  font-size: 0.66rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--sr-heading);
+}
+
+.md-typeset .skill-contract__section-title::before {
+  content: none !important;
+}
+
+.md-typeset .skill-contract__section-title::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: color-mix(in oklab, var(--sr-text-dim) 55%, transparent);
+}
+
+.md-typeset .skill-contract__section-name {
+  color: inherit;
+  flex: 0 0 auto;
+}
+
+/* Field row: two-column grid — labels and values align across the whole card.
+   Column 1 fits the longest metric id (evidence_completeness) snugly. */
+.md-typeset .skill-contract__row {
+  display: grid;
+  grid-template-columns: 10.5rem 1fr;
+  gap: 1.1rem;
+  padding: 0.15rem 0;
+  align-items: baseline;
+}
+
+.md-typeset .skill-contract__row:first-of-type {
+  padding-top: 0;
+}
+
+.md-typeset .skill-contract__field {
+  font-family: var(--md-code-font);
+  font-size: 0.58rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  color: var(--sr-text-dim);
+  padding-top: 0.1rem;
+}
+
+/* Inline value area — chips, code, links */
+/* Inline value area — tokens flow as prose and wrap naturally. Multiple
+   mono tokens (tools, cli, documents) are joined by middot separators so
+   they read as one delimited list, not a loose scatter. */
+.md-typeset .skill-contract__inline {
+  display: block;
+  line-height: 1.9;
+}
+
+.md-typeset .skill-contract__inline .skill-contract__mono:not(:last-child)::after {
+  content: ",";
+  color: var(--sr-text-dim);
+  margin-right: 0.35em;
+  font-weight: 400;
+}
+
+/* Lists inside rows — nuclear reset of Material's default ul/li so
+   bullets and paths align exactly with the value column. Any padding
+   or margin on ul/li inside the contract card is stripped. */
+.md-typeset .skill-contract ul {
+  margin: 0 !important;
+  padding: 0 !important;
+  padding-inline-start: 0 !important;
+  list-style: none !important;
+}
+
+.md-typeset .skill-contract li {
+  margin: 0 !important;
+  padding: 0;
+  list-style: none !important;
+}
+
+.md-typeset .skill-contract li::marker {
+  content: "";
+}
+
+.md-typeset .skill-contract .skill-contract__list li {
+  position: relative;
+  padding-left: 0.9rem !important;
+  margin: 0.1rem 0 !important;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.md-typeset .skill-contract__list li::before {
+  content: "\2022"; /* • bullet */
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--sr-text-dim);
+  font-size: 1em;
+}
+
+/* Value tokens — plain monospace text, no box, neutral color. Tools, cli,
+   documents, functions, and knowledge inputs are supporting detail: they
+   read as quiet inline code, not bright-blue attention-grabbers. */
+.md-typeset .skill-contract .skill-contract__mono,
+.md-typeset .skill-contract .skill-contract__knowledge > li {
+  font-family: var(--md-code-font);
+  font-size: 0.72rem;
+  font-weight: 400;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--sr-text);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+/* Function tag — canonical enum value (the published job). Subtle bordered
+   pill, matching the measure badge, to set it apart from plain tokens. */
+.md-typeset .skill-contract .skill-contract__chip--function {
+  display: inline-block;
+  font-family: var(--md-code-font);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 0.15em 0.55em;
+  border: 1px solid var(--sr-border);
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--sr-text-dim) 12%, transparent);
+  color: var(--sr-text);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+/* Metric row — three explicit tracks so the id never wraps:
+   [id: max-content] [measure: auto] [remaining space] [ref right-aligned] */
+.md-typeset .skill-contract__metrics {
+  display: grid;
+  gap: 0.25rem;
+}
+
+/* Metric row — 13rem key column (aligns with FUNCTIONS/SUCCESS/TOOLS
+   labels above), measure column sized to content (max-content so the
+   badge never stretches), ref takes the rest. */
+.md-typeset .skill-contract__metric {
+  display: grid;
+  grid-template-columns: 10.5rem max-content 1fr;
+  align-items: center;
+  gap: 1.1rem;
+  padding: 0.15rem 0;
+}
+
+/* Never let grid children stretch to fill their track. */
+.md-typeset .skill-contract__metric > * {
+  justify-self: start;
+}
+
+/* Metric ID — same style as field row labels for visual consistency. */
+.md-typeset .skill-contract__metric-id {
+  font-family: var(--md-code-font);
+  font-size: 0.58rem;
+  color: var(--sr-text-dim);
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  white-space: nowrap;
+}
+
+/* Measure badge — the one intentional pill: a subtle bordered tag that
+   marks the metric's measurement method (judge / deterministic / …). */
+.md-typeset .skill-contract .skill-contract__measure {
+  font-family: var(--md-code-font);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.15em 0.5em;
+  border: 1px solid var(--sr-border);
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--sr-text-dim) 12%, transparent);
+  color: var(--sr-text-dim);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.md-typeset .skill-contract__measure-placeholder {
+  display: inline-block;
+  width: 0;
+}
+
+/* Ref link — right-aligned short-SHA callout */
+.md-typeset .skill-contract__ref {
+  font-family: var(--md-code-font);
+  font-size: 0.7rem;
+  color: var(--sr-text-dim);
+  text-decoration: none;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  transition: color 0.15s ease;
+}
+
+.md-typeset .skill-contract__ref:hover {
+  color: var(--sr-blue);
+  text-decoration: none;
+}
+
+.md-typeset .skill-contract__ref-arrow {
+  display: inline-block;
+  opacity: 0.55;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.md-typeset .skill-contract__ref:hover .skill-contract__ref-arrow,
+.md-typeset .skill-contract__path:hover .skill-contract__ref-arrow {
+  opacity: 1;
+  transform: translateX(2px);
+}
+
+.md-typeset .skill-contract__ref-placeholder {
+  display: inline-block;
+  width: 0;
+}
+
+/* Path link — traceability */
+.md-typeset .skill-contract__path {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  color: var(--sr-text);
+  text-decoration: none;
+  font-size: 0.78rem;
+  transition: color 0.15s ease;
+}
+
+.md-typeset .skill-contract__path:hover {
+  color: var(--sr-blue);
+}
+
+.md-typeset .skill-contract__path code {
+  font-size: 0.72rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+}
+
+.md-typeset .skill-contract .skill-contract__paths li {
+  margin: 0.12rem 0 !important;
+  padding: 0;
+}
+
+/* Fixed context — a single recessed code well holding the literal
+   identifier lists (tools / cli / documents / knowledge) as config lines.
+   Contains the long MCP tool names in one contained surface. */
+.md-typeset .skill-contract__code {
+  font-family: var(--md-code-font);
+  font-size: 0.66rem;
+  line-height: 1.7;
+  color: var(--sr-text);
+  background: var(--sr-code-bg);
+  border: 1px solid var(--sr-border);
+  border-radius: 5px;
+  padding: 0.5rem 0.7rem;
+  overflow-wrap: anywhere;
+}
+
+.md-typeset .skill-contract__code-line {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: 0.6rem;
+  padding: 0.12rem 0;
+  align-items: baseline;
+}
+
+.md-typeset .skill-contract__code-key {
+  color: var(--sr-text-dim);
+  font-weight: 500;
+}
+
+.md-typeset .skill-contract__code-key::after {
+  content: ":";
+  opacity: 0.5;
+}
+
+.md-typeset .skill-contract__code-val {
+  color: var(--sr-text);
+}
+
+/* Dark mode — lift the pill borders above the near-invisible --sr-border
+   so the function tag and measure badge read as crisp outlined chips. */
+[data-md-color-scheme="slate"] .md-typeset .skill-contract .skill-contract__chip--function,
+[data-md-color-scheme="slate"] .md-typeset .skill-contract .skill-contract__measure {
+  border-color: color-mix(in oklab, var(--sr-text-dim) 55%, transparent);
+}
+
+/* Privacy tag inside a knowledge value — dim uppercase, trailing the kind. */
+.md-typeset .skill-contract__privacy {
+  font-size: 0.82em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--sr-text-dim);
+  margin-left: 0.35em;
+}
+
+/* Fade-up entrance — subtle, once per view */
+@media (prefers-reduced-motion: no-preference) {
+  .md-typeset .skill-contract {
+    animation: sr-contract-fade 0.55s ease-out both;
+  }
+  .md-typeset .skill-contract__section {
+    animation: sr-contract-slide 0.45s ease-out both;
+    animation-delay: calc(0.06s * var(--sr-section-idx, 0) + 0.15s);
+  }
+  .md-typeset .skill-contract__section[data-section="01"] { --sr-section-idx: 1; }
+  .md-typeset .skill-contract__section[data-section="02"] { --sr-section-idx: 2; }
+  .md-typeset .skill-contract__section[data-section="03"] { --sr-section-idx: 3; }
+  .md-typeset .skill-contract__section[data-section="04"] { --sr-section-idx: 4; }
+}
+
+@keyframes sr-contract-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes sr-contract-slide {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* Responsive: stack row label above value on narrow screens */
+@media (max-width: 42em) {
+  .md-typeset .skill-contract {
+    padding: 1.2rem 1.1rem 1rem;
+  }
+  .md-typeset .skill-contract__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .md-typeset .skill-contract__row {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+  .md-typeset .skill-contract__field {
+    padding-top: 0;
+  }
+  .md-typeset .skill-contract__metric {
+    grid-template-columns: 1fr auto;
+    row-gap: 0.4rem;
+  }
+  .md-typeset .skill-contract__ref {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+}

--- a/site/docs/plugins/assess-rfe/assess-rfe.md
+++ b/site/docs/plugins/assess-rfe/assess-rfe.md
@@ -22,43 +22,80 @@ what-if analysis, and near-miss identification).
 
 ## Contract
 
-!!! info "Skill Contract"
-
-    **Version**: `canonical-skill-v1`
-
-    **Problem Statement**: Score an RFE against the published rubric and explain the result.
-
-    **Functions:**
-
-    - `review`: Assess an artifact against expectations and identify issues, risks, or fit.
-
-    **Metrics:**
-
-    - `task_success` (`judge`): Whether the skill completes the intended job correctly for the task. Guidance: Prefer deterministic or verifier-backed checks; use judge only as a fallback. References: rubric_ref=`opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md`
-    - `evidence_completeness` (`judge`): Whether claims and verdicts are backed by enough concrete evidence. Guidance: Use verifier-backed checks when evidence can be counted; otherwise use a rubric-backed judge. References: rubric_ref=`opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md`
-    - `output_quality` (`judge`): Human-judged quality of the final artifact when deterministic checks are insufficient. Guidance: Judge only; always pair it with a stable rubric_ref and, when available, calibration data. References: rubric_ref=`opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md`
-
-    **Success Conditions:**
-
-    - Produces a complete rubric-based assessment for the supplied RFE input.
-    - Includes evidence-backed scoring rationale for each criterion.
-
-    **Must Preserve:**
-
-    - Do not skip rubric criteria or invent unsupported evidence.
-    - Do not change the accepted input modes declared by the skill.
-
-    **Fixed Context:**
-
-    - **Tools**: `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash`, `Agent`, `TaskGet`, `mcp__atlassian__getJiraIssue`, `mcp__atlassian__searchJiraIssuesUsingJql`
-    - **CLI**: `python3`
-    - **Documents**: —
-    - **Knowledge Inputs**: `repository_content` (public), `task_input` (task_private), `tool_output` (task_private)
-
-    **Source Assertions:**
-
-    - **Skill Path**: `skills/assess-rfe/SKILL.md`
-    - **Supporting Paths**: `skills/assess-rfe/scripts/agent_prompt.md`
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Score an RFE against the published rubric and explain the result.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">review</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Produces a complete rubric-based assessment for the supplied RFE input.</li>
+        <li>Includes evidence-backed scoring rationale for each criterion.</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/assess-rfe/blob/a7674fef9a0de4107e3416f05aba2d0b8c019025/skills/assess-rfe/scripts/agent_prompt.md" title="opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md">agent_prompt.md @ a7674fe<span class="skill-contract__ref-arrow" aria-hidden="true">→</span></a>
+      </div>
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">evidence_completeness</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/assess-rfe/blob/a7674fef9a0de4107e3416f05aba2d0b8c019025/skills/assess-rfe/scripts/agent_prompt.md" title="opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md">agent_prompt.md @ a7674fe<span class="skill-contract__ref-arrow" aria-hidden="true">→</span></a>
+      </div>
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">output_quality</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/assess-rfe/blob/a7674fef9a0de4107e3416f05aba2d0b8c019025/skills/assess-rfe/scripts/agent_prompt.md" title="opendatahub-io/assess-rfe@a7674fef9a0de4107e3416f05aba2d0b8c019025:skills/assess-rfe/scripts/agent_prompt.md">agent_prompt.md @ a7674fe<span class="skill-contract__ref-arrow" aria-hidden="true">→</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Not</span>
+      <ul class="skill-contract__list">
+        <li>Do not skip rubric criteria or invent unsupported evidence.</li>
+        <li>Do not change the accepted input modes declared by the skill.</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Read, Write, Edit, Glob, Grep, Bash, Agent, TaskGet, mcp__atlassian__getJiraIssue, mcp__atlassian__searchJiraIssuesUsingJql</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">python3</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, task_input<span class="skill-contract__privacy">task_private</span>, tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/assess-rfe/blob/main/skills/assess-rfe/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/assess-rfe/SKILL.md</code></a></div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Supporting</span>
+      <ul class="skill-contract__paths">
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/assess-rfe/blob/main/skills/assess-rfe/scripts/agent_prompt.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/assess-rfe/scripts/agent_prompt.md</code></a></li>
+      </ul>
+    </div>
+  </section>
+</div>
 
 ## Diagram
 

--- a/site/docs/plugins/assess-rfe/export-rubric.md
+++ b/site/docs/plugins/assess-rfe/export-rubric.md
@@ -17,42 +17,75 @@ understand how RFEs are evaluated.
 
 ## Contract
 
-!!! info "Skill Contract"
-
-    **Version**: `canonical-skill-v1`
-
-    **Problem Statement**: Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md in the current working directory.
-
-    **Functions:**
-
-    - `generate`: Produce a new artifact for the user or another tool to consume.
-
-    **Metrics:**
-
-    - `task_success` (`deterministic`): Whether the skill completes the intended job correctly for the task. Guidance: Prefer deterministic or verifier-backed checks; use judge only as a fallback.
-    - `latency` (`deterministic`): How quickly the skill produces the final usable result. Guidance: Deterministic only; measure elapsed wall-clock time for the user-visible outcome.
-
-    **Success Conditions:**
-
-    - Writes artifacts/rfe-rubric.md under the current working directory.
-    - Confirms the file was written and prints its path.
-
-    **Must Preserve:**
-
-    - Do not modify the rubric content while exporting it.
-    - Do not redirect the export to a path other than artifacts/rfe-rubric.md under the invocation working directory.
-
-    **Fixed Context:**
-
-    - **Tools**: `Read`, `Write`, `Bash`
-    - **CLI**: `python3`
-    - **Documents**: —
-    - **Knowledge Inputs**: `repository_content` (public), `task_input` (task_private)
-
-    **Source Assertions:**
-
-    - **Skill Path**: `skills/export-rubric/SKILL.md`
-    - **Supporting Paths**: `skills/export-rubric/scripts/export_rubric.py`
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Export the assess-rfe scoring rubric to artifacts/rfe-rubric.md in the current working directory.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">generate</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Writes artifacts/rfe-rubric.md under the current working directory.</li>
+        <li>Confirms the file was written and prints its path.</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--deterministic">deterministic</span>
+        <span class="skill-contract__ref-placeholder"></span>
+      </div>
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">latency</code>
+        <span class="skill-contract__measure skill-contract__measure--deterministic">deterministic</span>
+        <span class="skill-contract__ref-placeholder"></span>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Not</span>
+      <ul class="skill-contract__list">
+        <li>Do not modify the rubric content while exporting it.</li>
+        <li>Do not redirect the export to a path other than artifacts/rfe-rubric.md under the invocation working directory.</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Read, Write, Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">python3</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/assess-rfe/blob/main/skills/export-rubric/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/export-rubric/SKILL.md</code></a></div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Supporting</span>
+      <ul class="skill-contract__paths">
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/assess-rfe/blob/main/skills/export-rubric/scripts/export_rubric.py"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/export-rubric/scripts/export_rubric.py</code></a></li>
+      </ul>
+    </div>
+  </section>
+</div>
 
 ## Diagram
 

--- a/site/docs/plugins/pipeline-skills/pipeline-grouping.md
+++ b/site/docs/plugins/pipeline-skills/pipeline-grouping.md
@@ -31,41 +31,70 @@ reuse an existing ticket instead of filing a duplicate.
 
 ## Contract
 
-!!! info "Skill Contract"
-
-    **Version**: `canonical-skill-v1`
-
-    **Problem Statement**: Read preprocessed error files for all failed jobs, identify distinct failure patterns, and group jobs by shared root cause into grouping.json.
-
-    **Functions:**
-
-    - `analyze`: Interpret inputs to extract structure, meaning, or implications.
-
-    **Metrics:**
-
-    - `task_success` (`deterministic`): Whether the skill completes the intended job correctly for the task. Guidance: Prefer deterministic or verifier-backed checks; use judge only as a fallback.
-
-    **Success Conditions:**
-
-    - Produces grouping.json with all expected job IDs assigned to groups.
-    - Each group has a human-readable summary and representative error messages.
-
-    **Must Preserve:**
-
-    - Every expected job ID must appear in exactly one group.
-    - Do not modify job trace logs or error files.
-
-    **Fixed Context:**
-
-    - **Tools**: `Read`, `Bash`, `Grep`, `Glob`
-    - **CLI**: `python3`
-    - **Documents**: —
-    - **Knowledge Inputs**: `task_input` (task_private)
-
-    **Source Assertions:**
-
-    - **Skill Path**: `skills/pipeline-grouping/SKILL.md`
-    - **Supporting Paths**: `skills/pipeline-grouping/scripts/grouper.py`
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Read preprocessed error files for all failed jobs, identify distinct failure patterns, and group jobs by shared root cause into grouping.json.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Produces grouping.json with all expected job IDs assigned to groups.</li>
+        <li>Each group has a human-readable summary and representative error messages.</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--deterministic">deterministic</span>
+        <span class="skill-contract__ref-placeholder"></span>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Not</span>
+      <ul class="skill-contract__list">
+        <li>Every expected job ID must appear in exactly one group.</li>
+        <li>Do not modify job trace logs or error files.</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Read, Bash, Grep, Glob</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">python3</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-grouping/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-grouping/SKILL.md</code></a></div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Supporting</span>
+      <ul class="skill-contract__paths">
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-grouping/scripts/grouper.py"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-grouping/scripts/grouper.py</code></a></li>
+      </ul>
+    </div>
+  </section>
+</div>
 
 ## Diagram
 

--- a/site/docs/plugins/pipeline-skills/pipeline-rca.md
+++ b/site/docs/plugins/pipeline-skills/pipeline-rca.md
@@ -34,41 +34,73 @@ per-group report.
 
 ## Contract
 
-!!! info "Skill Contract"
-
-    **Version**: `canonical-skill-v1`
-
-    **Problem Statement**: Investigate the root cause of a CI/CD failure group by analyzing trace logs, source code, and build artifacts. Produce structured section files and a finding.json with classification metadata.
-
-    **Functions:**
-
-    - `analyze`: Interpret inputs to extract structure, meaning, or implications.
-
-    **Metrics:**
-
-    - `task_success` (`deterministic`): Whether the skill completes the intended job correctly for the task. Guidance: Prefer deterministic or verifier-backed checks; use judge only as a fallback.
-
-    **Success Conditions:**
-
-    - Produces finding.json with all required fields valid against the schema.
-    - Produces sections/error-overview.md and sections/root-cause.md.
-
-    **Must Preserve:**
-
-    - Do not fabricate log lines or error messages not present in the evidence.
-    - Redact credentials, tokens, and API keys in all output.
-
-    **Fixed Context:**
-
-    - **Tools**: `Read`, `Bash`, `Grep`, `Glob`
-    - **CLI**: `python3`, `git`, `glab`
-    - **Documents**: —
-    - **Knowledge Inputs**: `repository_content` (public), `task_input` (task_private)
-
-    **Source Assertions:**
-
-    - **Skill Path**: `skills/pipeline-rca/SKILL.md`
-    - **Supporting Paths**: `skills/pipeline-rca/references/finding.schema.json`, `skills/pipeline-rca/references/error-overview-section-template.md`, `skills/pipeline-rca/references/rca-section-template.md`, `skills/pipeline-rca/references/resolution-section-template.md`
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Investigate the root cause of a CI/CD failure group by analyzing trace logs, source code, and build artifacts. Produce structured section files and a finding.json with classification metadata.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Produces finding.json with all required fields valid against the schema.</li>
+        <li>Produces sections/error-overview.md and sections/root-cause.md.</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--deterministic">deterministic</span>
+        <span class="skill-contract__ref-placeholder"></span>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Not</span>
+      <ul class="skill-contract__list">
+        <li>Do not fabricate log lines or error messages not present in the evidence.</li>
+        <li>Redact credentials, tokens, and API keys in all output.</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Read, Bash, Grep, Glob</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">python3, git, glab</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-rca/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-rca/SKILL.md</code></a></div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Supporting</span>
+      <ul class="skill-contract__paths">
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-rca/references/finding.schema.json"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-rca/references/finding.schema.json</code></a></li>
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-rca/references/error-overview-section-template.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-rca/references/error-overview-section-template.md</code></a></li>
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-rca/references/rca-section-template.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-rca/references/rca-section-template.md</code></a></li>
+        <li><a class="skill-contract__path" href="https://github.com/opendatahub-io/pipeline-skills/blob/main/skills/pipeline-rca/references/resolution-section-template.md"><span class="skill-contract__ref-arrow" aria-hidden="true">↗</span><code>skills/pipeline-rca/references/resolution-section-template.md</code></a></li>
+      </ul>
+    </div>
+  </section>
+</div>
 
 ## Diagram
 

--- a/tests/test_generate_site.py
+++ b/tests/test_generate_site.py
@@ -15,24 +15,35 @@ class SiteContractRenderingTests(unittest.TestCase):
 
         for marker in (
             "## Contract",
-            '!!! info "Skill Contract"',
+            'class="skill-contract"',
             "canonical-skill-v1",
+            "Review the artifact.",  # problem_statement rendered as the lede
+            'data-section="01"',
+            'data-section="02"',
+            'data-section="03"',
+            'data-section="04"',
             "task_success",
-            "`review`",
-            "**Problem Statement**",
-            "**Success Conditions:**",
-            "**Metrics:**",
-            "`judge`",
-            "example-org/example-plugin@main:docs/review-rubric.md",
-            "**Must Preserve:**",
-            "**Source Assertions:**",
+            ">review<",  # function chip
+            "skill-contract__measure--judge",
+            "example-org/example-plugin@main:docs/review-rubric.md",  # title attr on ref
+            "review-rubric.md @ main",  # short ref label
+            "Must Not",
+            "Traceability",
             "skills/example-skill/SKILL.md",
         ):
             self.assertIn(marker, page)
-        for old_heading in ("### Problem Statement", "### Metrics"):
-            self.assertNotIn(old_heading, page)
+        # Old admonition/bullet markers should not appear
+        for old_marker in (
+            '!!! info "Skill Contract"',
+            "**Problem Statement**",
+            "**Success Conditions:**",
+            "**Metrics:**",
+            "**Must Preserve:**",
+            "**Source Assertions:**",
+        ):
+            self.assertNotIn(old_marker, page)
         idx_contract = page.index("## Contract")
-        idx_review = page.index("`review`", idx_contract)
+        idx_review = page.index(">review<", idx_contract)
         self.assertGreater(idx_review, idx_contract)
 
     def test_skill_page_omits_contract_when_contract_is_not_mapping(self):


### PR DESCRIPTION
## What

Redesigns the **Contract** section on skill pages (e.g. [`assess-rfe`](https://opendatahub-io.github.io/skills-registry/plugins/assess-rfe/assess-rfe/#contract)) from a flat MkDocs admonition into a bespoke, compact "spec sheet" card.

### Before
- One `!!! info` admonition with 8 sibling bold-label sub-sections.
- Metric bullets concatenated id + measure + full canonical description + measurement guidance + the full 40-char commit SHA (~350 chars each), with the same `rubric_ref` repeated verbatim per metric.
- Flat hierarchy, empty `Documents: —` rows, no links.

### After
- **Four framed clauses** — Identity / Optimization Targets / Invariants / Traceability — each with an editorial section rule.
- **Single aligned key column** — metric ids line up with field labels; values share one column across the whole card.
- **Metric rows** = id + measure badge + short-SHA link to the pinned file on GitHub. Canonical descriptions/guidance dropped (they live in `catalog.md#canonical-contract-system`); 40-char SHAs shortened to 7 and linked.
- **Fixed context** (tools / cli / documents / knowledge) collapsed into one recessed, config-style code well instead of loose token rows — contains the long MCP tool names cleanly.
- **Monochrome palette** — neutral value tokens, outlined function tag + measure badge with a subtle fill, brighter pill borders in dark mode; links are the only accent. Empty fields suppressed. Light/dark + mobile responsive.

## How

- `scripts/generate_site.py` — new `_render_contract_card` plus `_parse_contract_ref_url` / `_short_contract_ref_label` / `_esc` helpers; emits HTML via the already-enabled `md_in_html`. Reuses `source_browse_url` for link bases.
- `site/docs/assets/stylesheets/extra.css` — `.skill-contract` styles reusing existing design tokens.
- `tests/test_generate_site.py` — updated to assert the new markup.
- Regenerated the four contract-carrying skill pages (assess-rfe, export-rubric, pipeline-grouping, pipeline-rca).

## Verification
- `python3 scripts/generate_site.py` (idempotent)
- `python3 -m unittest discover -s tests -p 'test_*.py'` → 127 passing
- `python3 scripts/validate_registry.py` → PASSED
- Previewed via `mkdocs serve` in light/dark and at mobile width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract sections on skill pages now appear in a richer, card-style layout with clearer headings, grouped details, and improved traceability links.
  * Skill contract content is now shown with safer escaping and cleaner formatting for metrics, invariants, and supporting references.

* **Bug Fixes**
  * Improved rendering consistency across documentation pages.
  * Updated contract display tests to match the new visual format and ensure older formatting no longer appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->