### PR TITLE
chore: add shared .claude/settings.json with workflow permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(.tmp/skill-repos/**)",
+      "Read(.tmp/diagram-work/**)",
+      "Edit(site/docs/plugins/**)",
+      "Edit(.tmp/diagram-work/**)",
+      "Bash(python3 *)",
+      "Bash(d2 *)",
+      "Skill(diagram-skills:skill-diagram:*)",
+      "Skill(diagram-skills:diagram-layout:*)",
+      "Skill(skill-diagram:*)",
+      "Skill(diagram-layout:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ site/docs/plugins/*/artifacts/
 *.DS_Store
 scripts/__pycache__/
 site/docs/plugins/*/_discovered.yaml
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

`.claude/settings.json` was never tracked in this repo. This PR adds it as the **team-shared** Claude Code settings file, scoped to the diagram + site-docs workflow, and establishes the shared-vs-local split for permissions.

## What's shared (committed `settings.json`)

Repo-specific workflow grants only:

- `Read(.tmp/skill-repos/**)`, `Read(.tmp/diagram-work/**)`
- `Edit(site/docs/plugins/**)`, `Edit(.tmp/diagram-work/**)`
- `Bash(python3 *)`, `Bash(d2 *)`
- `Skill(diagram-skills:*)` / `Skill(skill-diagram:*)` / `Skill(diagram-layout:*)`

Path rules use `Edit(...)` rather than `Write(...)`: `Write(path)` allow rules are never matched by Claude Code's file permission checks, whereas `Edit(...)` covers all file-editing tools (`Write`, `Edit`, `NotebookEdit`). This also fixes the original warnings:

```
Write(site/docs/plugins/**) is not matched by file permission checks — only Edit(path) rules are.
Write(.tmp/diagram-work/**) is not matched by file permission checks — only Edit(path) rules are.
```

## What stays local (gitignored `settings.local.json`)

Broad, generic shell grants are **not** committed, so they aren't auto-approved for every contributor:

- `Bash(rm *)`, `Bash(cd *)`, `Bash(git clone *)`, `Bash(git pull *)`, `Bash(mkdir *)`, `Bash(mv *)`, `Bash(find *)`, `Bash(cat *)`, `Bash(open *)`, `Bash(ls *)`

`.claude/settings.local.json` is now added to `.gitignore` so personal settings are never accidentally committed.