### PR TITLE
Add productization-skills plugin to registry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -567,12 +567,16 @@
       "license": "Apache-2.0",
       "name": "productization-skills",
       "repository": "https://github.com/opendatahub-io/productization-skills",
+      "skills": [
+        "./productization-plugin/skills"
+      ],
       "source": {
         "ref": "v0.8.1",
         "repo": "opendatahub-io/productization-skills",
         "sha": "86f0ce3f1697bcbe2b849b2770d235deddb16abe",
         "source": "github"
       },
+      "strict": false,
       "version": "0.8.1"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -544,6 +544,36 @@
         "source": "github"
       },
       "version": "0.3.15"
+    },
+    {
+      "author": {
+        "name": "opendatahub-io"
+      },
+      "category": "devops",
+      "description": "Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.\n",
+      "homepage": "https://github.com/opendatahub-io/productization-skills",
+      "keywords": [
+        "gitlab",
+        "aws",
+        "slack",
+        "jira",
+        "konflux",
+        "mapt",
+        "devops",
+        "ci-cd",
+        "cloud",
+        "provisioning"
+      ],
+      "license": "Apache-2.0",
+      "name": "productization-skills",
+      "repository": "https://github.com/opendatahub-io/productization-skills",
+      "source": {
+        "ref": "v0.8.1",
+        "repo": "opendatahub-io/productization-skills",
+        "sha": "86f0ce3f1697bcbe2b849b2770d235deddb16abe",
+        "source": "github"
+      },
+      "version": "0.8.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -562,7 +562,9 @@
         "devops",
         "ci-cd",
         "cloud",
-        "provisioning"
+        "provisioning",
+        "google-workspace",
+        "reporting"
       ],
       "license": "Apache-2.0",
       "name": "productization-skills",

--- a/catalog.md
+++ b/catalog.md
@@ -284,39 +284,6 @@ Tags: pipeline, ci-cd, failure-analysis, grouping, root-cause, gitlab
 /plugin install pipeline-skills@opendatahub-skills
 ```
 
-### productization-skills
-
-Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
-
-v0.8.1 | Apache-2.0 | [opendatahub-io/productization-skills](https://github.com/opendatahub-io/productization-skills)
-
-Tags: gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning
-
-| Skill | Description | Functions | Metrics |
-|-------|-------------|-----------|---------|
-| `/gitlab-job-analyzer` | Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition | `analyze` | `task_success` (`judge`) |
-| `/aws-log-analyzer` | Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring | `analyze` | `task_success` (`judge`) |
-| `/slack-utilities` | Search messages, post updates, and interact with Slack workspaces | `retrieve`, `execute` | `task_success` (`judge`) |
-| `/gitlab-branch-manager` | Create and protect GitLab branches with configurable protection rules | `execute` | `task_success` (`judge`) |
-| `/jira-utilities` | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | `execute` | `task_success` (`judge`) |
-| `/jira-cve-tracker` | CVE deduplication and release-date clustering for Jira issues | `analyze` | `task_success` (`judge`) |
-| `/jira-release-setup` | Set up Jira release versions and manage release workflows | `execute` | `task_success` (`judge`) |
-| `/jira-sprint-manager` | Create sprints and assign issues to sprints on Jira boards | `execute` | `task_success` (`judge`) |
-| `/jira-gap-audit` | Audit Jira releases for gaps in issue coverage | `analyze` | `task_success` (`judge`) |
-| `/mapt-provisioner` | Provision and manage cloud VMs on AWS and Azure using mapt | `execute` | `task_success` (`judge`) |
-| `/konflux-its-analyzer` | Analyze Konflux integration test scenario failures | `analyze` | `task_success` (`judge`) |
-| `/gitlab-code-review` | Structured GitLab merge request code review | `review` | `task_success` (`judge`) |
-| `/slack-webhook` | Post messages to Slack channels via incoming webhooks | `execute` | `task_success` (`judge`) |
-| `/weekly-status` | Generate weekly status reports from project activity | `generate` | `task_success` (`judge`) |
-| `/gws-calendar-reader` | Read Google Calendar events and check free/busy status | `retrieve` | `task_success` (`judge`) |
-| `/gws-doc-action-extractor` | Extract action items from Google Docs | `retrieve`, `analyze` | `task_success` (`judge`) |
-| `/gws-drive-reader` | List, search, and read files from Google Drive | `retrieve` | `task_success` (`judge`) |
-| `/gws-slides-analyzer` | Read, search, and create Google Slides presentations | `retrieve`, `generate` | `task_success` (`judge`) |
-
-```bash
-/plugin install productization-skills@opendatahub-skills
-```
-
 ## Security Review
 
 Security analysis, threat modeling, and compliance review
@@ -491,4 +458,41 @@ Tags: spike, assessment, jira, research, scoring, rfe, openshift, rhoai, feasibi
 
 ```bash
 /plugin install spike-executor@opendatahub-skills
+```
+
+## Team-Specific
+
+Plugins hardcoded to a specific team's setup. Not generally reusable by other teams without modification.
+
+### productization-skills
+
+Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
+
+v0.8.1 | Team-Specific | Apache-2.0 | [opendatahub-io/productization-skills](https://github.com/opendatahub-io/productization-skills)
+
+Tags: gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning, google-workspace, reporting
+
+| Skill | Description | Functions | Metrics |
+|-------|-------------|-----------|---------|
+| `/gitlab-job-analyzer` | Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition | `analyze` | `task_success` (`judge`) |
+| `/aws-log-analyzer` | Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring | `analyze` | `task_success` (`judge`) |
+| `/slack-utilities` | Search messages, post updates, and interact with Slack workspaces | `retrieve`, `execute` | `task_success` (`judge`) |
+| `/gitlab-branch-manager` | Create and protect GitLab branches with configurable protection rules | `execute` | `task_success` (`judge`) |
+| `/jira-utilities` | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | `execute` | `task_success` (`judge`) |
+| `/jira-cve-tracker` | CVE deduplication and release-date clustering for Jira issues | `analyze` | `task_success` (`judge`) |
+| `/jira-release-setup` | Set up Jira release versions and manage release workflows | `execute` | `task_success` (`judge`) |
+| `/jira-sprint-manager` | Create sprints and assign issues to sprints on Jira boards | `execute` | `task_success` (`judge`) |
+| `/jira-gap-audit` | Audit Jira releases for gaps in issue coverage | `analyze` | `task_success` (`judge`) |
+| `/mapt-provisioner` | Provision and manage cloud VMs on AWS and Azure using mapt | `execute` | `task_success` (`judge`) |
+| `/konflux-its-analyzer` | Analyze Konflux integration test scenario failures | `analyze` | `task_success` (`judge`) |
+| `/gitlab-code-review` | Structured GitLab merge request code review | `review` | `task_success` (`judge`) |
+| `/slack-webhook` | Post messages to Slack channels via incoming webhooks | `execute` | `task_success` (`judge`) |
+| `/weekly-status` | Generate weekly status reports from project activity | `generate` | `task_success` (`judge`) |
+| `/gws-calendar-reader` | Read Google Calendar events and check free/busy status | `retrieve` | `task_success` (`judge`) |
+| `/gws-doc-action-extractor` | Extract action items from Google Docs | `retrieve`, `analyze` | `task_success` (`judge`) |
+| `/gws-drive-reader` | List, search, and read files from Google Drive | `retrieve` | `task_success` (`judge`) |
+| `/gws-slides-analyzer` | Read, search, and create Google Slides presentations | `retrieve`, `generate` | `task_success` (`judge`) |
+
+```bash
+/plugin install productization-skills@opendatahub-skills
 ```

--- a/catalog.md
+++ b/catalog.md
@@ -284,6 +284,39 @@ Tags: pipeline, ci-cd, failure-analysis, grouping, root-cause, gitlab
 /plugin install pipeline-skills@opendatahub-skills
 ```
 
+### productization-skills
+
+Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
+
+v0.8.1 | Apache-2.0 | [opendatahub-io/productization-skills](https://github.com/opendatahub-io/productization-skills)
+
+Tags: gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning
+
+| Skill | Description | Functions | Metrics |
+|-------|-------------|-----------|---------|
+| `/gitlab-job-analyzer` | Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition | `analyze` | `task_success` (`judge`) |
+| `/aws-log-analyzer` | Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring | `analyze` | `task_success` (`judge`) |
+| `/slack-utilities` | Search messages, post updates, and interact with Slack workspaces | `retrieve`, `execute` | `task_success` (`judge`) |
+| `/gitlab-branch-manager` | Create and protect GitLab branches with configurable protection rules | `execute` | `task_success` (`judge`) |
+| `/jira-utilities` | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | `execute` | `task_success` (`judge`) |
+| `/jira-cve-tracker` | CVE deduplication and release-date clustering for Jira issues | `analyze` | `task_success` (`judge`) |
+| `/jira-release-setup` | Set up Jira release versions and manage release workflows | `execute` | `task_success` (`judge`) |
+| `/jira-sprint-manager` | Create sprints and assign issues to sprints on Jira boards | `execute` | `task_success` (`judge`) |
+| `/jira-gap-audit` | Audit Jira releases for gaps in issue coverage | `analyze` | `task_success` (`judge`) |
+| `/mapt-provisioner` | Provision and manage cloud VMs on AWS and Azure using mapt | `execute` | `task_success` (`judge`) |
+| `/konflux-its-analyzer` | Analyze Konflux integration test scenario failures | `analyze` | `task_success` (`judge`) |
+| `/gitlab-code-review` | Structured GitLab merge request code review | `review` | `task_success` (`judge`) |
+| `/slack-webhook` | Post messages to Slack channels via incoming webhooks | `execute` | `task_success` (`judge`) |
+| `/weekly-status` | Generate weekly status reports from project activity | `generate` | `task_success` (`judge`) |
+| `/gws-calendar-reader` | Read Google Calendar events and check free/busy status | `retrieve` | `task_success` (`judge`) |
+| `/gws-doc-action-extractor` | Extract action items from Google Docs | `retrieve`, `analyze` | `task_success` (`judge`) |
+| `/gws-drive-reader` | List, search, and read files from Google Drive | `retrieve` | `task_success` (`judge`) |
+| `/gws-slides-analyzer` | Read, search, and create Google Slides presentations | `retrieve`, `generate` | `task_success` (`judge`) |
+
+```bash
+/plugin install productization-skills@opendatahub-skills
+```
+
 ## Security Review
 
 Security analysis, threat modeling, and compliance review

--- a/catalog.md
+++ b/catalog.md
@@ -478,8 +478,8 @@ Tags: gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisionin
 | `/aws-log-analyzer` | Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring | `analyze` | `task_success` (`judge`) |
 | `/slack-utilities` | Search messages, post updates, and interact with Slack workspaces | `retrieve`, `execute` | `task_success` (`judge`) |
 | `/gitlab-branch-manager` | Create and protect GitLab branches with configurable protection rules | `execute` | `task_success` (`judge`) |
-| `/jira-utilities` | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | `execute` | `task_success` (`judge`) |
-| `/jira-cve-tracker` | CVE deduplication and release-date clustering for Jira issues | `analyze` | `task_success` (`judge`) |
+| `/jira-utilities` | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | `retrieve`, `execute` | `task_success` (`judge`) |
+| `/jira-cve-tracker` | CVE deduplication and release-date clustering for Jira issues | `retrieve`, `analyze` | `task_success` (`judge`) |
 | `/jira-release-setup` | Set up Jira release versions and manage release workflows | `execute` | `task_success` (`judge`) |
 | `/jira-sprint-manager` | Create sprints and assign issues to sprints on Jira boards | `execute` | `task_success` (`judge`) |
 | `/jira-gap-audit` | Audit Jira releases for gaps in issue coverage | `analyze` | `task_success` (`judge`) |

--- a/registry.yaml
+++ b/registry.yaml
@@ -2479,3 +2479,539 @@ plugins:
       claude-code:
         install: "/plugin install docs-skills@opendatahub-skills"
     depends_on: []
+
+  - name: productization-skills
+    description: >
+      Claude Code plugin with specialized skills for DevOps and cloud-native
+      development workflows. Provides skills for GitLab CI/CD analysis,
+      AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch
+      management, Jira utilities, Konflux ITS analysis, cloud infrastructure
+      provisioning via mapt, and Google Workspace integration.
+    version: "0.8.1"
+    category: devops
+    tags: [gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning]
+    author:
+      name: opendatahub-io
+    license: Apache-2.0
+    source:
+      type: github
+      repo: opendatahub-io/productization-skills
+      ref: v0.8.1
+      sha: 86f0ce3f1697bcbe2b849b2770d235deddb16abe
+    homepage: https://github.com/opendatahub-io/productization-skills
+    repository: https://github.com/opendatahub-io/productization-skills
+    skills:
+      - name: gitlab-job-analyzer
+        description: Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-job-analyzer/SKILL.md
+          problem_statement: >
+            Analyze GitLab CI/CD job failures by parsing logs, identifying error patterns,
+            and providing structured root-cause analysis to speed up pipeline troubleshooting.
+          success_conditions:
+            - Identifies the root cause of the CI/CD job failure from logs
+            - Produces structured error analysis with actionable remediation steps
+          invariants:
+            must_preserve:
+              - Use glab CLI for all GitLab API interactions
+              - Never modify pipeline configuration or retry jobs without user confirmation
+            fixed_context:
+              tools: [Bash]
+              cli: [glab]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gitlab-job-analyzer/SKILL.md
+      - name: aws-log-analyzer
+        description: Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/aws-log-analyzer/SKILL.md
+          problem_statement: >
+            Troubleshoot and analyze AWS CloudWatch Logs to identify error patterns,
+            severity distributions, and trends for debugging and monitoring.
+          success_conditions:
+            - Retrieves and analyzes logs from the correct CloudWatch log group
+            - Produces structured error analysis with severity classification and pattern grouping
+          invariants:
+            must_preserve:
+              - Use AWS CLI for all CloudWatch Logs operations
+              - Never modify or delete log data
+            fixed_context:
+              tools: [Bash]
+              cli: [aws]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/aws-log-analyzer/SKILL.md
+      - name: slack-utilities
+        description: Search messages, post updates, and interact with Slack workspaces
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [retrieve, execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/slack-utilities/SKILL.md
+          problem_statement: >
+            Search messages, fetch thread replies, post updates, and interact with
+            Slack workspaces programmatically.
+          success_conditions:
+            - Retrieves or posts Slack messages as requested
+            - Correctly handles channel resolution and thread context
+          invariants:
+            must_preserve:
+              - Never post messages without user confirmation
+              - Use Slack API tokens from environment, never hardcode credentials
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/slack-utilities/SKILL.md
+      - name: gitlab-branch-manager
+        description: Create and protect GitLab branches with configurable protection rules
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-branch-manager/SKILL.md
+          problem_statement: >
+            Create and protect GitLab branches with configurable protection rules
+            for release and development workflows.
+          success_conditions:
+            - Creates branches from the correct source ref
+            - Applies requested protection rules correctly
+          invariants:
+            must_preserve:
+              - Use glab CLI for all GitLab API interactions
+              - Never delete branches without explicit user confirmation
+            fixed_context:
+              tools: [Bash]
+              cli: [glab]
+              knowledge_inputs:
+                - kind: task_input
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gitlab-branch-manager/SKILL.md
+      - name: jira-utilities
+        description: Manage Jira issues with JQL search, create/update issues, link issues, and sprint info
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-utilities/SKILL.md
+          problem_statement: >
+            Manage Jira issues with JQL search, create and update issues, link issues,
+            and retrieve sprint information.
+          success_conditions:
+            - Executes the requested Jira operation correctly
+            - Returns structured results for search and read operations
+          invariants:
+            must_preserve:
+              - Never delete issues without explicit user confirmation
+              - Use Jira MCP tools or REST API, never modify Jira data without confirmation
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: task_input
+                  privacy: task_private
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/jira-utilities/SKILL.md
+      - name: jira-cve-tracker
+        description: CVE deduplication and release-date clustering for Jira issues
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-cve-tracker/SKILL.md
+          problem_statement: >
+            Query a Jira project for open CVE vulnerability issues, deduplicate across
+            container variants, and cluster by release date for triage prioritization.
+          success_conditions:
+            - Retrieves and deduplicates CVE issues correctly
+            - Clusters CVEs by release date for actionable triage output
+          invariants:
+            must_preserve:
+              - Never modify CVE issues without explicit user confirmation
+              - Preserve original CVE identifiers and severity ratings
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/jira-cve-tracker/SKILL.md
+      - name: jira-release-setup
+        description: Set up Jira release versions and manage release workflows
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-release-setup/SKILL.md
+          problem_statement: >
+            Create the complete Jira card structure for a product release milestone,
+            encoding the release card template as epics, tasks, and subtasks.
+          success_conditions:
+            - Creates the full release card hierarchy per the template
+            - Links all created issues correctly to epics and parent issues
+          invariants:
+            must_preserve:
+              - Follow the encoded release card template structure exactly
+              - Never skip required epics or tasks from the template
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: repository_content
+                  privacy: public
+                - kind: task_input
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/jira-release-setup/SKILL.md
+      - name: jira-sprint-manager
+        description: Create sprints and assign issues to sprints on Jira boards
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-sprint-manager/SKILL.md
+          problem_statement: >
+            Create sprints and assign issues to sprints on Jira boards for
+            sprint planning and management workflows.
+          success_conditions:
+            - Creates sprints with correct dates and board association
+            - Moves issues to the correct sprint
+          invariants:
+            must_preserve:
+              - Never close or delete sprints without user confirmation
+              - Preserve existing sprint assignments unless explicitly asked to change
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: task_input
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/jira-sprint-manager/SKILL.md
+      - name: jira-gap-audit
+        description: Audit Jira releases for gaps in issue coverage
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-gap-audit/SKILL.md
+          problem_statement: >
+            Audit existing Jira cards for a release against the expected card template,
+            reporting missing epics, excess cards, and coverage gaps.
+          success_conditions:
+            - Compares actual release cards against the template
+            - Reports all missing and excess items with clear categorization
+          invariants:
+            must_preserve:
+              - Never create or modify Jira issues during audit, only report findings
+              - Use the canonical release template as the source of truth
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: repository_content
+                  privacy: public
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/jira-gap-audit/SKILL.md
+      - name: mapt-provisioner
+        description: Provision and manage cloud VMs on AWS and Azure using mapt
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/mapt-provisioner/SKILL.md
+          problem_statement: >
+            Provision and manage cloud VMs on AWS and Azure using mapt for
+            development, testing, and CI/CD environments.
+          success_conditions:
+            - Provisions the requested VM with correct specs and cloud provider
+            - Returns connection details for the provisioned machine
+          invariants:
+            must_preserve:
+              - Never destroy machines without explicit user confirmation
+              - Always use mapt CLI, never call cloud provider APIs directly
+            fixed_context:
+              tools: [Bash]
+              cli: [mapt]
+              knowledge_inputs:
+                - kind: task_input
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/mapt-provisioner/SKILL.md
+      - name: konflux-its-analyzer
+        description: Analyze Konflux integration test scenario failures
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/konflux-its-analyzer/SKILL.md
+          problem_statement: >
+            Analyze failed Konflux integration test scenario PipelineRuns using
+            KubeArchive to identify test failure root causes.
+          success_conditions:
+            - Retrieves the correct PipelineRun logs from KubeArchive
+            - Identifies the root cause of the integration test failure
+          invariants:
+            must_preserve:
+              - Use KubeArchive API for log retrieval, never access clusters directly
+              - Never modify or rerun pipelines without user confirmation
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/konflux-its-analyzer/SKILL.md
+      - name: gitlab-code-review
+        description: Structured GitLab merge request code review
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [review]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-code-review/SKILL.md
+          problem_statement: >
+            Perform structured code review of GitLab merge requests using multiple
+            specialized review dimensions with confidence-based scoring.
+          success_conditions:
+            - Reviews the MR diff across all configured dimensions
+            - Produces findings with confidence scores and actionable feedback
+          invariants:
+            must_preserve:
+              - Use glab CLI for all GitLab API interactions
+              - Never approve or merge MRs without explicit user confirmation
+            fixed_context:
+              tools: [Bash]
+              cli: [glab]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gitlab-code-review/SKILL.md
+      - name: slack-webhook
+        description: Post messages to Slack channels via incoming webhooks
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [execute]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/slack-webhook/SKILL.md
+          problem_statement: >
+            Post messages to Slack channels via incoming webhook URLs, supporting
+            plain text and Slack Block Kit JSON payloads.
+          success_conditions:
+            - Posts the message to the correct Slack webhook
+            - Formats Block Kit payloads correctly when requested
+          invariants:
+            must_preserve:
+              - Never post without user confirmation of the message content
+              - Use webhook URLs from environment or user input, never hardcode
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: task_input
+                  privacy: task_private
+          source_assertions:
+            skill_path: productization-plugin/skills/slack-webhook/SKILL.md
+      - name: weekly-status
+        description: Generate weekly status reports from project activity
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [generate]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/weekly-status/SKILL.md
+          problem_statement: >
+            Generate a weekly project status update paragraph for stakeholders from
+            project activity across git, Jira, and other sources.
+          success_conditions:
+            - Gathers activity from the correct time period
+            - Produces a concise stakeholder-ready status paragraph
+          invariants:
+            must_preserve:
+              - Report only factual activity, never fabricate accomplishments
+              - Use the user's configured sources for activity data
+            fixed_context:
+              tools: [Bash]
+              cli: [git, curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/weekly-status/SKILL.md
+      - name: gws-calendar-reader
+        description: Read Google Calendar events and check free/busy status
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [retrieve]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-calendar-reader/SKILL.md
+          problem_statement: >
+            Read Google Calendar events and check free/busy status for team
+            availability and scheduling.
+          success_conditions:
+            - Retrieves events for the requested time range and calendar
+            - Correctly reports free/busy availability
+          invariants:
+            must_preserve:
+              - Read-only access to calendar data, never create or modify events
+              - Use Google Workspace API via authenticated scripts only
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gws-calendar-reader/SKILL.md
+      - name: gws-doc-action-extractor
+        description: Extract action items from Google Docs
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [retrieve, analyze]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-doc-action-extractor/SKILL.md
+          problem_statement: >
+            Scan Google Docs for action patterns and extract action items
+            for tracking and follow-up.
+          success_conditions:
+            - Scans the correct Google Docs
+            - Extracts action items with assignees and context
+          invariants:
+            must_preserve:
+              - Read-only access to documents, never modify content
+              - Use Google Workspace API via authenticated scripts only
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gws-doc-action-extractor/SKILL.md
+      - name: gws-drive-reader
+        description: List, search, and read files from Google Drive
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [retrieve]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-drive-reader/SKILL.md
+          problem_statement: >
+            List, search, and read files from Google Drive including Docs,
+            Sheets, Slides, and plain files.
+          success_conditions:
+            - Finds and retrieves the requested files from Google Drive
+            - Returns content in a usable format for the requested file type
+          invariants:
+            must_preserve:
+              - Read-only access to Drive files, never upload or modify
+              - Use Google Workspace API via authenticated scripts only
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gws-drive-reader/SKILL.md
+      - name: gws-slides-analyzer
+        description: Read, search, and create Google Slides presentations
+        user-invocable: true
+        contract:
+          version: canonical-skill-v1
+          functions: [retrieve, generate]
+          metrics:
+            - id: task_success
+              measure: judge
+              rubric_ref: opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-slides-analyzer/SKILL.md
+          problem_statement: >
+            Search, read, create, and add diagrams to Google Slides presentations
+            for documentation and reporting workflows.
+          success_conditions:
+            - Retrieves or creates presentations as requested
+            - Formats slide content correctly with proper layout
+          invariants:
+            must_preserve:
+              - Never modify existing presentations without user confirmation
+              - Use Google Workspace API via authenticated scripts only
+            fixed_context:
+              tools: [Bash]
+              cli: [curl]
+              knowledge_inputs:
+                - kind: tool_output
+                  privacy: organization_private
+          source_assertions:
+            skill_path: productization-plugin/skills/gws-slides-analyzer/SKILL.md
+    harnesses:
+      claude-code:
+        install: "/plugin install productization-skills@opendatahub-skills"
+    depends_on: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -2489,7 +2489,8 @@ plugins:
       provisioning via mapt, and Google Workspace integration.
     version: "0.8.1"
     category: devops
-    tags: [gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning]
+    scope: team
+    tags: [gitlab, aws, slack, jira, konflux, mapt, devops, ci-cd, cloud, provisioning, google-workspace, reporting]
     author:
       name: opendatahub-io
     license: Apache-2.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -2498,6 +2498,8 @@ plugins:
       repo: opendatahub-io/productization-skills
       ref: v0.8.1
       sha: 86f0ce3f1697bcbe2b849b2770d235deddb16abe
+    strict: false
+    skills_dir: productization-plugin/skills
     homepage: https://github.com/opendatahub-io/productization-skills
     repository: https://github.com/opendatahub-io/productization-skills
     skills:

--- a/registry.yaml
+++ b/registry.yaml
@@ -2526,10 +2526,10 @@ plugins:
               - Never modify pipeline configuration or retry jobs without user confirmation
             fixed_context:
               tools: [Bash]
-              cli: [glab]
+              cli: [glab, jq]
               knowledge_inputs:
                 - kind: tool_output
-                  privacy: task_private
+                  privacy: organization_private
           source_assertions:
             skill_path: productization-plugin/skills/gitlab-job-analyzer/SKILL.md
       - name: aws-log-analyzer
@@ -2554,10 +2554,10 @@ plugins:
               - Never modify or delete log data
             fixed_context:
               tools: [Bash]
-              cli: [aws]
+              cli: [aws, jq]
               knowledge_inputs:
                 - kind: tool_output
-                  privacy: task_private
+                  privacy: organization_private
           source_assertions:
             skill_path: productization-plugin/skills/aws-log-analyzer/SKILL.md
       - name: slack-utilities
@@ -2582,7 +2582,7 @@ plugins:
               - Use Slack API tokens from environment, never hardcode credentials
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [python3, jq]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -2610,7 +2610,7 @@ plugins:
               - Never delete branches without explicit user confirmation
             fixed_context:
               tools: [Bash]
-              cli: [glab]
+              cli: [glab, jq]
               knowledge_inputs:
                 - kind: task_input
                   privacy: task_private
@@ -2621,7 +2621,7 @@ plugins:
         user-invocable: true
         contract:
           version: canonical-skill-v1
-          functions: [execute]
+          functions: [retrieve, execute]
           metrics:
             - id: task_success
               measure: judge
@@ -2635,10 +2635,10 @@ plugins:
           invariants:
             must_preserve:
               - Never delete issues without explicit user confirmation
-              - Use Jira MCP tools or REST API, never modify Jira data without confirmation
+              - Use the acli CLI (or Jira REST API) for all interactions; never modify Jira data without confirmation
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [acli, jq, curl]
               knowledge_inputs:
                 - kind: task_input
                   privacy: task_private
@@ -2651,7 +2651,7 @@ plugins:
         user-invocable: true
         contract:
           version: canonical-skill-v1
-          functions: [analyze]
+          functions: [retrieve, analyze]
           metrics:
             - id: task_success
               measure: judge
@@ -2668,7 +2668,7 @@ plugins:
               - Preserve original CVE identifiers and severity ratings
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [acli, jq, curl]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -2696,7 +2696,7 @@ plugins:
               - Never skip required epics or tasks from the template
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [acli, jq]
               knowledge_inputs:
                 - kind: repository_content
                   privacy: public
@@ -2726,7 +2726,7 @@ plugins:
               - Preserve existing sprint assignments unless explicitly asked to change
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [acli, jq]
               knowledge_inputs:
                 - kind: task_input
                   privacy: task_private
@@ -2754,7 +2754,7 @@ plugins:
               - Use the canonical release template as the source of truth
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [acli, jq]
               knowledge_inputs:
                 - kind: repository_content
                   privacy: public
@@ -2784,7 +2784,7 @@ plugins:
               - Always use mapt CLI, never call cloud provider APIs directly
             fixed_context:
               tools: [Bash]
-              cli: [mapt]
+              cli: [mapt, jq]
               knowledge_inputs:
                 - kind: task_input
                   privacy: task_private
@@ -2812,10 +2812,10 @@ plugins:
               - Never modify or rerun pipelines without user confirmation
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [kubectl, jq]
               knowledge_inputs:
                 - kind: tool_output
-                  privacy: task_private
+                  privacy: organization_private
           source_assertions:
             skill_path: productization-plugin/skills/konflux-its-analyzer/SKILL.md
       - name: gitlab-code-review
@@ -2840,10 +2840,10 @@ plugins:
               - Never approve or merge MRs without explicit user confirmation
             fixed_context:
               tools: [Bash]
-              cli: [glab]
+              cli: [glab, git]
               knowledge_inputs:
                 - kind: tool_output
-                  privacy: task_private
+                  privacy: organization_private
           source_assertions:
             skill_path: productization-plugin/skills/gitlab-code-review/SKILL.md
       - name: slack-webhook
@@ -2868,7 +2868,7 @@ plugins:
               - Use webhook URLs from environment or user input, never hardcode
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [curl, jq]
               knowledge_inputs:
                 - kind: task_input
                   privacy: task_private
@@ -2896,7 +2896,7 @@ plugins:
               - Use the user's configured sources for activity data
             fixed_context:
               tools: [Bash]
-              cli: [git, curl]
+              cli: [git, acli, jq]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -2924,7 +2924,7 @@ plugins:
               - Use Google Workspace API via authenticated scripts only
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [gws, jq]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -2952,7 +2952,7 @@ plugins:
               - Use Google Workspace API via authenticated scripts only
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [gws, jq]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -2980,7 +2980,7 @@ plugins:
               - Use Google Workspace API via authenticated scripts only
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [gws, jq]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private
@@ -3008,7 +3008,7 @@ plugins:
               - Use Google Workspace API via authenticated scripts only
             fixed_context:
               tools: [Bash]
-              cli: [curl]
+              cli: [gws, jq, python3]
               knowledge_inputs:
                 - kind: tool_output
                   privacy: organization_private

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -34,3 +34,9 @@ DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Kon
 Pipeline failure analysis skills for AIPCC CI/CD pipelines. Groups failed jobs by shared root cause using preprocessed error logs, then performs root cause analysis per group with structured findings, section files, and confidence-rated diagnoses. Designed to run inside a Claude Code container as part of the pipeline-failure-analyzer CI pipeline.
 
 **2 skills** - v0.1.0
+
+### [productization-skills](../plugins/productization-skills/index.md)
+
+Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
+
+**18 skills** - v0.8.1

--- a/site/docs/categories/devops.md
+++ b/site/docs/categories/devops.md
@@ -34,9 +34,3 @@ DevOps and TestOps automation skills for ODH/RHOAI — component onboarding, Kon
 Pipeline failure analysis skills for AIPCC CI/CD pipelines. Groups failed jobs by shared root cause using preprocessed error logs, then performs root cause analysis per group with structured findings, section files, and confidence-rated diagnoses. Designed to run inside a Claude Code container as part of the pipeline-failure-analyzer CI pipeline.
 
 **2 skills** - v0.1.0
-
-### [productization-skills](../plugins/productization-skills/index.md)
-
-Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
-
-**18 skills** - v0.8.1

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -14,7 +14,7 @@ title: Categories
 | [Evaluation & Testing](evaluation.md) | 5 | Skills for evaluating and testing AI agent skills |
 | [Code Quality](code-quality.md) | 1 | Code review, linting, and quality enforcement |
 | [Documentation](documentation.md) | 2 | Skills for generating and maintaining documentation |
-| [DevOps & CI/CD](devops.md) | 4 | Skills for deployment, CI/CD, and infrastructure |
+| [DevOps & CI/CD](devops.md) | 5 | Skills for deployment, CI/CD, and infrastructure |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
 | [Development Tools](development-tools.md) | 4 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 3 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/categories/index.md
+++ b/site/docs/categories/index.md
@@ -14,7 +14,7 @@ title: Categories
 | [Evaluation & Testing](evaluation.md) | 5 | Skills for evaluating and testing AI agent skills |
 | [Code Quality](code-quality.md) | 1 | Code review, linting, and quality enforcement |
 | [Documentation](documentation.md) | 2 | Skills for generating and maintaining documentation |
-| [DevOps & CI/CD](devops.md) | 5 | Skills for deployment, CI/CD, and infrastructure |
+| [DevOps & CI/CD](devops.md) | 4 | Skills for deployment, CI/CD, and infrastructure |
 | [Security Review](security.md) | 1 | Security analysis, threat modeling, and compliance review |
 | [Development Tools](development-tools.md) | 4 | Developer productivity tools for packaging, CI/CD debugging, and workflow automation |
 | [Product Planning](planning.md) | 3 | Skills for requirements, RFEs, and product strategy |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Skills and plugins for AI-assisted software engineering workflows
 
-20 plugins | 106 skills | 7 categories
+21 plugins | 124 skills | 7 categories
 
 [Getting Started](getting-started.md){ .md-button .md-button--primary }
 
@@ -164,6 +164,14 @@ hide:
 
     **1 skills** - Documentation - v0.3.15
 
+-   **[productization-skills](plugins/productization-skills/index.md)**
+
+    ---
+
+    Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for Git...
+
+    **18 skills** - DevOps & CI/CD - v0.8.1
+
 </div>
 
 ## Generic
@@ -193,7 +201,7 @@ hide:
 - [Evaluation & Testing](categories/evaluation.md) -- Skills for evaluating and testing AI agent skills (5 plugins)
 - [Code Quality](categories/code-quality.md) -- Code review, linting, and quality enforcement (1 plugin)
 - [Documentation](categories/documentation.md) -- Skills for generating and maintaining documentation (2 plugins)
-- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (4 plugins)
+- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (5 plugins)
 - [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)
 - [Development Tools](categories/development-tools.md) -- Developer productivity tools for packaging, CI/CD debugging, and workflow automation (4 plugins)
 - [Product Planning](categories/planning.md) -- Skills for requirements, RFEs, and product strategy (3 plugins)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -164,14 +164,6 @@ hide:
 
     **1 skills** - Documentation - v0.3.15
 
--   **[productization-skills](plugins/productization-skills/index.md)**
-
-    ---
-
-    Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for Git...
-
-    **18 skills** - DevOps & CI/CD - v0.8.1
-
 </div>
 
 ## Generic
@@ -196,12 +188,26 @@ hide:
 
 </div>
 
+## Teams
+
+<div class="grid cards" markdown>
+
+-   **[productization-skills](plugins/productization-skills/index.md)**
+
+    ---
+
+    Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for Git...
+
+    **18 skills** - DevOps & CI/CD - v0.8.1
+
+</div>
+
 ## Categories
 
 - [Evaluation & Testing](categories/evaluation.md) -- Skills for evaluating and testing AI agent skills (5 plugins)
 - [Code Quality](categories/code-quality.md) -- Code review, linting, and quality enforcement (1 plugin)
 - [Documentation](categories/documentation.md) -- Skills for generating and maintaining documentation (2 plugins)
-- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (5 plugins)
+- [DevOps & CI/CD](categories/devops.md) -- Skills for deployment, CI/CD, and infrastructure (4 plugins)
 - [Security Review](categories/security.md) -- Security analysis, threat modeling, and compliance review (1 plugin)
 - [Development Tools](categories/development-tools.md) -- Developer productivity tools for packaging, CI/CD debugging, and workflow automation (4 plugins)
 - [Product Planning](categories/planning.md) -- Skills for requirements, RFEs, and product strategy (3 plugins)

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -3293,3 +3293,85 @@ Examples:
 ```
 
 ---
+
+## productization-skills
+
+Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
+
+**Repository**: https://github.com/opendatahub-io/productization-skills
+
+### Skills
+
+#### /gitlab-job-analyzer
+
+Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition
+
+#### /aws-log-analyzer
+
+Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring
+
+#### /slack-utilities
+
+Search messages, post updates, and interact with Slack workspaces
+
+#### /gitlab-branch-manager
+
+Create and protect GitLab branches with configurable protection rules
+
+#### /jira-utilities
+
+Manage Jira issues with JQL search, create/update issues, link issues, and sprint info
+
+#### /jira-cve-tracker
+
+CVE deduplication and release-date clustering for Jira issues
+
+#### /jira-release-setup
+
+Set up Jira release versions and manage release workflows
+
+#### /jira-sprint-manager
+
+Create sprints and assign issues to sprints on Jira boards
+
+#### /jira-gap-audit
+
+Audit Jira releases for gaps in issue coverage
+
+#### /mapt-provisioner
+
+Provision and manage cloud VMs on AWS and Azure using mapt
+
+#### /konflux-its-analyzer
+
+Analyze Konflux integration test scenario failures
+
+#### /gitlab-code-review
+
+Structured GitLab merge request code review
+
+#### /slack-webhook
+
+Post messages to Slack channels via incoming webhooks
+
+#### /weekly-status
+
+Generate weekly status reports from project activity
+
+#### /gws-calendar-reader
+
+Read Google Calendar events and check free/busy status
+
+#### /gws-doc-action-extractor
+
+Extract action items from Google Docs
+
+#### /gws-drive-reader
+
+List, search, and read files from Google Drive
+
+#### /gws-slides-analyzer
+
+Read, search, and create Google Slides presentations
+
+---

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -24,6 +24,7 @@
 - [code-review-skills](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/): AI-powered code review for GitLab merge requests. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to the GitLab MR (in CI) or displays them locally for preview. Supports chill mode filtering and comment deduplication.
 - [spike-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates. 9-step lifecycle: intake, plan, Jira sync, AI research enrichment with hallucination detection, pytest test suites on OpenShift, rubric-based scoring with security gates, and RFE input generation. Supports both runtime and protocol library assessment.
 - [docs-skills](https://opendatahub-io.github.io/skills-registry/plugins/docs-skills/): Documentation review, writing, and workflow tools for AsciiDoc and Markdown documentation. Includes an orchestrated multi-step pipeline, standalone review skills, codebase analysis for onboarding, and JIRA/PR integration.
+- [productization-skills](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/): Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
 
 ## Skills
 
@@ -102,6 +103,24 @@
 - [gitlab-code-review](https://opendatahub-io.github.io/skills-registry/plugins/code-review-skills/gitlab-code-review/): Perform AI code review on a GitLab merge request with structured JSON feedback and inline comments
 - [SPIKE-executor](https://opendatahub-io.github.io/skills-registry/plugins/spike-executor/SPIKE-executor/): Execute RHOAI SPIKE investigations with human-in-the-loop approval gates
 - [docs-orchestrator](https://opendatahub-io.github.io/skills-registry/plugins/docs-skills/docs-orchestrator/): Documentation workflow orchestrator. Reads the step list from .agent_workspace/docs-workflow.yaml (or the plugin default). Runs steps sequentially, manages progress state, handles iteration and confirmation gates. Claude is the orchestrator — the YAML is a step list, not a workflow engine.
+- [gitlab-job-analyzer](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gitlab-job-analyzer/): Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition
+- [aws-log-analyzer](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/aws-log-analyzer/): Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring
+- [slack-utilities](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/slack-utilities/): Search messages, post updates, and interact with Slack workspaces
+- [gitlab-branch-manager](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gitlab-branch-manager/): Create and protect GitLab branches with configurable protection rules
+- [jira-utilities](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/jira-utilities/): Manage Jira issues with JQL search, create/update issues, link issues, and sprint info
+- [jira-cve-tracker](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/jira-cve-tracker/): CVE deduplication and release-date clustering for Jira issues
+- [jira-release-setup](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/jira-release-setup/): Set up Jira release versions and manage release workflows
+- [jira-sprint-manager](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/jira-sprint-manager/): Create sprints and assign issues to sprints on Jira boards
+- [jira-gap-audit](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/jira-gap-audit/): Audit Jira releases for gaps in issue coverage
+- [mapt-provisioner](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/mapt-provisioner/): Provision and manage cloud VMs on AWS and Azure using mapt
+- [konflux-its-analyzer](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/konflux-its-analyzer/): Analyze Konflux integration test scenario failures
+- [gitlab-code-review](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gitlab-code-review/): Structured GitLab merge request code review
+- [slack-webhook](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/slack-webhook/): Post messages to Slack channels via incoming webhooks
+- [weekly-status](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/weekly-status/): Generate weekly status reports from project activity
+- [gws-calendar-reader](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gws-calendar-reader/): Read Google Calendar events and check free/busy status
+- [gws-doc-action-extractor](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gws-doc-action-extractor/): Extract action items from Google Docs
+- [gws-drive-reader](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gws-drive-reader/): List, search, and read files from Google Drive
+- [gws-slides-analyzer](https://opendatahub-io.github.io/skills-registry/plugins/productization-skills/gws-slides-analyzer/): Read, search, and create Google Slides presentations
 
 ## Optional
 

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Plugins
 
-20 plugins registered in the marketplace.
+21 plugins registered in the marketplace.
 
 ## SDLC
 
@@ -31,6 +31,7 @@ title: Plugins
 | [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |
 | [docs-skills](docs-skills/index.md) | Documentation | 1 | v0.3.15 |
+| [productization-skills](productization-skills/index.md) | DevOps & CI/CD | 18 | v0.8.1 |
 
 ## Generic
 

--- a/site/docs/plugins/index.md
+++ b/site/docs/plugins/index.md
@@ -31,7 +31,6 @@ title: Plugins
 | [code-review-skills](code-review-skills/index.md) | Code Quality | 1 | v0.1.0 |
 | [spike-executor](spike-executor/index.md) | Product Planning | 1 | v0.2.0 |
 | [docs-skills](docs-skills/index.md) | Documentation | 1 | v0.3.15 |
-| [productization-skills](productization-skills/index.md) | DevOps & CI/CD | 18 | v0.8.1 |
 
 ## Generic
 
@@ -39,3 +38,9 @@ title: Plugins
 |--------|----------|--------|---------|
 | [odh-ai-helpers](odh-ai-helpers/index.md) | Development Tools | 19 | v0.1.0 |
 | [agent-eval-harness](agent-eval-harness/index.md) | Evaluation & Testing | 10 | v1.30.0 |
+
+## Teams
+
+| Plugin | Category | Skills | Version |
+|--------|----------|--------|---------|
+| [productization-skills](productization-skills/index.md) | DevOps & CI/CD | 18 | v0.8.1 |

--- a/site/docs/plugins/productization-skills/aws-log-analyzer.md
+++ b/site/docs/plugins/productization-skills/aws-log-analyzer.md
@@ -1,0 +1,79 @@
+---
+title: aws-log-analyzer
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# aws-log-analyzer
+
+Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Troubleshoot and analyze AWS CloudWatch Logs to identify error patterns, severity distributions, and trends for debugging and monitoring.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves and analyzes logs from the correct CloudWatch log group</li>
+        <li>Produces structured error analysis with severity classification and pattern grouping</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/aws-log-analyzer/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/aws-log-analyzer/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Use AWS CLI for all CloudWatch Logs operations</li>
+        <li>Never modify or delete log data</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">aws</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/aws-log-analyzer/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/aws-log-analyzer/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/aws-log-analyzer
+```

--- a/site/docs/plugins/productization-skills/aws-log-analyzer.md
+++ b/site/docs/plugins/productization-skills/aws-log-analyzer.md
@@ -58,8 +58,8 @@ Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">aws</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">aws, jq</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>
   </section>

--- a/site/docs/plugins/productization-skills/gitlab-branch-manager.md
+++ b/site/docs/plugins/productization-skills/gitlab-branch-manager.md
@@ -58,7 +58,7 @@ Create and protect GitLab branches with configurable protection rules
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/gitlab-branch-manager.md
+++ b/site/docs/plugins/productization-skills/gitlab-branch-manager.md
@@ -1,0 +1,79 @@
+---
+title: gitlab-branch-manager
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gitlab-branch-manager
+
+Create and protect GitLab branches with configurable protection rules
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Create and protect GitLab branches with configurable protection rules for release and development workflows.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Creates branches from the correct source ref</li>
+        <li>Applies requested protection rules correctly</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-branch-manager/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-branch-manager/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Use glab CLI for all GitLab API interactions</li>
+        <li>Never delete branches without explicit user confirmation</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-branch-manager/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gitlab-branch-manager/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gitlab-branch-manager
+```

--- a/site/docs/plugins/productization-skills/gitlab-code-review.md
+++ b/site/docs/plugins/productization-skills/gitlab-code-review.md
@@ -1,0 +1,79 @@
+---
+title: gitlab-code-review
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gitlab-code-review
+
+Structured GitLab merge request code review
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Perform structured code review of GitLab merge requests using multiple specialized review dimensions with confidence-based scoring.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">review</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Reviews the MR diff across all configured dimensions</li>
+        <li>Produces findings with confidence scores and actionable feedback</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-code-review/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-code-review/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Use glab CLI for all GitLab API interactions</li>
+        <li>Never approve or merge MRs without explicit user confirmation</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-code-review/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gitlab-code-review/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gitlab-code-review
+```

--- a/site/docs/plugins/productization-skills/gitlab-code-review.md
+++ b/site/docs/plugins/productization-skills/gitlab-code-review.md
@@ -58,8 +58,8 @@ Structured GitLab merge request code review
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab, git</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>
   </section>

--- a/site/docs/plugins/productization-skills/gitlab-job-analyzer.md
+++ b/site/docs/plugins/productization-skills/gitlab-job-analyzer.md
@@ -1,0 +1,79 @@
+---
+title: gitlab-job-analyzer
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gitlab-job-analyzer
+
+Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Analyze GitLab CI/CD job failures by parsing logs, identifying error patterns, and providing structured root-cause analysis to speed up pipeline troubleshooting.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Identifies the root cause of the CI/CD job failure from logs</li>
+        <li>Produces structured error analysis with actionable remediation steps</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-job-analyzer/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gitlab-job-analyzer/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Use glab CLI for all GitLab API interactions</li>
+        <li>Never modify pipeline configuration or retry jobs without user confirmation</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gitlab-job-analyzer/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gitlab-job-analyzer/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gitlab-job-analyzer
+```

--- a/site/docs/plugins/productization-skills/gitlab-job-analyzer.md
+++ b/site/docs/plugins/productization-skills/gitlab-job-analyzer.md
@@ -58,8 +58,8 @@ Analyze GitLab CI/CD job failures with structured scripts and error pattern reco
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">glab, jq</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>
   </section>

--- a/site/docs/plugins/productization-skills/gws-calendar-reader.md
+++ b/site/docs/plugins/productization-skills/gws-calendar-reader.md
@@ -1,0 +1,79 @@
+---
+title: gws-calendar-reader
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gws-calendar-reader
+
+Read Google Calendar events and check free/busy status
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Read Google Calendar events and check free/busy status for team availability and scheduling.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves events for the requested time range and calendar</li>
+        <li>Correctly reports free/busy availability</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-calendar-reader/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-calendar-reader/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Read-only access to calendar data, never create or modify events</li>
+        <li>Use Google Workspace API via authenticated scripts only</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-calendar-reader/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gws-calendar-reader/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gws-calendar-reader
+```

--- a/site/docs/plugins/productization-skills/gws-calendar-reader.md
+++ b/site/docs/plugins/productization-skills/gws-calendar-reader.md
@@ -58,7 +58,7 @@ Read Google Calendar events and check free/busy status
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">gws, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/gws-doc-action-extractor.md
+++ b/site/docs/plugins/productization-skills/gws-doc-action-extractor.md
@@ -59,7 +59,7 @@ Extract action items from Google Docs
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">gws, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/gws-doc-action-extractor.md
+++ b/site/docs/plugins/productization-skills/gws-doc-action-extractor.md
@@ -1,0 +1,80 @@
+---
+title: gws-doc-action-extractor
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gws-doc-action-extractor
+
+Extract action items from Google Docs
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Scan Google Docs for action patterns and extract action items for tracking and follow-up.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Scans the correct Google Docs</li>
+        <li>Extracts action items with assignees and context</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-doc-action-extractor/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-doc-action-extractor/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Read-only access to documents, never modify content</li>
+        <li>Use Google Workspace API via authenticated scripts only</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-doc-action-extractor/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gws-doc-action-extractor/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gws-doc-action-extractor
+```

--- a/site/docs/plugins/productization-skills/gws-drive-reader.md
+++ b/site/docs/plugins/productization-skills/gws-drive-reader.md
@@ -1,0 +1,79 @@
+---
+title: gws-drive-reader
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gws-drive-reader
+
+List, search, and read files from Google Drive
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">List, search, and read files from Google Drive including Docs, Sheets, Slides, and plain files.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Finds and retrieves the requested files from Google Drive</li>
+        <li>Returns content in a usable format for the requested file type</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-drive-reader/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-drive-reader/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Read-only access to Drive files, never upload or modify</li>
+        <li>Use Google Workspace API via authenticated scripts only</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-drive-reader/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gws-drive-reader/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gws-drive-reader
+```

--- a/site/docs/plugins/productization-skills/gws-drive-reader.md
+++ b/site/docs/plugins/productization-skills/gws-drive-reader.md
@@ -58,7 +58,7 @@ List, search, and read files from Google Drive
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">gws, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/gws-slides-analyzer.md
+++ b/site/docs/plugins/productization-skills/gws-slides-analyzer.md
@@ -59,7 +59,7 @@ Read, search, and create Google Slides presentations
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">gws, jq, python3</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/gws-slides-analyzer.md
+++ b/site/docs/plugins/productization-skills/gws-slides-analyzer.md
@@ -1,0 +1,80 @@
+---
+title: gws-slides-analyzer
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# gws-slides-analyzer
+
+Read, search, and create Google Slides presentations
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Search, read, create, and add diagrams to Google Slides presentations for documentation and reporting workflows.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
+        <span class="skill-contract__chip skill-contract__chip--function">generate</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves or creates presentations as requested</li>
+        <li>Formats slide content correctly with proper layout</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-slides-analyzer/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/gws-slides-analyzer/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never modify existing presentations without user confirmation</li>
+        <li>Use Google Workspace API via authenticated scripts only</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/gws-slides-analyzer/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/gws-slides-analyzer/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/gws-slides-analyzer
+```

--- a/site/docs/plugins/productization-skills/index.md
+++ b/site/docs/plugins/productization-skills/index.md
@@ -14,9 +14,10 @@ Claude Code plugin with specialized skills for DevOps and cloud-native developme
     - **Version**: 0.8.1
     - **Author**: opendatahub-io
     - **License**: Apache-2.0
+    - **Scope**: Team-specific
     - **Category**: [DevOps & CI/CD](../../categories/devops.md)
     - **Repository**: [opendatahub-io/productization-skills](https://github.com/opendatahub-io/productization-skills)
-    - **Tags**: <span class="tag-pill">gitlab</span> <span class="tag-pill">aws</span> <span class="tag-pill">slack</span> <span class="tag-pill">jira</span> <span class="tag-pill">konflux</span> <span class="tag-pill">mapt</span> <span class="tag-pill">devops</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">cloud</span> <span class="tag-pill">provisioning</span>
+    - **Tags**: <span class="tag-pill">gitlab</span> <span class="tag-pill">aws</span> <span class="tag-pill">slack</span> <span class="tag-pill">jira</span> <span class="tag-pill">konflux</span> <span class="tag-pill">mapt</span> <span class="tag-pill">devops</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">cloud</span> <span class="tag-pill">provisioning</span> <span class="tag-pill">google-workspace</span> <span class="tag-pill">reporting</span>
 
 ## Skills
 

--- a/site/docs/plugins/productization-skills/index.md
+++ b/site/docs/plugins/productization-skills/index.md
@@ -1,0 +1,48 @@
+---
+title: productization-skills
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# productization-skills
+
+Claude Code plugin with specialized skills for DevOps and cloud-native development workflows. Provides skills for GitLab CI/CD analysis, AWS CloudWatch Logs troubleshooting, Slack integration, GitLab branch management, Jira utilities, Konflux ITS analysis, cloud infrastructure provisioning via mapt, and Google Workspace integration.
+
+!!! info "Plugin Details"
+
+    - **Version**: 0.8.1
+    - **Author**: opendatahub-io
+    - **License**: Apache-2.0
+    - **Category**: [DevOps & CI/CD](../../categories/devops.md)
+    - **Repository**: [opendatahub-io/productization-skills](https://github.com/opendatahub-io/productization-skills)
+    - **Tags**: <span class="tag-pill">gitlab</span> <span class="tag-pill">aws</span> <span class="tag-pill">slack</span> <span class="tag-pill">jira</span> <span class="tag-pill">konflux</span> <span class="tag-pill">mapt</span> <span class="tag-pill">devops</span> <span class="tag-pill">ci-cd</span> <span class="tag-pill">cloud</span> <span class="tag-pill">provisioning</span>
+
+## Skills
+
+| Skill | Description | Invocable |
+|-------|-------------|-----------|
+| [`/gitlab-job-analyzer`](gitlab-job-analyzer.md) | Analyze GitLab CI/CD job failures with structured scripts and error pattern recognition | :material-check: |
+| [`/aws-log-analyzer`](aws-log-analyzer.md) | Troubleshoot and analyze AWS CloudWatch Logs for debugging and monitoring | :material-check: |
+| [`/slack-utilities`](slack-utilities.md) | Search messages, post updates, and interact with Slack workspaces | :material-check: |
+| [`/gitlab-branch-manager`](gitlab-branch-manager.md) | Create and protect GitLab branches with configurable protection rules | :material-check: |
+| [`/jira-utilities`](jira-utilities.md) | Manage Jira issues with JQL search, create/update issues, link issues, and sprint info | :material-check: |
+| [`/jira-cve-tracker`](jira-cve-tracker.md) | CVE deduplication and release-date clustering for Jira issues | :material-check: |
+| [`/jira-release-setup`](jira-release-setup.md) | Set up Jira release versions and manage release workflows | :material-check: |
+| [`/jira-sprint-manager`](jira-sprint-manager.md) | Create sprints and assign issues to sprints on Jira boards | :material-check: |
+| [`/jira-gap-audit`](jira-gap-audit.md) | Audit Jira releases for gaps in issue coverage | :material-check: |
+| [`/mapt-provisioner`](mapt-provisioner.md) | Provision and manage cloud VMs on AWS and Azure using mapt | :material-check: |
+| [`/konflux-its-analyzer`](konflux-its-analyzer.md) | Analyze Konflux integration test scenario failures | :material-check: |
+| [`/gitlab-code-review`](gitlab-code-review.md) | Structured GitLab merge request code review | :material-check: |
+| [`/slack-webhook`](slack-webhook.md) | Post messages to Slack channels via incoming webhooks | :material-check: |
+| [`/weekly-status`](weekly-status.md) | Generate weekly status reports from project activity | :material-check: |
+| [`/gws-calendar-reader`](gws-calendar-reader.md) | Read Google Calendar events and check free/busy status | :material-check: |
+| [`/gws-doc-action-extractor`](gws-doc-action-extractor.md) | Extract action items from Google Docs | :material-check: |
+| [`/gws-drive-reader`](gws-drive-reader.md) | List, search, and read files from Google Drive | :material-check: |
+| [`/gws-slides-analyzer`](gws-slides-analyzer.md) | Read, search, and create Google Slides presentations | :material-check: |
+
+## Installation
+
+```bash
+/plugin install productization-skills@opendatahub-skills
+```

--- a/site/docs/plugins/productization-skills/jira-cve-tracker.md
+++ b/site/docs/plugins/productization-skills/jira-cve-tracker.md
@@ -24,6 +24,7 @@ CVE deduplication and release-date clustering for Jira issues
     <div class="skill-contract__row">
       <span class="skill-contract__field">Functions</span>
       <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
         <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
       </div>
     </div>
@@ -58,7 +59,7 @@ CVE deduplication and release-date clustering for Jira issues
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">acli, jq, curl</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/jira-cve-tracker.md
+++ b/site/docs/plugins/productization-skills/jira-cve-tracker.md
@@ -1,0 +1,79 @@
+---
+title: jira-cve-tracker
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-cve-tracker
+
+CVE deduplication and release-date clustering for Jira issues
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Query a Jira project for open CVE vulnerability issues, deduplicate across container variants, and cluster by release date for triage prioritization.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves and deduplicates CVE issues correctly</li>
+        <li>Clusters CVEs by release date for actionable triage output</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-cve-tracker/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-cve-tracker/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never modify CVE issues without explicit user confirmation</li>
+        <li>Preserve original CVE identifiers and severity ratings</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-cve-tracker/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/jira-cve-tracker/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/jira-cve-tracker
+```

--- a/site/docs/plugins/productization-skills/jira-gap-audit.md
+++ b/site/docs/plugins/productization-skills/jira-gap-audit.md
@@ -58,7 +58,7 @@ Audit Jira releases for gaps in issue coverage
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">acli, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/jira-gap-audit.md
+++ b/site/docs/plugins/productization-skills/jira-gap-audit.md
@@ -1,0 +1,79 @@
+---
+title: jira-gap-audit
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-gap-audit
+
+Audit Jira releases for gaps in issue coverage
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Audit existing Jira cards for a release against the expected card template, reporting missing epics, excess cards, and coverage gaps.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Compares actual release cards against the template</li>
+        <li>Reports all missing and excess items with clear categorization</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-gap-audit/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-gap-audit/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never create or modify Jira issues during audit, only report findings</li>
+        <li>Use the canonical release template as the source of truth</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-gap-audit/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/jira-gap-audit/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/jira-gap-audit
+```

--- a/site/docs/plugins/productization-skills/jira-release-setup.md
+++ b/site/docs/plugins/productization-skills/jira-release-setup.md
@@ -58,7 +58,7 @@ Set up Jira release versions and manage release workflows
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">acli, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, task_input<span class="skill-contract__privacy">task_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/jira-release-setup.md
+++ b/site/docs/plugins/productization-skills/jira-release-setup.md
@@ -1,0 +1,79 @@
+---
+title: jira-release-setup
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-release-setup
+
+Set up Jira release versions and manage release workflows
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Create the complete Jira card structure for a product release milestone, encoding the release card template as epics, tasks, and subtasks.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Creates the full release card hierarchy per the template</li>
+        <li>Links all created issues correctly to epics and parent issues</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-release-setup/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-release-setup/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Follow the encoded release card template structure exactly</li>
+        <li>Never skip required epics or tasks from the template</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">repository_content<span class="skill-contract__privacy">public</span>, task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-release-setup/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/jira-release-setup/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/jira-release-setup
+```

--- a/site/docs/plugins/productization-skills/jira-sprint-manager.md
+++ b/site/docs/plugins/productization-skills/jira-sprint-manager.md
@@ -1,0 +1,79 @@
+---
+title: jira-sprint-manager
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-sprint-manager
+
+Create sprints and assign issues to sprints on Jira boards
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Create sprints and assign issues to sprints on Jira boards for sprint planning and management workflows.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Creates sprints with correct dates and board association</li>
+        <li>Moves issues to the correct sprint</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-sprint-manager/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-sprint-manager/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never close or delete sprints without user confirmation</li>
+        <li>Preserve existing sprint assignments unless explicitly asked to change</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-sprint-manager/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/jira-sprint-manager/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/jira-sprint-manager
+```

--- a/site/docs/plugins/productization-skills/jira-sprint-manager.md
+++ b/site/docs/plugins/productization-skills/jira-sprint-manager.md
@@ -58,7 +58,7 @@ Create sprints and assign issues to sprints on Jira boards
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">acli, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/jira-utilities.md
+++ b/site/docs/plugins/productization-skills/jira-utilities.md
@@ -1,0 +1,79 @@
+---
+title: jira-utilities
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# jira-utilities
+
+Manage Jira issues with JQL search, create/update issues, link issues, and sprint info
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Manage Jira issues with JQL search, create and update issues, link issues, and retrieve sprint information.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Executes the requested Jira operation correctly</li>
+        <li>Returns structured results for search and read operations</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-utilities/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/jira-utilities/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never delete issues without explicit user confirmation</li>
+        <li>Use Jira MCP tools or REST API, never modify Jira data without confirmation</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span>, tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/jira-utilities/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/jira-utilities/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/jira-utilities
+```

--- a/site/docs/plugins/productization-skills/jira-utilities.md
+++ b/site/docs/plugins/productization-skills/jira-utilities.md
@@ -24,6 +24,7 @@ Manage Jira issues with JQL search, create/update issues, link issues, and sprin
     <div class="skill-contract__row">
       <span class="skill-contract__field">Functions</span>
       <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
         <span class="skill-contract__chip skill-contract__chip--function">execute</span>
       </div>
     </div>
@@ -51,14 +52,14 @@ Manage Jira issues with JQL search, create/update issues, link issues, and sprin
       <span class="skill-contract__field">Must Preserve</span>
       <ul class="skill-contract__list">
         <li>Never delete issues without explicit user confirmation</li>
-        <li>Use Jira MCP tools or REST API, never modify Jira data without confirmation</li>
+        <li>Use the acli CLI (or Jira REST API) for all interactions; never modify Jira data without confirmation</li>
       </ul>
     </div>
     <div class="skill-contract__row">
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">acli, jq, curl</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span>, tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/konflux-its-analyzer.md
+++ b/site/docs/plugins/productization-skills/konflux-its-analyzer.md
@@ -1,0 +1,79 @@
+---
+title: konflux-its-analyzer
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# konflux-its-analyzer
+
+Analyze Konflux integration test scenario failures
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Analyze failed Konflux integration test scenario PipelineRuns using KubeArchive to identify test failure root causes.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">analyze</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves the correct PipelineRun logs from KubeArchive</li>
+        <li>Identifies the root cause of the integration test failure</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/konflux-its-analyzer/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/konflux-its-analyzer/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Use KubeArchive API for log retrieval, never access clusters directly</li>
+        <li>Never modify or rerun pipelines without user confirmation</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/konflux-its-analyzer/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/konflux-its-analyzer/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/konflux-its-analyzer
+```

--- a/site/docs/plugins/productization-skills/konflux-its-analyzer.md
+++ b/site/docs/plugins/productization-skills/konflux-its-analyzer.md
@@ -58,8 +58,8 @@ Analyze Konflux integration test scenario failures
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">task_private</span></span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">kubectl, jq</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>
   </section>

--- a/site/docs/plugins/productization-skills/mapt-provisioner.md
+++ b/site/docs/plugins/productization-skills/mapt-provisioner.md
@@ -1,0 +1,79 @@
+---
+title: mapt-provisioner
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# mapt-provisioner
+
+Provision and manage cloud VMs on AWS and Azure using mapt
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Provision and manage cloud VMs on AWS and Azure using mapt for development, testing, and CI/CD environments.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Provisions the requested VM with correct specs and cloud provider</li>
+        <li>Returns connection details for the provisioned machine</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/mapt-provisioner/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/mapt-provisioner/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never destroy machines without explicit user confirmation</li>
+        <li>Always use mapt CLI, never call cloud provider APIs directly</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">mapt</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/mapt-provisioner/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/mapt-provisioner/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/mapt-provisioner
+```

--- a/site/docs/plugins/productization-skills/mapt-provisioner.md
+++ b/site/docs/plugins/productization-skills/mapt-provisioner.md
@@ -58,7 +58,7 @@ Provision and manage cloud VMs on AWS and Azure using mapt
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">mapt</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">mapt, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/slack-utilities.md
+++ b/site/docs/plugins/productization-skills/slack-utilities.md
@@ -1,0 +1,80 @@
+---
+title: slack-utilities
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# slack-utilities
+
+Search messages, post updates, and interact with Slack workspaces
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Search messages, fetch thread replies, post updates, and interact with Slack workspaces programmatically.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">retrieve</span>
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Retrieves or posts Slack messages as requested</li>
+        <li>Correctly handles channel resolution and thread context</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/slack-utilities/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/slack-utilities/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never post messages without user confirmation</li>
+        <li>Use Slack API tokens from environment, never hardcode credentials</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/slack-utilities/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/slack-utilities/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/slack-utilities
+```

--- a/site/docs/plugins/productization-skills/slack-utilities.md
+++ b/site/docs/plugins/productization-skills/slack-utilities.md
@@ -59,7 +59,7 @@ Search messages, post updates, and interact with Slack workspaces
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">python3, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/slack-webhook.md
+++ b/site/docs/plugins/productization-skills/slack-webhook.md
@@ -58,7 +58,7 @@ Post messages to Slack channels via incoming webhooks
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/slack-webhook.md
+++ b/site/docs/plugins/productization-skills/slack-webhook.md
@@ -1,0 +1,79 @@
+---
+title: slack-webhook
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# slack-webhook
+
+Post messages to Slack channels via incoming webhooks
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Post messages to Slack channels via incoming webhook URLs, supporting plain text and Slack Block Kit JSON payloads.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">execute</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Posts the message to the correct Slack webhook</li>
+        <li>Formats Block Kit payloads correctly when requested</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/slack-webhook/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/slack-webhook/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Never post without user confirmation of the message content</li>
+        <li>Use webhook URLs from environment or user input, never hardcode</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">task_input<span class="skill-contract__privacy">task_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/slack-webhook/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/slack-webhook/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/slack-webhook
+```

--- a/site/docs/plugins/productization-skills/weekly-status.md
+++ b/site/docs/plugins/productization-skills/weekly-status.md
@@ -58,7 +58,7 @@ Generate weekly status reports from project activity
       <span class="skill-contract__field">Fixed Context</span>
       <div class="skill-contract__code">
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
-      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">git, curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">git, acli, jq</span></div>
       <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
       </div>
     </div>

--- a/site/docs/plugins/productization-skills/weekly-status.md
+++ b/site/docs/plugins/productization-skills/weekly-status.md
@@ -1,0 +1,79 @@
+---
+title: weekly-status
+---
+
+<!-- Auto-generated from registry.yaml. Do not edit directly. -->
+
+
+# weekly-status
+
+Generate weekly status reports from project activity
+
+**Plugin**: [productization-skills](index.md) | **:material-check: User-invocable**
+
+## Contract
+
+<div class="skill-contract">
+  <header class="skill-contract__header">
+    <span class="skill-contract__eyebrow">Skill Contract</span>
+    <span class="skill-contract__version">canonical-skill-v1</span>
+  </header>
+  <p class="skill-contract__lede">Generate a weekly project status update paragraph for stakeholders from project activity across git, Jira, and other sources.</p>
+  <section class="skill-contract__section" data-section="01">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Identity</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Functions</span>
+      <div class="skill-contract__inline">
+        <span class="skill-contract__chip skill-contract__chip--function">generate</span>
+      </div>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Success</span>
+      <ul class="skill-contract__list">
+        <li>Gathers activity from the correct time period</li>
+        <li>Produces a concise stakeholder-ready status paragraph</li>
+      </ul>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="02">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Optimization Targets</span></h3>
+    <div class="skill-contract__metrics">
+      <div class="skill-contract__metric">
+        <code class="skill-contract__metric-id">task_success</code>
+        <span class="skill-contract__measure skill-contract__measure--judge">judge</span>
+        <a class="skill-contract__ref" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/weekly-status/SKILL.md" title="opendatahub-io/productization-skills@86f0ce3f1697bcbe2b849b2770d235deddb16abe:productization-plugin/skills/weekly-status/SKILL.md">SKILL.md @ 86f0ce3<span class="skill-contract__ref-arrow" aria-hidden="true">&#x2192;</span></a>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="03">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Invariants</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Must Preserve</span>
+      <ul class="skill-contract__list">
+        <li>Report only factual activity, never fabricate accomplishments</li>
+        <li>Use the user&#x27;s configured sources for activity data</li>
+      </ul>
+    </div>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Fixed Context</span>
+      <div class="skill-contract__code">
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">tools</span><span class="skill-contract__code-val">Bash</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">cli</span><span class="skill-contract__code-val">git, curl</span></div>
+      <div class="skill-contract__code-line"><span class="skill-contract__code-key">knowledge</span><span class="skill-contract__code-val">tool_output<span class="skill-contract__privacy">organization_private</span></span></div>
+      </div>
+    </div>
+  </section>
+  <section class="skill-contract__section" data-section="04">
+    <h3 class="skill-contract__section-title"><span class="skill-contract__section-name">Traceability</span></h3>
+    <div class="skill-contract__row">
+      <span class="skill-contract__field">Skill</span>
+      <div class="skill-contract__inline"><a class="skill-contract__path" href="https://github.com/opendatahub-io/productization-skills/blob/86f0ce3f1697bcbe2b849b2770d235deddb16abe/productization-plugin/skills/weekly-status/SKILL.md"><span class="skill-contract__ref-arrow" aria-hidden="true">&#x2197;</span><code>productization-plugin/skills/weekly-status/SKILL.md</code></a></div>
+    </div>
+  </section>
+</div>
+
+## Usage
+
+```bash
+/weekly-status
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -199,6 +199,26 @@ nav:
     - docs-skills:
       - plugins/docs-skills/index.md
       - docs-orchestrator: plugins/docs-skills/docs-orchestrator.md
+    - productization-skills:
+      - plugins/productization-skills/index.md
+      - gitlab-job-analyzer: plugins/productization-skills/gitlab-job-analyzer.md
+      - aws-log-analyzer: plugins/productization-skills/aws-log-analyzer.md
+      - slack-utilities: plugins/productization-skills/slack-utilities.md
+      - gitlab-branch-manager: plugins/productization-skills/gitlab-branch-manager.md
+      - jira-utilities: plugins/productization-skills/jira-utilities.md
+      - jira-cve-tracker: plugins/productization-skills/jira-cve-tracker.md
+      - jira-release-setup: plugins/productization-skills/jira-release-setup.md
+      - jira-sprint-manager: plugins/productization-skills/jira-sprint-manager.md
+      - jira-gap-audit: plugins/productization-skills/jira-gap-audit.md
+      - mapt-provisioner: plugins/productization-skills/mapt-provisioner.md
+      - konflux-its-analyzer: plugins/productization-skills/konflux-its-analyzer.md
+      - gitlab-code-review: plugins/productization-skills/gitlab-code-review.md
+      - slack-webhook: plugins/productization-skills/slack-webhook.md
+      - weekly-status: plugins/productization-skills/weekly-status.md
+      - gws-calendar-reader: plugins/productization-skills/gws-calendar-reader.md
+      - gws-doc-action-extractor: plugins/productization-skills/gws-doc-action-extractor.md
+      - gws-drive-reader: plugins/productization-skills/gws-drive-reader.md
+      - gws-slides-analyzer: plugins/productization-skills/gws-slides-analyzer.md
   - Categories:
     - categories/index.md
     - Evaluation & Testing: categories/evaluation.md


### PR DESCRIPTION
## Summary

- Register `opendatahub-io/productization-skills` plugin with 18 skills
- Category: DevOps & CI/CD
- Skills: GitLab CI/CD analysis, AWS CloudWatch Logs, Slack, Jira (utilities, CVE tracker, release setup, sprint manager, gap audit), Konflux ITS analysis, mapt provisioning, GitLab branch management, Google Workspace (Calendar, Drive, Docs, Slides), weekly status

## Validation

- `validate_registry.py` — PASSED (21 plugins, 123 skills)
- `sync_marketplace.py` — regenerated
- `generate_catalog.py` — regenerated
- `generate_site.py` — regenerated

## Context

Migrated from `aipcc-cicd/claudio-skills` → `opendatahub-io/productization-skills` (AIPCC-19466).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `productization-skills` plugin, expanding the marketplace to 21 plugins and 124 skills.
  * Introduced 18 DevOps and cloud-native skills covering GitLab, AWS, Slack, Jira, Konflux, Google Workspace, and cloud provisioning.
  * Added installation details, marketplace listings, and usage documentation for all new skills.

* **Documentation**
  * Updated knowledge and autofix skill listings, naming, and descriptions.
  * Added comprehensive plugin and skill reference pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->