### PR TITLE
fix(ci): read skill-linter error counts from the shapes it actually emits

### DIFF
--- a/scripts/run_skill_linter.py
+++ b/scripts/run_skill_linter.py
@@ -147,18 +147,21 @@ def extract_skill_linter_error_count(report: dict) -> int:
     skill-linter nests counts under ``summary`` and repeats them per entry in
     ``skills``; a bare top-level ``errorCount`` is still honoured so the check keeps
     working if the pinned version changes shape. Reading only the top level made this
-    check a no-op against real output. Raises ValueError when a count is present but
-    not an integer so the caller can fail closed.
+    check a no-op against real output.
+
+    Every count must be a non-negative JSON integer. Raises ValueError otherwise so the
+    caller can fail closed. Coercing with ``int()`` instead would quietly read ``false``,
+    ``0.5`` and ``-1`` as zero errors, which is the opposite of what this guard is for.
     """
     highest = 0
     for label, raw in _iter_reported_error_counts(report):
-        try:
-            value = int(raw)
-        except (TypeError, ValueError) as exc:
+        # bool is a subclass of int, so reject it explicitly.
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
             raise ValueError(
-                f"skill-linter output has non-numeric {label}: {raw!r}"
-            ) from exc
-        highest = max(highest, value)
+                f"skill-linter output has an invalid {label}: {raw!r} "
+                "(expected a non-negative integer)"
+            )
+        highest = max(highest, raw)
     return highest
 
 

--- a/scripts/run_skill_linter.py
+++ b/scripts/run_skill_linter.py
@@ -125,6 +125,43 @@ def skill_linter_dir_from_contract_skill_path(repo_root: Path, skill_path_relati
     return artifact.parent
 
 
+def _iter_reported_error_counts(report: dict):
+    """Yield (label, raw value) for every error count skill-linter may report."""
+    if "errorCount" in report:
+        yield "errorCount", report["errorCount"]
+
+    summary = report.get("summary")
+    if isinstance(summary, dict) and "errorCount" in summary:
+        yield "summary.errorCount", summary["errorCount"]
+
+    skills = report.get("skills")
+    if isinstance(skills, list):
+        for index, entry in enumerate(skills):
+            if isinstance(entry, dict) and "errorCount" in entry:
+                yield f"skills[{index}].errorCount", entry["errorCount"]
+
+
+def extract_skill_linter_error_count(report: dict) -> int:
+    """Highest error count in a skill-linter report, across every shape it emits.
+
+    skill-linter nests counts under ``summary`` and repeats them per entry in
+    ``skills``; a bare top-level ``errorCount`` is still honoured so the check keeps
+    working if the pinned version changes shape. Reading only the top level made this
+    check a no-op against real output. Raises ValueError when a count is present but
+    not an integer so the caller can fail closed.
+    """
+    highest = 0
+    for label, raw in _iter_reported_error_counts(report):
+        try:
+            value = int(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"skill-linter output has non-numeric {label}: {raw!r}"
+            ) from exc
+        highest = max(highest, value)
+    return highest
+
+
 def interpret_skill_linter_success_stdout(stdout: str) -> tuple[bool, str | None]:
     """Interpret stdout when skill-linter exits 0. Fail-closed when non-empty and not JSON object."""
     trimmed = stdout.strip()
@@ -136,11 +173,10 @@ def interpret_skill_linter_success_stdout(stdout: str) -> tuple[bool, str | None
     except ValueError as exc:
         return False, str(exc)
 
-    error_count_raw = report.get("errorCount", 0)
     try:
-        error_count = int(error_count_raw)
-    except (TypeError, ValueError):
-        return False, f"skill-linter output has non-numeric errorCount: {error_count_raw!r}"
+        error_count = extract_skill_linter_error_count(report)
+    except ValueError as exc:
+        return False, str(exc)
 
     if error_count > 0 or report.get("errors"):
         return False, json.dumps(report, indent=2)

--- a/tests/test_run_skill_linter.py
+++ b/tests/test_run_skill_linter.py
@@ -1,12 +1,15 @@
+import json
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
+from scripts.registry_contracts import SKILL_LINTER_VERSION
 from scripts.run_skill_linter import (
     _select_touched_skill_keys,
     build_skill_linter_command,
+    extract_skill_linter_error_count,
     interpret_skill_linter_success_stdout,
     normalize_git_ref,
     parse_skill_linter_output,
@@ -182,6 +185,79 @@ class SkillLinterWrapperTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIsNotNone(detail)
         self.assertIn("errorCount", detail)
+
+    def test_interpret_stdout_rejects_errors_nested_under_summary(self):
+        # Real skill-linter output shape: counts live under "summary", never at top level.
+        payload = json.dumps(
+            {
+                "version": SKILL_LINTER_VERSION,
+                "summary": {
+                    "skillCount": 1,
+                    "errorCount": 2,
+                    "warningCount": 0,
+                    "infoCount": 0,
+                    "fixableCount": 0,
+                },
+                "skills": [{"path": "/tmp/skills/example", "errorCount": 2, "diagnostics": []}],
+            }
+        )
+        ok, detail = interpret_skill_linter_success_stdout(payload)
+        self.assertFalse(ok)
+        self.assertIsNotNone(detail)
+        self.assertIn("errorCount", detail)
+
+    def test_interpret_stdout_rejects_errors_reported_only_per_skill(self):
+        payload = json.dumps(
+            {
+                "version": SKILL_LINTER_VERSION,
+                "summary": {"skillCount": 1, "errorCount": 0},
+                "skills": [{"path": "/tmp/skills/example", "errorCount": 3}],
+            }
+        )
+        ok, detail = interpret_skill_linter_success_stdout(payload)
+        self.assertFalse(ok)
+        self.assertIsNotNone(detail)
+
+    def test_interpret_stdout_accepts_clean_real_report(self):
+        payload = json.dumps(
+            {
+                "version": SKILL_LINTER_VERSION,
+                "summary": {
+                    "skillCount": 1,
+                    "errorCount": 0,
+                    "warningCount": 1,
+                    "infoCount": 3,
+                    "fixableCount": 0,
+                },
+                "skills": [{"path": "/tmp/skills/example", "errorCount": 0, "diagnostics": []}],
+            }
+        )
+        ok, detail = interpret_skill_linter_success_stdout(payload)
+        self.assertTrue(ok)
+        self.assertIsNone(detail)
+
+    def test_interpret_stdout_rejects_nonnumeric_summary_error_count(self):
+        payload = '{"summary": {"errorCount": "oops"}}'
+        ok, detail = interpret_skill_linter_success_stdout(payload)
+        self.assertFalse(ok)
+        self.assertIsNotNone(detail)
+        self.assertIn("summary.errorCount", detail)
+
+    def test_extract_error_count_reads_every_reported_location(self):
+        self.assertEqual(extract_skill_linter_error_count({}), 0)
+        self.assertEqual(extract_skill_linter_error_count({"errorCount": 4}), 4)
+        self.assertEqual(extract_skill_linter_error_count({"summary": {"errorCount": 5}}), 5)
+        self.assertEqual(
+            extract_skill_linter_error_count({"skills": [{"errorCount": 0}, {"errorCount": 6}]}),
+            6,
+        )
+        # summary already totals the per-skill counts, so take the highest rather than the sum.
+        self.assertEqual(
+            extract_skill_linter_error_count(
+                {"summary": {"errorCount": 2}, "skills": [{"errorCount": 1}, {"errorCount": 1}]}
+            ),
+            2,
+        )
 
     def test_skill_is_skill_linter_candidate_requires_skill_md_path(self):
         plugin_github = {"name": "p", "source": {"type": "github", "repo": "a/b"}, "skills": []}

--- a/tests/test_run_skill_linter.py
+++ b/tests/test_run_skill_linter.py
@@ -243,6 +243,26 @@ class SkillLinterWrapperTests(unittest.TestCase):
         self.assertIsNotNone(detail)
         self.assertIn("summary.errorCount", detail)
 
+    def test_interpret_stdout_rejects_malformed_counts_at_every_location(self):
+        # int() would read every one of these as zero errors and pass the report.
+        for raw in ("false", "0.5", "-1"):
+            for payload in (
+                '{"errorCount": %s}' % raw,
+                '{"summary": {"errorCount": %s}}' % raw,
+                '{"summary": {"errorCount": 0}, "skills": [{"errorCount": %s}]}' % raw,
+            ):
+                with self.subTest(payload=payload):
+                    ok, detail = interpret_skill_linter_success_stdout(payload)
+                    self.assertFalse(ok)
+                    self.assertIsNotNone(detail)
+                    self.assertIn("errorCount", detail)
+
+    def test_extract_error_count_requires_non_negative_integers(self):
+        for raw in (False, True, 0.5, 2.0, -1, "3", None, [], {}):
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError):
+                    extract_skill_linter_error_count({"summary": {"errorCount": raw}})
+
     def test_extract_error_count_reads_every_reported_location(self):
         self.assertEqual(extract_skill_linter_error_count({}), 0)
         self.assertEqual(extract_skill_linter_error_count({"errorCount": 4}), 4)


### PR DESCRIPTION
## Problem

`interpret_skill_linter_success_stdout()` in `scripts/run_skill_linter.py` is the fail-closed guard for the case where skill-linter exits 0 but still reports errors. It reads `errorCount` and `errors` from the **top level** of the report — but skill-linter nests counts under `summary` and repeats them per entry in `skills`.

Real output, captured from the pinned version (`npx --package skill-linter@0.1.4 skill-linter check <dir> --format json`):

```json
{
  "version": "0.1.4",
  "summary": {"skillCount": 1, "errorCount": 2, "warningCount": 0, "infoCount": 0, "fixableCount": 0},
  "skills": [{"path": "…", "errorCount": 2, "diagnostics": [{"ruleId": "parser", "severity": "error", …}]}]
}
```

There is no top-level `errorCount`, so `report.get("errorCount", 0)` always returned the default `0` and `report.get("errors")` was always `None`. Fed that exact report, the guard returned `(True, None)`.

## Impact

**Nothing is escaping today.** skill-linter exits 1 whenever `errorCount > 0` (verified: exit 1 with `errorCount: 2`, exit 0 with `errorCount: 0`), so `_run_one_skill()` catches failures via the process exit code at `scripts/run_skill_linter.py:352`. The layer behind it was simply dead — and would stay dead if a future pinned version ever reported errors while exiting 0, which is the only scenario this helper exists for.

## Fix

Read every location the counter can appear — top level, `summary`, and each `skills[]` entry — and take the highest. `summary` already totals the per-skill counts, so taking the max avoids double counting while still failing on a per-skill count that `summary` somehow missed. A count that is present but non-numeric still fails closed, now with the offending location named in the message.

The bare top-level shape is still honoured, so this is compatible if the pinned version changes again.

## Why it survived

`tests/test_run_skill_linter.py` asserted against `{"errorCount": 1, "violations": []}` — a payload skill-linter never produces. The test passed against a function that could not work. That case is kept (it covers the bare shape) and coverage for the real shape is added:

- errors nested under `summary` → rejected
- errors reported only per-skill → rejected
- clean real report (0 errors, 1 warning, 3 info) → accepted
- non-numeric `summary.errorCount` → rejected
- `extract_skill_linter_error_count()` unit coverage for all locations

## Verification

- `python3 -m pytest tests/` → **132 passed, 6 subtests passed**
- Real 2-error payload → `(False, …)`; real clean payload → `(True, None)`

## Scope

Found while reviewing #100; unrelated to it and independently mergeable. Touches no registry data and no generated artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill linter result handling across top-level, summary, and individual skill reports.
  * Linter runs now correctly fail when any valid error count is detected.
  * Invalid, negative, or non-numeric error counts are handled safely without producing misleading results.

* **Tests**
  * Added coverage for nested reports, per-skill errors, clean results, overlapping counts, and invalid count values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->