### PR TITLE
feat(ci): detect registry skill names that drift from upstream SKILL.md

### DIFF
--- a/.github/workflows/skill-name-drift.yml
+++ b/.github/workflows/skill-name-drift.yml
@@ -1,0 +1,29 @@
+name: Skill Name Drift
+
+# The PR-scoped check in validate.yml only sees plugins whose registry entry changed.
+# Most drift starts upstream — a skill is renamed or deleted in its own repo and the
+# registry silently keeps advertising the old command. This sweep catches that.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-skill-names:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.3 jsonschema==4.26.0
+
+      - name: Check every plugin's skill names against its source repo
+        run: python3 scripts/validate_registry.py --check-skill-names

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Run skill-linter for touched skills
         run: python3 scripts/run_skill_linter.py --diff-base "${{ env.DIFF_BASE }}"
 
+      - name: Check skill names against source for touched plugins
+        run: python3 scripts/validate_registry.py --diff-base "${{ env.DIFF_BASE }}" --check-skill-names
+
       - name: Run unit tests
         run: python3 -m unittest discover -s tests -p 'test_*.py'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,24 @@ CI runs on pull requests and pushes to `main`. It automatically:
 - Validates `registry.yaml` against the JSON Schema and touched-skill contract rules (diff-aware vs the PR base branch or prior push commit).
 - Runs pinned `skill-linter` on skills you changed when they declare GitHub `source` and `contract.source_assertions`.
 - Checks that referenced GitHub repos are reachable and that expected manifests or paths resolve as validated by `scripts/validate_registry.py`.
+- Clones the plugins you touched and checks each registry skill `name` against the upstream `SKILL.md` frontmatter.
+
+### Skill name drift
+
+A registry skill `name` must match the `name` in that skill's upstream `SKILL.md` frontmatter — that is the value Claude Code registers as the slash command. If they disagree, the catalog and site publish a command that resolves to nothing.
+
+`scripts/validate_registry.py --check-skill-names` clones each plugin's source and compares. Run it yourself with `--diff-base origin/main` to check only the plugins you touched:
+
+```bash
+python3 scripts/validate_registry.py --diff-base origin/main --check-skill-names
+```
+
+It **fails** when a registry skill has no upstream `SKILL.md` declaring that name. It **warns**, without failing, when:
+
+- the registry and the upstream frontmatter disagree on `user-invocable` (remember the registry value is catalog-only — the source `SKILL.md` is what controls the `/` menu);
+- a `strict: false` plugin has upstream skills missing from `registry.yaml`. Those install anyway, since the whole `skills_dir` is loaded, so they are live but undocumented commands. For `strict: true` plugins the registry list is a curated subset by design and is not flagged.
+
+Most drift starts upstream, where no registry PR is involved, so the same sweep runs weekly across every plugin via the `Skill Name Drift` workflow.
 
 ### 5. Review and Merge
 

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -8,6 +8,7 @@ Usage:
     python3 scripts/validate_registry.py --validate-remote-plugins  # Clone and validate new plugins
     python3 scripts/validate_registry.py --staged               # Require contracts for skills changed vs HEAD (staged registry)
     python3 scripts/validate_registry.py --diff-base REF        # Require contracts for skills changed since REF
+    python3 scripts/validate_registry.py --check-skill-names    # Check skill names against upstream SKILL.md
 """
 
 import argparse
@@ -376,6 +377,144 @@ def validate_remote_plugin(plugin: dict) -> list[str]:
     return errors
 
 
+def _iter_upstream_skill_files(plugin: dict, repo_path: Path) -> list[Path]:
+    """SKILL.md files in a cloned plugin repo, from the first skills directory that has any.
+
+    Mirrors the first-match lookup in validate_remote_plugin() rather than taking the union.
+    A repo can ship its published skills in skills/ while also keeping its own tooling in
+    .claude/skills/; unioning the two would report that tooling as missing from the registry.
+    """
+    root = repo_path.resolve()
+    locations = [
+        repo_path / plugin.get("skills_dir", "skills"),
+        repo_path / ".claude" / "skills",
+        repo_path / "skills",
+    ]
+    for location in locations:
+        try:
+            resolved = location.resolve()
+        except OSError:
+            continue
+        if not resolved.is_relative_to(root) or not resolved.is_dir():
+            continue
+        found = sorted(resolved.glob("*/SKILL.md"))
+        if found:
+            return found
+    return []
+
+
+def check_skill_names_against_source(plugin: dict, repo_path: Path) -> tuple[list[str], list[str]]:
+    """Compare registry skill names with the upstream SKILL.md frontmatter in a cloned repo.
+
+    Returns (errors, warnings). A registry skill with no upstream SKILL.md is an error:
+    the catalog publishes a slash command that resolves to nothing. Upstream skills the
+    registry omits, and user-invocable disagreements, are warnings — they misdescribe the
+    plugin without inventing a command, and several are known upstream-side gaps.
+    """
+    from scripts.discover_skills import parse_frontmatter
+
+    name = get_plugin_label(plugin)
+    upstream: dict[str, bool] = {}
+    for skill_md in _iter_upstream_skill_files(plugin, repo_path):
+        try:
+            frontmatter = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not isinstance(frontmatter, dict):
+            continue
+        declared = frontmatter.get("name")
+        skill_name = declared.strip() if isinstance(declared, str) and declared.strip() \
+            else skill_md.parent.name
+        # Absent user-invocable means the Claude Code default, which is true.
+        upstream[skill_name] = frontmatter.get("user-invocable", True) is not False
+
+    if not upstream:
+        # validate_remote_plugin already reports "no SKILL.md found"; don't double-report.
+        return [], []
+
+    errors = []
+    warnings = []
+    registered = set()
+    for skill in iter_skills(plugin):
+        skill_name = skill.get("name")
+        if not isinstance(skill_name, str):
+            continue
+        registered.add(skill_name)
+        if skill_name not in upstream:
+            errors.append(
+                f"  Plugin '{name}' skill '{skill_name}': no upstream SKILL.md declares this name "
+                f"(found: {', '.join(sorted(upstream)) or 'none'}). "
+                "The catalog would publish a command that does not exist."
+            )
+            continue
+        registry_invocable = skill.get("user-invocable", True) is not False
+        if registry_invocable != upstream[skill_name]:
+            warnings.append(
+                f"  Plugin '{name}' skill '{skill_name}': registry says "
+                f"user-invocable={registry_invocable}, upstream SKILL.md resolves to "
+                f"{upstream[skill_name]}. Set user-invocable in the source SKILL.md to match."
+            )
+
+    # Only flag unlisted upstream skills for strict: false plugins. There the whole
+    # skills_dir is installed, so anything missing from registry.yaml is a live command
+    # with no documentation. A strict: true registry list is a curated subset by design.
+    if plugin.get("strict", True) is False:
+        unlisted = sorted(set(upstream) - registered)
+        if unlisted:
+            shown = ", ".join(unlisted[:5])
+            more = f", +{len(unlisted) - 5} more" if len(unlisted) > 5 else ""
+            warnings.append(
+                f"  Plugin '{name}': {len(unlisted)} upstream skill(s) not listed in "
+                f"registry.yaml ({shown}{more}). strict: false installs the whole "
+                "skills_dir, so these are undocumented commands."
+            )
+
+    return errors, warnings
+
+
+def diff_touched_plugins(registry: dict, base_ref: str) -> list[str] | None:
+    """Plugin names whose registry entry differs from base_ref, or None if base is unreadable."""
+    try:
+        base_registry = load_registry_from_ref(base_ref)
+    except (subprocess.CalledProcessError, RuntimeError, ValueError):
+        return None
+    base_by_name = {p.get("name"): p for p in base_registry.get("plugins", [])}
+    return sorted(
+        p.get("name")
+        for p in registry.get("plugins", [])
+        if base_by_name.get(p.get("name")) != p
+    )
+
+
+def check_remote_skill_names(plugin: dict) -> tuple[list[str], list[str]]:
+    """Clone a plugin repo and compare its SKILL.md names with the registry entry."""
+    from scripts.registry_contracts import GIT_CLONE_TYPES, redact_url, source_clone_url
+
+    name = get_plugin_label(plugin)
+    source = plugin.get("source")
+    if not source or source.get("type") not in GIT_CLONE_TYPES:
+        return [], []
+
+    try:
+        ref = normalize_git_ref(source.get("ref", "main"))
+        clone_url = source_clone_url(source)
+    except (ValueError, KeyError):
+        # validate_remote_plugin reports malformed sources; nothing to add here.
+        return [], []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            result = shallow_clone(clone_url, ref, tmpdir)
+        except RuntimeError as exc:
+            return [], [f"  Plugin '{name}': could not clone to check skill names: {redact_url(str(exc))}"]
+        if result.returncode != 0:
+            return [], [
+                f"  Plugin '{name}': could not clone {redact_url(clone_url)} (ref={ref}) "
+                "to check skill names"
+            ]
+        return check_skill_names_against_source(plugin, Path(tmpdir))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -387,6 +526,10 @@ def main() -> None:
                         help="Show plugins added since BASE_REF")
     parser.add_argument("--validate-remote-plugins", action="store_true",
                         help="Clone and validate plugin repos")
+    parser.add_argument("--check-skill-names", action="store_true",
+                        help="Clone plugin repos and check registry skill names against "
+                             "upstream SKILL.md frontmatter (scoped to plugins touched "
+                             "since --diff-base, if given)")
     parser.add_argument("--staged", action="store_true",
                         help="Require contracts for skills changed between HEAD and staged registry.yaml")
     parser.add_argument("--diff-base", metavar="REF",
@@ -491,6 +634,38 @@ def main() -> None:
                     print(e)
             else:
                 print("    OK")
+
+    # Registry skill names vs upstream SKILL.md frontmatter
+    if args.check_skill_names:
+        plugins_to_check = registry.get("plugins", [])
+        scope = "all"
+        if args.diff_base:
+            touched_names = diff_touched_plugins(registry, args.diff_base)
+            if touched_names is None:
+                print(f"WARNING: could not read registry.yaml from {args.diff_base}, "
+                      "checking every plugin", file=sys.stderr)
+            else:
+                plugins_to_check = [p for p in plugins_to_check
+                                    if p.get("name") in set(touched_names)]
+                scope = f"touched since {args.diff_base}"
+
+        print(f"Checking skill names against source ({len(plugins_to_check)} plugin(s), {scope})...")
+        name_errors: list[str] = []
+        name_warnings: list[str] = []
+        for plugin in plugins_to_check:
+            errors, warnings = check_remote_skill_names(plugin)
+            name_errors.extend(errors)
+            name_warnings.extend(warnings)
+
+        for w in name_warnings:
+            print(f"  WARNING:{w.lstrip(' ')}")
+        all_errors.extend(name_errors)
+        if name_errors:
+            print(f"  FAIL: {len(name_errors)} skill name error(s)")
+            for e in name_errors:
+                print(e)
+        else:
+            print("  OK")
 
     # Summary
     print()

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -656,5 +656,128 @@ class RemotePluginValidationTests(unittest.TestCase):
         run_mock.assert_not_called()
 
 
+class SkillNameDriftTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.validate_registry = get_validate_registry_module()
+
+    @staticmethod
+    def write_skill(root: Path, relative_dir: str, name: str, user_invocable=None):
+        skill_dir = root / relative_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["---", f"name: {name}", "description: A skill."]
+        if user_invocable is not None:
+            lines.append(f"user-invocable: {str(user_invocable).lower()}")
+        lines += ["---", "", f"# {name}", ""]
+        (skill_dir / "SKILL.md").write_text("\n".join(lines), encoding="utf-8")
+
+    def check(self, plugin, build):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            build(root)
+            return self.validate_registry.check_skill_names_against_source(plugin, root)
+
+    def test_registry_name_without_upstream_skill_is_an_error(self):
+        plugin = {"name": "p", "skills": [{"name": "knowledge.repo"}]}
+        errors, _ = self.check(
+            plugin, lambda root: self.write_skill(root, "skills", "knowledge-repo")
+        )
+
+        self.assertEqual(1, len(errors), errors)
+        self.assertIn("knowledge.repo", errors[0])
+        self.assertIn("knowledge-repo", errors[0])
+
+    def test_matching_names_produce_nothing(self):
+        plugin = {"name": "p", "skills": [{"name": "alpha"}, {"name": "beta"}]}
+        errors, warnings = self.check(
+            plugin,
+            lambda root: [
+                self.write_skill(root, "skills", "alpha"),
+                self.write_skill(root, "skills", "beta"),
+            ],
+        )
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+
+    def test_user_invocable_disagreement_warns_but_does_not_fail(self):
+        plugin = {"name": "p", "skills": [{"name": "alpha", "user-invocable": False}]}
+        # Upstream omits the key, so it resolves to the Claude Code default of true.
+        errors, warnings = self.check(
+            plugin, lambda root: self.write_skill(root, "skills", "alpha")
+        )
+
+        self.assertEqual([], errors)
+        self.assertEqual(1, len(warnings), warnings)
+        self.assertIn("user-invocable", warnings[0])
+
+    def test_unlisted_upstream_skills_warn_only_for_non_strict_plugins(self):
+        def build(root):
+            self.write_skill(root, "skills", "alpha")
+            self.write_skill(root, "skills", "extra")
+
+        strict_plugin = {"name": "p", "skills": [{"name": "alpha"}]}
+        errors, warnings = self.check(strict_plugin, build)
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings, "strict: true registry lists are curated subsets")
+
+        loose_plugin = {"name": "p", "strict": False, "skills": [{"name": "alpha"}]}
+        errors, warnings = self.check(loose_plugin, build)
+        self.assertEqual([], errors)
+        self.assertEqual(1, len(warnings), warnings)
+        self.assertIn("extra", warnings[0])
+
+    def test_only_the_first_populated_skills_dir_is_used(self):
+        # A repo can publish skills/ while keeping its own tooling in .claude/skills/.
+        def build(root):
+            self.write_skill(root, "skills", "alpha")
+            self.write_skill(root, ".claude/skills", "repo-local-tooling")
+
+        plugin = {"name": "p", "strict": False, "skills": [{"name": "alpha"}]}
+        errors, warnings = self.check(plugin, build)
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings, "tooling in .claude/skills must not be reported")
+
+    def test_directory_name_is_the_fallback_when_frontmatter_omits_name(self):
+        def build(root):
+            skill_dir = root / "skills" / "alpha"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\ndescription: No name key.\n---\n\n# alpha\n", encoding="utf-8"
+            )
+
+        plugin = {"name": "p", "skills": [{"name": "alpha"}]}
+        errors, warnings = self.check(plugin, build)
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+
+    def test_repo_without_any_skill_md_is_left_to_remote_validation(self):
+        plugin = {"name": "p", "skills": [{"name": "alpha"}]}
+        errors, warnings = self.check(plugin, lambda root: None)
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+
+    def test_diff_touched_plugins_lists_changed_entries(self):
+        base = {"plugins": [{"name": "a", "version": "1"}, {"name": "b", "version": "1"}]}
+        current = {"plugins": [{"name": "a", "version": "2"}, {"name": "b", "version": "1"}]}
+
+        with mock.patch.object(self.validate_registry, "load_registry_from_ref",
+                               return_value=base):
+            self.assertEqual(["a"],
+                             self.validate_registry.diff_touched_plugins(current, "origin/main"))
+
+    def test_diff_touched_plugins_returns_none_when_base_is_unreadable(self):
+        with mock.patch.object(self.validate_registry, "load_registry_from_ref",
+                               side_effect=ValueError("no such ref")):
+            self.assertIsNone(
+                self.validate_registry.diff_touched_plugins({"plugins": []}, "origin/nope")
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

A registry skill `name` is meant to mirror the upstream `SKILL.md` frontmatter `name` — that is what Claude Code registers as the slash command. **Nothing checks this.** A manual audit of all 106 skills across all 20 plugin repos found two entries advertising commands that do not exist, one real skill missing entirely, and 14 `user-invocable` disagreements.

Worse, the drift mostly starts **upstream**: `autofix-research` was deleted in its own repo and the registry kept publishing `/autofix-research`. No registry PR was ever opened, so no PR-scoped check could have caught it.

## What this adds

`scripts/validate_registry.py --check-skill-names` clones each plugin source and compares its `SKILL.md` frontmatter against the registry entry. The clone plumbing already existed for `--validate-remote-plugins`; this reuses it.

Severity is split so the check can land without failing on the known gaps:

| Finding | Level | Why |
|---|---|---|
| Registry skill no upstream `SKILL.md` declares | **error** | The catalog publishes a command that resolves to nothing |
| `user-invocable` disagreement | warning | The registry value is catalog-only; the fix belongs in the source `SKILL.md` |
| `strict: false` plugin with unlisted upstream skills | warning | The whole `skills_dir` installs, so these are live but undocumented commands |
| `strict: true` plugin with unlisted upstream skills | *not flagged* | That list is a curated subset by design (cf. #73, which pruned `docs-skills` deliberately) |

Skill discovery uses the **first populated** skills directory rather than the union of all candidates, matching `validate_remote_plugin()`. Without that, `autofix-skills` — which publishes `skills/` while keeping its own `debug-autofix-skills` tooling in `.claude/skills/` — got reported as missing a registry entry for its own dev tooling.

## Wiring

Two places, catching different things:

- **`validate.yml`** — scoped to plugins touched since the diff base, so a bad entry cannot be *introduced*. Usually zero clones; this PR's own run checks 0 plugins.
- **`skill-name-drift.yml`** (new) — sweeps every plugin weekly, plus `workflow_dispatch`. This is the one that catches upstream-side drift.

## Results against `main` today

```
TOTAL: 2 error(s), 18 warning(s)
```

Both errors are the phantom commands. The 18 warnings are 14 `user-invocable` drifts and 4 unlisted-skill rollups (`rfe-creator` 8, `rhoai-security-reviewer` 26, `odh-ai-helpers` 58, `quality-tooling` 2). This reproduces the manual audit **exactly**, independently.

The `rhoai-security-reviewer` rollup is the same defect as #85 ("installs ~28 skills, advertises 2"), surfaced automatically.

## Verification

- `pytest tests/` → **136 passed** (9 new tests, no network — they build skill trees in a temp dir)
- Against `main`'s registry: 2 errors, as above
- Against the registry from the companion fix PR, scoped to touched plugins: **`Checking skill names against source (2 plugin(s), touched since origin/main)... OK`**

That last pair is the real proof: the guard fails on the bug and passes on the fix.

## Merge order

Please merge the companion registry fix first. This PR is additive and passes on its own — its scoped check sees zero touched plugins since it changes no registry data — but the **weekly sweep will be red until those two phantom entries are corrected**.