### PR TITLE
feat(catalog): support and surface MCP servers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,6 +167,18 @@ number for display. It is catalog-only metadata (not propagated to
 repo at install time. A plugin may set `skill_count` **or** list `skills`, not
 both.
 
+### Agents and MCP servers
+
+Besides skills, a plugin may provide **agents** (`agents` + `agents_dir`) and
+**MCP servers** (`mcp_servers`). Each renders as its own table on the plugin's
+catalog and site page. `agents_dir` (like `skills_dir`) points the marketplace
+entry at agent files for `strict: false` plugins. `mcp_servers` is catalog-only
+display metadata (name + description of each server declared in the source
+`plugin.json` `mcpServers`); Claude Code reads the real config from that
+`plugin.json`, so it is never propagated to `marketplace.json`. This lets an
+MCP-only plugin (e.g. `pf-mcp`) advertise what it provides instead of reading as
+"0 skills".
+
 ## CI Pipeline
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,11 @@ The schema enforces `skills_dir` requires `strict` to be present (`dependentRequ
 
 The `source` field in marketplace.json uses `"source": "github"` (not `"type"`). The `skills` field must be an array (e.g., `["./.claude/skills"]`), not a string. The sync script handles both correctly.
 
-### Agents
+### Agents and MCP servers
 
 Plugins can include agents (defined in `agents/` directories) alongside skills. Agents run in isolated context windows and are auto-delegated by Claude or selected via `/agents`. The `agents_dir` field works like `skills_dir` — only valid with `strict: false`.
+
+Plugins can also provide MCP servers. List them in `mcp_servers: [{name, description}]` so the catalog/site show what the plugin offers (useful for an MCP-only plugin that has no skills, e.g. `pf-mcp`). `mcp_servers` is catalog-only — Claude Code reads the real server config from the source `plugin.json` `mcpServers`, so it is not propagated to `marketplace.json`. Both `agents` and `mcp_servers` render as their own table on the plugin page.
 
 ### Meta-plugins (bundles) and skill_count
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,22 @@ Rules for bundles:
 - `includes` is different from `depends_on`. `depends_on` records a peer plugin this one *requires*; `includes` records the plugins this one *installs together*, and renders as an "Includes" section in the catalog and site. Neither reaches `marketplace.json`.
 - `validate_registry.py` rejects a bundle that references an undefined member, lists itself, forms a cycle, or carries its own `skills`/`skill_count`.
 
+### Agents and MCP servers
+
+A plugin can provide **agents** and **MCP servers** alongside (or instead of) skills. Both are surfaced as their own table on the plugin's catalog and site page:
+
+```yaml
+    agents:
+      - name: python-packaging-investigator
+        description: Investigates Python package repositories and packaging complexity
+    mcp_servers:
+      - name: patternfly
+        description: Component documentation, design token lookup, and accessibility guidance via MCP
+```
+
+- **`agents`** lists the agents the plugin ships (matching the agent file names). For a `strict: false` plugin, also set `agents_dir` so the marketplace entry points Claude Code at them; for a `strict: true` plugin, the `plugin.json` is authoritative and `agents` is catalog-only display metadata.
+- **`mcp_servers`** lists the MCP servers the plugin provides (matching the keys in the plugin's `plugin.json` `mcpServers`). It is **catalog-only** display metadata — Claude Code reads the actual server config from the source `plugin.json`, so `mcp_servers` is never propagated to `marketplace.json`. Use it so an MCP-only plugin (e.g. `pf-mcp`) advertises what it offers instead of appearing as "0 skills".
+
 ### 3. Regenerate Artifacts
 
 After editing `registry.yaml`, validate and regenerate artifacts so CI stays in sync (same sequence as `CLAUDE.md`):

--- a/catalog.md
+++ b/catalog.md
@@ -486,6 +486,10 @@ v0.1.0 | Generic | MIT
 
 Tags: patternfly, mcp
 
+| MCP Server | Description |
+|------------|-------------|
+| patternfly | PatternFly component documentation, design token lookup, and accessibility guidance via the Model Context Protocol |
+
 ```bash
 /plugin install pf-mcp@opendatahub-skills
 ```

--- a/registry.yaml
+++ b/registry.yaml
@@ -2614,6 +2614,9 @@ plugins:
       ref: main
     homepage: https://github.com/rh-uxd/ai-helpers
     repository: https://github.com/rh-uxd/ai-helpers
+    mcp_servers:
+      - name: patternfly
+        description: PatternFly component documentation, design token lookup, and accessibility guidance via the Model Context Protocol
     depends_on: []
 
   - name: docs-skills

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -369,6 +369,13 @@
           "type": "string",
           "description": "Path to agents directory in the repo (used when strict: false)"
         },
+        "mcp_servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mcpServer"
+          },
+          "description": "MCP servers this plugin provides (declared in the plugin's plugin.json 'mcpServers'). Catalog-only display metadata — Claude Code reads the actual server config from the source plugin.json; not propagated to marketplace.json."
+        },
         "harnesses": {
           "type": "object",
           "additionalProperties": {
@@ -482,6 +489,21 @@
         "description": {
           "type": "string",
           "description": "What this agent does"
+        }
+      }
+    },
+    "mcpServer": {
+      "type": "object",
+      "required": ["name", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "MCP server name (matches a key in the plugin.json 'mcpServers' object)"
+        },
+        "description": {
+          "type": "string",
+          "description": "What this MCP server provides"
         }
       }
     }

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -267,6 +267,17 @@ def render_plugin(plugin: dict, registry_name: str) -> list[str]:
             lines.append(f"| {aname} | {adesc} |")
         lines.append("")
 
+    # MCP servers table
+    mcp_servers = plugin.get("mcp_servers", [])
+    if mcp_servers:
+        lines.append("| MCP Server | Description |")
+        lines.append("|------------|-------------|")
+        for server in mcp_servers:
+            mname = server["name"]
+            mdesc = server.get("description", "")
+            lines.append(f"| {mname} | {mdesc} |")
+        lines.append("")
+
     # Install command
     lines.append("```bash")
     lines.append(f"/plugin install {name}@{registry_name}")

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -1091,6 +1091,18 @@ def generate_llms_txt(registry: dict, site_url: str) -> str:
                 sdesc = s.get("description", "").strip()
                 lines.append(f"- [{sname}]({site_url}/plugins/{pname}/{sname}/): {sdesc} (internal)")
     lines.append("")
+    mcp_lines = []
+    for p in plugins:
+        pname = p["name"]
+        for server in p.get("mcp_servers", []):
+            mname = server["name"]
+            mdesc = server.get("description", "").strip()
+            mcp_lines.append(f"- [{mname}]({site_url}/plugins/{pname}/): {mdesc}")
+    if mcp_lines:
+        lines.append("## MCP Servers")
+        lines.append("")
+        lines.extend(mcp_lines)
+        lines.append("")
     return "\n".join(lines)
 
 
@@ -1162,6 +1174,15 @@ def generate_llms_full_txt(registry: dict, docs_dir: Path) -> str:
                 for ex in examples:
                     lines.append(ex)
                 lines.append("```")
+                lines.append("")
+        mcp_servers = p.get("mcp_servers", [])
+        if mcp_servers:
+            lines.append("### MCP Servers")
+            lines.append("")
+            for server in mcp_servers:
+                lines.append(f"#### {server['name']}")
+                lines.append("")
+                lines.append(server.get("description", "").strip())
                 lines.append("")
         lines.append("---")
         lines.append("")

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -368,6 +368,7 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
     deps = plugin.get("depends_on", [])
     skills = plugin.get("skills", [])
     agents = plugin.get("agents", [])
+    mcp_servers = plugin.get("mcp_servers", [])
     registry_name = registry["name"]
     categories = registry.get("categories", {})
     cat_name = categories.get(category, {}).get("name", category)
@@ -465,6 +466,18 @@ def generate_plugin_page(plugin: dict, registry: dict, enrichment: dict | None,
             aname = agent["name"]
             adesc = agent.get("description", "")
             lines.append(f"| {aname} | {adesc} |")
+        lines.append("")
+
+    # MCP servers table
+    if mcp_servers:
+        lines.append("## MCP Servers")
+        lines.append("")
+        lines.append("| MCP Server | Description |")
+        lines.append("|------------|-------------|")
+        for server in mcp_servers:
+            mname = server["name"]
+            mdesc = server.get("description", "")
+            lines.append(f"| {mname} | {mdesc} |")
         lines.append("")
 
     contract_summary = mapping_if_dict(plugin.get("contract_summary"))

--- a/site/docs/llms-full.txt
+++ b/site/docs/llms-full.txt
@@ -3225,6 +3225,12 @@ PatternFly MCP server -- component documentation, design token lookup, and acces
 
 ### Skills
 
+### MCP Servers
+
+#### patternfly
+
+PatternFly component documentation, design token lookup, and accessibility guidance via the Model Context Protocol
+
 ---
 
 ## docs-skills

--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -163,3 +163,7 @@
 - [security-audit](https://opendatahub-io.github.io/skills-registry/plugins/python-package-skills/security-audit/): Run a security audit on a Python package with risk rating and structured verdict (internal)
 - [pipeline-grouping](https://opendatahub-io.github.io/skills-registry/plugins/pipeline-skills/pipeline-grouping/): Group failed CI/CD pipeline jobs by error similarity using log analysis and Jira ticket deduplication (internal)
 - [pipeline-rca](https://opendatahub-io.github.io/skills-registry/plugins/pipeline-skills/pipeline-rca/): Root cause analysis for a pipeline failure error group with structured findings and section files (internal)
+
+## MCP Servers
+
+- [patternfly](https://opendatahub-io.github.io/skills-registry/plugins/pf-mcp/): PatternFly component documentation, design token lookup, and accessibility guidance via the Model Context Protocol

--- a/site/docs/plugins/pf-mcp/index.md
+++ b/site/docs/plugins/pf-mcp/index.md
@@ -18,6 +18,12 @@ PatternFly MCP server -- component documentation, design token lookup, and acces
     - **Category**: [Development Tools](../../categories/development-tools.md)
     - **Tags**: <span class="tag-pill">patternfly</span> <span class="tag-pill">mcp</span>
 
+## MCP Servers
+
+| MCP Server | Description |
+|------------|-------------|
+| patternfly | PatternFly component documentation, design token lookup, and accessibility guidance via the Model Context Protocol |
+
 ## Installation
 
 ```bash

--- a/tests/test_generate_catalog.py
+++ b/tests/test_generate_catalog.py
@@ -45,6 +45,19 @@ class CatalogGitSourceTests(unittest.TestCase):
         self.assertNotIn("github.com", content.split("Quick Start")[1])
 
 
+class CatalogMcpServerTests(unittest.TestCase):
+    def test_catalog_renders_mcp_servers_table(self):
+        registry = build_registry_with_contract()
+        registry["plugins"][0]["mcp_servers"] = [
+            {"name": "patternfly", "description": "Component docs via MCP"}
+        ]
+
+        content = generate_catalog.generate_catalog(registry)
+
+        self.assertIn("| MCP Server | Description |", content)
+        self.assertIn("| patternfly | Component docs via MCP |", content)
+
+
 class CatalogMalformedContractRenderingTests(unittest.TestCase):
     def test_catalog_skips_non_dict_contract_for_columns(self):
         registry = build_registry_with_contract()

--- a/tests/test_generate_site.py
+++ b/tests/test_generate_site.py
@@ -235,6 +235,27 @@ class SkillCountTests(unittest.TestCase):
         self.assertIn("## MCP Servers", page)
         self.assertIn("| patternfly | Component docs via MCP |", page)
 
+    def test_llms_txt_and_full_surface_mcp_servers(self):
+        import tempfile
+        from pathlib import Path
+        registry = {
+            "name": "opendatahub-skills",
+            "categories": {},
+            "plugins": [
+                {"name": "pf-mcp", "description": "MCP plugin", "version": "0.1.0",
+                 "source": {"type": "git-subdir", "url": "https://x/y.git", "path": "p"},
+                 "skill_count": 0,
+                 "mcp_servers": [{"name": "patternfly", "description": "Docs via MCP"}]},
+            ],
+        }
+        llms = generate_site.generate_llms_txt(registry, "https://example.test")
+        self.assertIn("## MCP Servers", llms)
+        self.assertIn("[patternfly](https://example.test/plugins/pf-mcp/): Docs via MCP", llms)
+        with tempfile.TemporaryDirectory() as d:
+            full = generate_site.generate_llms_full_txt(registry, Path(d))
+        self.assertIn("### MCP Servers", full)
+        self.assertIn("#### patternfly", full)
+
 
 class VisiblePluginsTests(unittest.TestCase):
     def _registry(self):

--- a/tests/test_generate_site.py
+++ b/tests/test_generate_site.py
@@ -220,6 +220,21 @@ class SkillCountTests(unittest.TestCase):
         self.assertIn("[`leaf-a`](../leaf-a/index.md)", page)
         self.assertIn("[`leaf-b`](../leaf-b/index.md)", page)
 
+    def test_plugin_page_renders_mcp_servers(self):
+        plugin = {
+            "name": "pf-mcp", "description": "An MCP plugin", "version": "0.1.0",
+            "source": {"type": "git-subdir", "url": "https://x/y.git", "path": "p"},
+            "skill_count": 0,
+            "mcp_servers": [
+                {"name": "patternfly", "description": "Component docs via MCP"},
+            ],
+        }
+        registry = {"name": "opendatahub-skills", "plugins": [plugin], "categories": {}}
+        page = generate_site.generate_plugin_page(
+            plugin, registry, enrichment=None, plugin_dir=None)
+        self.assertIn("## MCP Servers", page)
+        self.assertIn("| patternfly | Component docs via MCP |", page)
+
 
 class VisiblePluginsTests(unittest.TestCase):
     def _registry(self):

--- a/tests/test_validate_registry.py
+++ b/tests/test_validate_registry.py
@@ -123,6 +123,24 @@ class SchemaTests(unittest.TestCase):
 
         self.assertEqual([], errors)
 
+    def test_schema_accepts_mcp_servers(self):
+        registry = build_registry()
+        registry["plugins"][0]["mcp_servers"] = [
+            {"name": "patternfly", "description": "Component docs via MCP"}
+        ]
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertEqual([], errors)
+
+    def test_schema_rejects_mcp_server_without_description(self):
+        registry = build_registry()
+        registry["plugins"][0]["mcp_servers"] = [{"name": "patternfly"}]
+
+        errors = self.validate_registry.validate_schema(registry, self.schema)
+
+        self.assertNotEqual([], errors)
+
     def test_schema_rejects_unknown_function_value(self):
         registry = build_registry()
         add_minimal_contract(registry["plugins"][0]["skills"][0])


### PR DESCRIPTION
## Summary

Adds support for **MCP servers** in the registry so a plugin that provides MCP servers advertises them in the catalog and docs site — mirroring the existing `agents` support. Motivated by `pf-mcp` (part of the PatternFly bundle), which previously read as **"0 skills"** despite providing the PatternFly MCP server.

## What changed

- **Schema**: new `mcp_servers` plugin field — an array of `{name, description}` (new `$defs/mcpServer`), placed alongside `agents`/`agents_dir`.
- **Rendering**: catalog (`generate_catalog.py`) and site (`generate_site.py`) render an **MCP Servers** table on the plugin page, exactly like the Agents table.
- **Registry**: `pf-mcp` now declares its `patternfly` MCP server, so its page shows what it provides instead of an empty "0 skills".
- **Docs**: ARCHITECTURE / CONTRIBUTING / CLAUDE document `mcp_servers` (and, since it was undocumented in CONTRIBUTING, the pre-existing `agents` support).
- **Tests**: schema acceptance/rejection, catalog + site rendering.

## Design notes

- `mcp_servers` is **catalog-only display metadata**. Claude Code reads the real server config from the source plugin's `plugin.json` `mcpServers` (for `pf-mcp`, `@patternfly/patternfly-mcp` via npx), so `mcp_servers` is **not propagated to `marketplace.json`** — verified. This matches how a `strict: true` plugin's skills/agents lists are display-only.
- No `mcp_servers_dir`: unlike skills/agents, MCP servers aren't file/dir-based — they live in the `plugin.json` `mcpServers` object.
- MCP servers don't count as skills; counts are unchanged (registry total stays 149). `pf-mcp` keeps `skill_count: 0` and additionally lists its MCP server.

## Testing

- `python3 -m unittest discover -s tests` → **171 passing**.
- All four generators re-run; sync gate clean; `marketplace.json` unchanged.
- `validate_registry.py` passes.

Builds directly on the merged meta-plugin PR (#107); this closes the "`pf-mcp` shows 0 skills" gap noted there.
