### PR TITLE
chore: gitignore mkdocs build output (site/site, _site)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .venv/
+# mkdocs build output — never commit. Default local build dir is site/site/
+# (mkdocs.yml lives in site/ with no site_dir override); CI deploys to /_site/
+# via `mkdocs build --site-dir ../_site`.
+site/site/
 site/_site/
+/_site/
 __pycache__/
 *.pyc
 .idea/


### PR DESCRIPTION
## Summary

Ignore mkdocs build output so it can't be committed accidentally.

The `.gitignore` ignored `site/_site/`, but that's not where mkdocs actually builds:

- A **local** `mkdocs build` writes to **`site/site/`** — `mkdocs.yml` lives in `site/` and sets no `site_dir`, so mkdocs uses its default `site/` relative to the config.
- **CI deploy** writes to **`/_site/`** (repo root) via `mkdocs build --site-dir ../_site` (`.github/workflows/deploy-site.yml`).

Neither was ignored, so a stray local build could be staged — which just happened: a review step ran `mkdocs build` and a `git add -A` swept **583 `site/site/` files** into a PR.

## Change

Add `site/site/` and `/_site/` to `.gitignore` (keeping the existing `site/_site/`). Verified with `git check-ignore` that all three build-output paths are now ignored. Nothing is currently tracked at those paths, so this only affects future untracked build output.
